### PR TITLE
feat: add haptic feedback on tap-to-focus

### DIFF
--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -4689,6 +4689,8 @@ final class NativeAppModel {
     func setFocusPoint(at point: CGPoint, feedSize: CGSize) {
         guard !interfaceLocked, !focusPointLocked else { return }
         guard feedSize.width > 0, feedSize.height > 0 else { return }
+        // Light tap confirming the AF point moved; after the guards so locked taps stay silent.
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
         let normalizedX = min(max(point.x / feedSize.width, 0), 1)
         let normalizedY = min(max(point.y / feedSize.height, 0), 1)
         // Coordinate space from the latest live-view header; fall back to a 16:9 default before the


### PR DESCRIPTION
Adds a light impact haptic when tapping the live-view feed to set a focus point. The haptic fires in `NativeAppModel.setFocusPoint` — the single funnel for all tap-to-focus paths — after the interface-lock and focus-point-lock guards, so taps that don't move the AF point produce no feedback. Matches the existing haptic language in the monitor (selection ticks for DISP/assist, heavy thump for record and focus-lock).

Closes #49

Verified with `just native-check` (all checks green: demo-isolation, lint, 639 core tests, iOS + watch builds). Haptics can't be felt on the simulator; on-device feel check welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
