### PR TITLE
fix: make onboarding and status copy body-agnostic for the Z lineup

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -66,9 +66,9 @@
 		<string>NIKON_ZR_</string>
 	</array>
 	<key>NSCameraUsageDescription</key>
-	<string>OpenZCine uses the camera to scan the Wi-Fi SSID and key shown on your Nikon ZR's screen so it can connect to the camera.</string>
+	<string>OpenZCine uses the camera to scan the Wi-Fi SSID and key shown on your Nikon camera's screen so it can connect to the camera.</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>OpenZCine needs access to your Nikon ZR camera over the local Wi-Fi network (when your iPhone is connected to the camera's WiFi hotspot) for live view streaming and camera control.</string>
+	<string>OpenZCine needs access to your Nikon camera over the local Wi-Fi network (when your iPhone is connected to the camera's WiFi hotspot) for live view streaming and camera control.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>OpenZCine saves exported clips to your photo library when you choose Save to Photos.</string>
 	<key>UIApplicationSupportsIndirectInputEvents</key>

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -879,7 +879,7 @@ final class NativeAppModel {
     }
 
     private func cameraWiFiJoinDeviceName() -> String {
-        guard let savedCamera = preferredJoinCameraWiFiSavedCamera() else { return "Nikon ZR" }
+        guard let savedCamera = preferredJoinCameraWiFiSavedCamera() else { return "Nikon camera" }
         return ConnectionProgressCopy.resolveDisplayName(
             rawName: savedCamera.displayName,
             savedCamera: savedCamera

--- a/ios/Runner/NativeCameraSession.swift
+++ b/ios/Runner/NativeCameraSession.swift
@@ -56,7 +56,7 @@ enum NativeCameraSessionError: Error, LocalizedError {
     var errorDescription: String? {
         switch self {
         case .noHost:
-            return "Enter the camera IP address, or connect to the Nikon ZR Wi-Fi network first."
+            return "Enter the camera IP address, or connect to the camera's Wi-Fi network first."
         case .connectionFailed(let message):
             return message
         case .connectionClosed:
@@ -368,7 +368,7 @@ final class NativeCameraSession: @unchecked Sendable {
             establishmentSummary: "",
             identity: NativeCameraIdentity(
                 host: host,
-                cameraName: cameraName ?? "Nikon ZR",
+                cameraName: cameraName ?? "Nikon camera",
                 manufacturer: "",
                 model: "",
                 deviceVersion: "",

--- a/ios/Runner/StartupDesign.swift
+++ b/ios/Runner/StartupDesign.swift
@@ -1117,15 +1117,15 @@ enum StartupWizardContent {
         switch transport {
         case .cameraAccessPoint:
             return [
-                "On the Nikon ZR: Network menu → Connect to computer → Network settings.",
+                "On the camera: Network menu → Connect to computer → Network settings.",
                 "Choose Create Profile and give the profile a name.",
-                "Select Direct connection to computer — the ZR shows its SSID and key.",
+                "Select Direct connection to computer — the camera shows its SSID and key.",
             ]
         case .phoneHotspot:
             return [
                 "Turn on Personal Hotspot on your iPhone (Settings → Personal Hotspot).",
                 "On the same screen, turn off Maximize Compatibility — it slows live view.",
-                "On the Nikon ZR: Network menu → Connect to computer.",
+                "On the camera: Network menu → Connect to computer.",
                 "We'll walk through joining your hotspot in the next step.",
             ]
         case .usbC:
@@ -1150,7 +1150,7 @@ enum StartupWizardContent {
                     steps: tight
                         ? ["Keep the SSID & key screen visible"]
                         : [
-                            "Leave the ZR on its Direct connection screen",
+                            "Leave the camera on its Direct connection screen",
                             "It shows the network SSID and key",
                         ]
                 ),
@@ -1220,7 +1220,7 @@ enum StartupWizardContent {
                 : "The camera now shows its Wi‑Fi SSID and key. Scan that screen with your phone and OpenZCine joins the camera's network for you — no typing."
         case .phoneHotspot:
             return
-                "On iPhone: Settings → Personal Hotspot → turn on Allow Others to Join. Then on the Nikon ZR:"
+                "On iPhone: Settings → Personal Hotspot → turn on Allow Others to Join. Then on the camera:"
         case .usbC:
             return tight
                 ? "Plug in the cable, allow camera access, then find your camera."
@@ -1434,7 +1434,7 @@ struct StartupFirstPairWizardView: View {
                 .minimumScaleFactor(0.7)
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.top, 10)
-            Text("We'll walk you through it — your ZR is connected in about a minute.")
+            Text("We'll walk you through it — your camera is connected in about a minute.")
                 .font(.system(size: 13, weight: .regular, design: .rounded))
                 .foregroundStyle(StartupColors.muted)
                 .lineSpacing(3)
@@ -1507,7 +1507,7 @@ struct StartupFirstPairWizardView: View {
                     yourCamerasButton
                 }
             }
-            Text("We'll walk you through it — your ZR is connected in about a minute.")
+            Text("We'll walk you through it — your camera is connected in about a minute.")
                 .font(.system(size: 12, weight: .regular, design: .rounded))
                 .foregroundStyle(StartupColors.muted)
                 .lineSpacing(2)
@@ -1533,7 +1533,7 @@ struct StartupFirstPairWizardView: View {
             return "Each trades battery, quality, and convenience — pick what fits the shoot."
         case .prepareCamera:
             return
-                "Menu names match the Nikon ZR; they may vary slightly by firmware version."
+                "Menu names match the Nikon ZR; they may vary by model and firmware version."
         case .connectNetwork:
             return "Get both devices onto the same network — we'll find the camera automatically."
         case .discoverAndPair:

--- a/ios/Runner/StartupPermissions.swift
+++ b/ios/Runner/StartupPermissions.swift
@@ -23,7 +23,7 @@ enum StartupPermissionKind: String, CaseIterable, Identifiable {
     var detail: String {
         switch self {
         case .camera: "Scan the Wi‑Fi details off the camera screen."
-        case .localNetwork: "Find and stream from the ZR over Wi‑Fi."
+        case .localNetwork: "Find and stream from your camera over Wi‑Fi."
         }
     }
 


### PR DESCRIPTION
First concrete step toward supporting the full Nikon Z mirrorless lineup (discussion #12). A user-facing copy pass over hardcoded "ZR" wording — onboarding wizard steps, permission explainers, connection error/fallback names, and Info.plist usage descriptions now read correctly for any Z body ("the camera" / "your camera" / "Nikon camera"). The prepare-step footer still names the Nikon ZR as the menu-path reference but now notes names vary by model and firmware.

Functional ZR specifics are deliberately untouched: `NIKON_ZR_` SSID prefixes, the `ZR_` PTP friendly-name → "Nikon ZR" mapping, AccessorySetupKit descriptors, discovery AP address, and protocol comments/identifiers.

Verified with `just check` + `just native-check`; wizard screens screenshot-verified in portrait and landscape with no truncation.

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)
