### PR TITLE
fix: make level gauge roll mapping and layout orientation-aware

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		331C808C294A63AB00263BE6 /* CameraWiFiCredentialStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807C294A618700263BE6 /* CameraWiFiCredentialStoreTests.swift */; };
 		331C808D294A63AB00263BE7 /* FirstPairWizardStepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807D294A618700263BE7 /* FirstPairWizardStepTests.swift */; };
 		331C808E294A63AB00263BE8 /* LevelDisplayRollTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807E294A618700263BE8 /* LevelDisplayRollTests.swift */; };
+		331C808F294A63AB00263BE9 /* LevelGaugeSeatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807F294A618700263BE9 /* LevelGaugeSeatTests.swift */; };
 		354E32F45664AA90999EF23C /* MonitorLUT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E943CC20E05A8C345F7D2A9 /* MonitorLUT.swift */; };
 		3B2081943B1D2A36C4DA228C /* ScopeSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D329D509E000B93B59AE9A11 /* ScopeSampler.swift */; };
 		3B2081943B1D2A36C4DA228D /* AudioLevelMeter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D329D509E000B93B59AE9A12 /* AudioLevelMeter.swift */; };
@@ -181,6 +182,7 @@
 		331C807C294A618700263BE6 /* CameraWiFiCredentialStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraWiFiCredentialStoreTests.swift; sourceTree = "<group>"; };
 		331C807D294A618700263BE7 /* FirstPairWizardStepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstPairWizardStepTests.swift; sourceTree = "<group>"; };
 		331C807E294A618700263BE8 /* LevelDisplayRollTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelDisplayRollTests.swift; sourceTree = "<group>"; };
+		331C807F294A618700263BE9 /* LevelGaugeSeatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelGaugeSeatTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		381B085F758DD57850E6CFAE /* FrameioModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FrameioModels.swift; path = ../Sources/OpenZCineCore/Frameio/FrameioModels.swift; sourceTree = SOURCE_ROOT; };
 		3D4E5F60718293A4B5C6D7E8 /* MediaDeliveryPopup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MediaDeliveryPopup.swift; sourceTree = "<group>"; };
@@ -314,6 +316,7 @@
 				331C807C294A618700263BE6 /* CameraWiFiCredentialStoreTests.swift */,
 				331C807D294A618700263BE7 /* FirstPairWizardStepTests.swift */,
 				331C807E294A618700263BE8 /* LevelDisplayRollTests.swift */,
+				331C807F294A618700263BE9 /* LevelGaugeSeatTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -619,6 +622,7 @@
 				331C808C294A63AB00263BE6 /* CameraWiFiCredentialStoreTests.swift in Sources */,
 				331C808D294A63AB00263BE7 /* FirstPairWizardStepTests.swift in Sources */,
 				331C808E294A63AB00263BE8 /* LevelDisplayRollTests.swift in Sources */,
+				331C808F294A63AB00263BE9 /* LevelGaugeSeatTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		331C808C294A63AB00263BE6 /* CameraWiFiCredentialStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807C294A618700263BE6 /* CameraWiFiCredentialStoreTests.swift */; };
 		331C808D294A63AB00263BE7 /* FirstPairWizardStepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807D294A618700263BE7 /* FirstPairWizardStepTests.swift */; };
+		331C808E294A63AB00263BE8 /* LevelDisplayRollTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807E294A618700263BE8 /* LevelDisplayRollTests.swift */; };
 		354E32F45664AA90999EF23C /* MonitorLUT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E943CC20E05A8C345F7D2A9 /* MonitorLUT.swift */; };
 		3B2081943B1D2A36C4DA228C /* ScopeSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D329D509E000B93B59AE9A11 /* ScopeSampler.swift */; };
 		3B2081943B1D2A36C4DA228D /* AudioLevelMeter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D329D509E000B93B59AE9A12 /* AudioLevelMeter.swift */; };
@@ -179,6 +180,7 @@
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C807C294A618700263BE6 /* CameraWiFiCredentialStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraWiFiCredentialStoreTests.swift; sourceTree = "<group>"; };
 		331C807D294A618700263BE7 /* FirstPairWizardStepTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstPairWizardStepTests.swift; sourceTree = "<group>"; };
+		331C807E294A618700263BE8 /* LevelDisplayRollTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LevelDisplayRollTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		381B085F758DD57850E6CFAE /* FrameioModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FrameioModels.swift; path = ../Sources/OpenZCineCore/Frameio/FrameioModels.swift; sourceTree = SOURCE_ROOT; };
 		3D4E5F60718293A4B5C6D7E8 /* MediaDeliveryPopup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MediaDeliveryPopup.swift; sourceTree = "<group>"; };
@@ -311,6 +313,7 @@
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
 				331C807C294A618700263BE6 /* CameraWiFiCredentialStoreTests.swift */,
 				331C807D294A618700263BE7 /* FirstPairWizardStepTests.swift */,
+				331C807E294A618700263BE8 /* LevelDisplayRollTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -615,6 +618,7 @@
 				331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */,
 				331C808C294A63AB00263BE6 /* CameraWiFiCredentialStoreTests.swift in Sources */,
 				331C808D294A63AB00263BE7 /* FirstPairWizardStepTests.swift in Sources */,
+				331C808E294A63AB00263BE8 /* LevelDisplayRollTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/MonitorOverlays.swift
+++ b/ios/Runner/MonitorOverlays.swift
@@ -799,7 +799,8 @@ struct FeedLevelView: View {
         let pitch = model.cameraLevelPitch ?? device.pitch
         Group {
             if style == .gauge {
-                LevelGaugeView(roll: roll, pitch: pitch, feed: feed)
+                LevelGaugeView(
+                    roll: roll, pitch: pitch, feed: feed, isPortrait: model.monitorIsPortrait)
             } else {
                 LevelHorizonView(roll: roll)
                     .position(x: feed.midX, y: feed.midY)
@@ -811,27 +812,50 @@ struct FeedLevelView: View {
         .onChange(of: usesDeviceFallback) { _, fallback in
             fallback ? device.start() : device.stop()
         }
+        // The gravity→roll mapping depends on which way the interface is rotated, so keep the
+        // motion source told about the current shell orientation.
+        .onChange(of: model.monitorIsPortrait, initial: true) { _, portrait in
+            device.isPortrait = portrait
+        }
         .onDisappear { device.stop() }
     }
 }
 
-/// Streams the device's gravity-derived roll/pitch (degrees) while the level overlay is on. The app
-/// is locked landscape, so gravity is projected into the screen plane for the horizon tilt. The axis
-/// signs are best-effort and may want a one-line flip on hardware — the simulator reports no motion,
-/// so this can't be calibrated headlessly.
+/// Streams the device's gravity-derived roll/pitch (degrees) while the level overlay is on. Gravity
+/// arrives in CoreMotion's fixed, portrait-referenced device frame (+x out the right edge, +y out
+/// the top, +z out of the screen), so the screen-plane roll depends on which way the interface is
+/// rotated — `isPortrait` selects the mapping for the two orientations the app supports (Portrait,
+/// LandscapeRight). The simulator reports no motion, so the mapping is derived from CoreMotion's
+/// documented axis conventions; on-hardware sign calibration may still want a one-line flip.
 @Observable
 final class DeviceLevel {
     var roll: Double = 0
     var pitch: Double = 0
+    /// True while the monitor shell is laid out portrait; kept current by the hosting view.
+    var isPortrait = false
 
     @ObservationIgnored private let manager = CMMotionManager()
+
+    /// Screen-plane roll in degrees from the device-frame gravity vector: 0 = upright for the
+    /// given interface orientation, positive = tilted clockwise from the viewer's perspective.
+    ///
+    /// Roll is the angle of gravity off screen-down, toward screen-right: `atan2(g·right, g·down)`.
+    /// Portrait: screen right/down = device +x/−y. LandscapeRight (home side right, device +x
+    /// pointing at the sky, so g.x = −1 when level): screen right/down = device −y/−x.
+    static func displayRoll(gravityX: Double, gravityY: Double, isPortrait: Bool) -> Double {
+        let radians =
+            isPortrait
+            ? atan2(gravityX, -gravityY)
+            : atan2(-gravityY, -gravityX)
+        return radians * 180 / .pi
+    }
 
     func start() {
         guard manager.isDeviceMotionAvailable, !manager.isDeviceMotionActive else { return }
         manager.deviceMotionUpdateInterval = 1.0 / 30.0
         manager.startDeviceMotionUpdates(to: .main) { [weak self] motion, _ in
             guard let self, let g = motion?.gravity else { return }
-            let newRoll = atan2(g.x, -g.y) * 180 / .pi
+            let newRoll = Self.displayRoll(gravityX: g.x, gravityY: g.y, isPortrait: isPortrait)
             let newPitch = atan2(g.z, (g.x * g.x + g.y * g.y).squareRoot()) * 180 / .pi
             // Light low-pass so the readout settles instead of jittering on every sample.
             roll = roll * 0.75 + newRoll * 0.25
@@ -869,13 +893,17 @@ struct LevelGaugeView: View {
     let roll: Double
     let pitch: Double
     let feed: CGRect
+    let isPortrait: Bool
 
     var body: some View {
         ZStack {
             LevelAxisGauge(orientation: .horizontal, value: roll)
-                // Seated just above the bottom capture/assist bars (chrome bottom inset 12 +
-                // control height 58, plus the gauge's own readout half-height and a small gap).
-                .position(x: feed.midX, y: feed.maxY - 104)
+                // Landscape: seated just above the bottom capture/assist bars that overlay the
+                // feed (chrome bottom inset 12 + control height 58, plus the gauge's own readout
+                // half-height and a small gap). Portrait: no chrome overlays the feed band — the
+                // landscape offset would strand the track mid-image on the ~16:9 band, so hug the
+                // image's bottom edge instead.
+                .position(x: feed.midX, y: feed.maxY - (isPortrait ? 30 : 104))
             LevelAxisGauge(orientation: .vertical, value: pitch)
                 // Hugs the feed's trailing edge, beside the right-rail record button — the
                 // readout text sits on the track's feed side, so the whole gauge stays inside.

--- a/ios/Runner/MonitorOverlays.swift
+++ b/ios/Runner/MonitorOverlays.swift
@@ -771,12 +771,41 @@ struct FeedAlignedAssists: View {
                         FeedCrosshairView(feed: feed)
                     }
                     if visible.contains(.level) && model.assistConfiguration.level.enabled {
-                        FeedLevelView(style: model.assistConfiguration.level.style, feed: feed)
+                        FeedLevelView(
+                            style: model.assistConfiguration.level.style, feed: feed,
+                            visibleBounds: Self.visibleBounds(
+                                contentGlobal: proxy.frame(in: .global), size: proxy.size,
+                                screen: screenBounds))
                     }
                 }
             }
         }
         .allowsHitTesting(false)
+    }
+
+    /// The foreground scene's bounds — the on-screen area the over-widened feed content gets
+    /// clipped to (the portrait fill crop frame spans the full viewport width, so the screen
+    /// intersection and the clip intersection coincide).
+    private var screenBounds: CGRect? {
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        let scene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
+        return scene?.coordinateSpace.bounds
+    }
+
+    /// The portion of this overlay that is actually on screen, in its own coordinate space.
+    ///
+    /// Framing aids register pixel-exact with the feed content — including content that portrait
+    /// fill (and fill + de-squeeze) over-widens past the screen and clips. HUD instruments like the
+    /// level gauge instead seat against what the operator can see; this recovers that rect by
+    /// intersecting the content with the screen (`screen` and `contentGlobal` share the global
+    /// space). Falls back to the full content bounds when the intersection degenerates (no scene
+    /// yet, zero-size first layout).
+    static func visibleBounds(contentGlobal: CGRect, size: CGSize, screen: CGRect?) -> CGRect {
+        let bounds = CGRect(origin: .zero, size: size)
+        guard let screen else { return bounds }
+        let screenLocal = screen.offsetBy(dx: -contentGlobal.minX, dy: -contentGlobal.minY)
+        let visible = bounds.intersection(screenLocal)
+        return visible.isNull || visible.isEmpty ? bounds : visible
     }
 }
 
@@ -791,16 +820,24 @@ struct FeedLevelView: View {
     @Environment(NativeAppModel.self) private var model
     let style: AssistConfiguration.Level.Style
     let feed: CGRect
+    /// On-screen portion of the overlay in its coordinate space — what the gauge seats against.
+    let visibleBounds: CGRect
     @State private var device = DeviceLevel()
 
     var body: some View {
         let usesDeviceFallback = model.cameraLevelRoll == nil
         let roll = model.cameraLevelRoll ?? device.roll
         let pitch = model.cameraLevelPitch ?? device.pitch
+        // Portrait fill overlays a capture strip on the visible feed's bottom edge; the roll track
+        // seats above it. Fit tiles its controls below the feed band, so nothing to clear there.
+        let bottomChrome =
+            model.monitorIsPortrait && model.preferences.portraitFeedAspect == .fill
+            ? CGFloat(MonitorPortraitLayout.captureBarHeight) : 0
         Group {
             if style == .gauge {
                 LevelGaugeView(
-                    roll: roll, pitch: pitch, feed: feed, isPortrait: model.monitorIsPortrait)
+                    roll: roll, pitch: pitch, feed: feed, visibleBounds: visibleBounds,
+                    isPortrait: model.monitorIsPortrait, bottomChrome: bottomChrome)
             } else {
                 LevelHorizonView(roll: roll)
                     .position(x: feed.midX, y: feed.midY)
@@ -893,21 +930,44 @@ struct LevelGaugeView: View {
     let roll: Double
     let pitch: Double
     let feed: CGRect
+    /// On-screen portion of the overlay's coordinate space (see `FeedAlignedAssists.visibleBounds`).
+    let visibleBounds: CGRect
     let isPortrait: Bool
+    /// Height of chrome overlaying the visible feed's bottom edge (portrait fill capture strip).
+    let bottomChrome: CGFloat
+
+    /// Seats for the two tracks. The gauge is a HUD instrument, not a framing aid: unlike
+    /// grid/crosshair/guides (which stay pixel-exact with the image content, even when portrait
+    /// fill or de-squeeze widen it past the screen), the gauge seats against the VISIBLE feed —
+    /// the content rect intersected with the on-screen bounds — so neither track can land in the
+    /// clipped-away overhang.
+    ///
+    /// Roll (horizontal track): centred, lifted off the visible bottom edge — landscape by the
+    /// bottom capture/assist bars that overlay the feed (chrome bottom inset 12 + control height
+    /// 58, plus the gauge's readout half-height and a small gap), portrait by a bottom-edge hug
+    /// plus `bottomChrome` for any strip overlaying the visible feed (fill's capture bar).
+    /// Pitch (vertical track): hugs the visible trailing edge, readout on the feed side.
+    static func seats(
+        feed: CGRect, visibleBounds: CGRect, isPortrait: Bool, bottomChrome: CGFloat
+    ) -> (roll: CGPoint, pitch: CGPoint) {
+        var visible = feed.intersection(visibleBounds)
+        if visible.isNull || visible.isEmpty { visible = feed }
+        let rollLift = (isPortrait ? 30 : 104) + bottomChrome
+        return (
+            roll: CGPoint(x: visible.midX, y: visible.maxY - rollLift),
+            pitch: CGPoint(x: visible.maxX - 44, y: visible.midY)
+        )
+    }
 
     var body: some View {
+        let seats = Self.seats(
+            feed: feed, visibleBounds: visibleBounds, isPortrait: isPortrait,
+            bottomChrome: bottomChrome)
         ZStack {
             LevelAxisGauge(orientation: .horizontal, value: roll)
-                // Landscape: seated just above the bottom capture/assist bars that overlay the
-                // feed (chrome bottom inset 12 + control height 58, plus the gauge's own readout
-                // half-height and a small gap). Portrait: no chrome overlays the feed band — the
-                // landscape offset would strand the track mid-image on the ~16:9 band, so hug the
-                // image's bottom edge instead.
-                .position(x: feed.midX, y: feed.maxY - (isPortrait ? 30 : 104))
+                .position(seats.roll)
             LevelAxisGauge(orientation: .vertical, value: pitch)
-                // Hugs the feed's trailing edge, beside the right-rail record button — the
-                // readout text sits on the track's feed side, so the whole gauge stays inside.
-                .position(x: feed.maxX - 44, y: feed.midY)
+                .position(seats.pitch)
         }
         .allowsHitTesting(false)
     }

--- a/ios/RunnerTests/LevelDisplayRollTests.swift
+++ b/ios/RunnerTests/LevelDisplayRollTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+
+@testable import Runner
+
+/// The level overlay's device fallback maps CoreMotion gravity (fixed, portrait-referenced device
+/// frame: +x out the right edge, +y out the top) to screen-plane roll for the two orientations the
+/// app supports. An axis pointing at the ground reads +1, at the sky −1 — so upright portrait is
+/// gravity (0, −1) and upright LandscapeRight (home side right, device +x skyward) is (−1, 0).
+@Suite("Level gauge display roll")
+struct LevelDisplayRollTests {
+
+    /// Gravity components for a device rotated `phi` degrees counterclockwise (viewer's
+    /// perspective) from portrait-upright: g.x = −sin φ, g.y = −cos φ.
+    private func gravity(deviceCCWDegrees phi: Double) -> (x: Double, y: Double) {
+        let r = phi * .pi / 180
+        return (-sin(r), -cos(r))
+    }
+
+    @Test("Portrait: upright reads level, clockwise tilt reads positive")
+    func portraitMapping() {
+        let level = gravity(deviceCCWDegrees: 0)
+        #expect(
+            abs(DeviceLevel.displayRoll(gravityX: level.x, gravityY: level.y, isPortrait: true))
+                < 0.0001)
+
+        // 10° clockwise = −10° CCW.
+        let tilted = gravity(deviceCCWDegrees: -10)
+        let roll = DeviceLevel.displayRoll(gravityX: tilted.x, gravityY: tilted.y, isPortrait: true)
+        #expect(abs(roll - 10) < 0.0001)
+    }
+
+    @Test("LandscapeRight: upright reads level, clockwise tilt reads positive")
+    func landscapeRightMapping() {
+        // Interface LandscapeRight = device rotated +90° CCW (home side right).
+        let level = gravity(deviceCCWDegrees: 90)
+        #expect(level.x == -1)
+        #expect(
+            abs(DeviceLevel.displayRoll(gravityX: level.x, gravityY: level.y, isPortrait: false))
+                < 0.0001)
+
+        let tilted = gravity(deviceCCWDegrees: 80)  // 10° clockwise from landscape-upright
+        let roll = DeviceLevel.displayRoll(
+            gravityX: tilted.x, gravityY: tilted.y, isPortrait: false)
+        #expect(abs(roll - 10) < 0.0001)
+    }
+
+    @Test("The two orientations disagree by exactly 90° for the same physical pose")
+    func orientationOffset() {
+        let pose = gravity(deviceCCWDegrees: 45)
+        let portrait = DeviceLevel.displayRoll(gravityX: pose.x, gravityY: pose.y, isPortrait: true)
+        let landscape = DeviceLevel.displayRoll(
+            gravityX: pose.x, gravityY: pose.y, isPortrait: false)
+        #expect(abs((portrait - landscape) - (-90)) < 0.0001)
+    }
+}

--- a/ios/RunnerTests/LevelGaugeSeatTests.swift
+++ b/ios/RunnerTests/LevelGaugeSeatTests.swift
@@ -1,0 +1,97 @@
+import CoreGraphics
+import Testing
+
+@testable import Runner
+
+/// The level gauge is a HUD instrument: its tracks seat against the VISIBLE feed area (content
+/// rect ∩ on-screen bounds), unlike the framing aids that stay pixel-exact with the content even
+/// when portrait fill or de-squeeze widen it past the screen.
+@Suite("Level gauge seats")
+struct LevelGaugeSeatTests {
+
+    @Test("Landscape: fully visible feed seats against the feed itself")
+    func landscapeFullyVisible() {
+        let feed = CGRect(x: 40, y: 0, width: 800, height: 390)
+        let screen = CGRect(x: 0, y: 0, width: 874, height: 402)
+        let seats = LevelGaugeView.seats(
+            feed: feed, visibleBounds: screen, isPortrait: false, bottomChrome: 0)
+        #expect(seats.roll == CGPoint(x: feed.midX, y: feed.maxY - 104))
+        #expect(seats.pitch == CGPoint(x: feed.maxX - 44, y: feed.midY))
+    }
+
+    @Test("Portrait fit: feed band fully visible, roll hugs the band bottom")
+    func portraitFit() {
+        let feed = CGRect(x: 0, y: 0, width: 402, height: 226)
+        let bounds = CGRect(x: 0, y: 0, width: 402, height: 226)
+        let seats = LevelGaugeView.seats(
+            feed: feed, visibleBounds: bounds, isPortrait: true, bottomChrome: 0)
+        #expect(seats.roll == CGPoint(x: feed.midX, y: feed.maxY - 30))
+        #expect(seats.pitch == CGPoint(x: feed.maxX - 44, y: feed.midY))
+    }
+
+    @Test("Portrait fill: over-widened content clamps both tracks to the visible rect")
+    func portraitFillOverWidened() {
+        // Content over-widened to height * 16/9; the visible slice is the screen-width window
+        // centred in it (overlay-local coordinates).
+        let feed = CGRect(x: 0, y: 0, width: 1000, height: 560)
+        let visible = CGRect(x: 299, y: 0, width: 402, height: 560)
+        let seats = LevelGaugeView.seats(
+            feed: feed, visibleBounds: visible, isPortrait: true, bottomChrome: 64)
+        // Pitch track lands inside the visible window, not at the clipped-away content edge.
+        #expect(seats.pitch.x == visible.maxX - 44)
+        #expect(seats.pitch.y == visible.midY)
+        // Roll track centres on the visible window and clears the fill capture strip (64) plus
+        // the fit-mode bottom hug (30).
+        #expect(seats.roll.x == visible.midX)
+        #expect(seats.roll.y == visible.maxY - 94)
+    }
+
+    @Test("Portrait fill + de-squeeze: seats stay inside both the image and the screen")
+    func portraitFillDesqueezed() {
+        // De-squeeze shrinks the over-widened content to a centred sub-rect that can still be
+        // wider than the screen; the seat is the intersection of the two.
+        let desqueezed = CGRect(x: 125, y: 0, width: 750, height: 560)
+        let visible = CGRect(x: 299, y: 0, width: 402, height: 560)
+        let seats = LevelGaugeView.seats(
+            feed: desqueezed, visibleBounds: visible, isPortrait: true, bottomChrome: 64)
+        #expect(seats.pitch.x <= min(desqueezed.maxX, visible.maxX) - 44)
+        #expect(seats.pitch.x == visible.maxX - 44)
+        #expect(seats.roll.x == visible.midX)
+    }
+
+    @Test("Degenerate visible bounds fall back to the feed rect")
+    func degenerateVisibleBounds() {
+        let feed = CGRect(x: 0, y: 0, width: 800, height: 450)
+        let disjoint = CGRect(x: 2000, y: 2000, width: 10, height: 10)
+        let seats = LevelGaugeView.seats(
+            feed: feed, visibleBounds: disjoint, isPortrait: false, bottomChrome: 0)
+        #expect(seats.roll == CGPoint(x: feed.midX, y: feed.maxY - 104))
+        #expect(seats.pitch == CGPoint(x: feed.maxX - 44, y: feed.midY))
+    }
+
+    @Test("Visible bounds: screen intersection recovers the clip window in overlay-local space")
+    func visibleBoundsIntersection() {
+        // Portrait fill on a 402pt-wide screen: content 1000pt wide, centred, so its global
+        // origin sits 299pt off-screen to the left.
+        let contentGlobal = CGRect(x: -299, y: 52, width: 1000, height: 560)
+        let visible = FeedAlignedAssists.visibleBounds(
+            contentGlobal: contentGlobal,
+            size: CGSize(width: 1000, height: 560),
+            screen: CGRect(x: 0, y: 0, width: 402, height: 874))
+        #expect(visible == CGRect(x: 299, y: 0, width: 402, height: 560))
+    }
+
+    @Test("Visible bounds: no scene or a disjoint screen falls back to the full content bounds")
+    func visibleBoundsFallback() {
+        let size = CGSize(width: 800, height: 450)
+        let content = CGRect(origin: .zero, size: size)
+        #expect(
+            FeedAlignedAssists.visibleBounds(contentGlobal: content, size: size, screen: nil)
+                == content)
+        #expect(
+            FeedAlignedAssists.visibleBounds(
+                contentGlobal: CGRect(x: 5000, y: 5000, width: 800, height: 450), size: size,
+                screen: CGRect(x: 0, y: 0, width: 402, height: 874))
+                == content)
+    }
+}


### PR DESCRIPTION
The horizon/level gauge misbehaved with the portrait layout in two ways. First, the device-fallback roll was computed as `atan2(g.x, -g.y)` regardless of orientation; CoreMotion gravity lives in the fixed portrait-referenced device frame, so this measures tilt from portrait-upright — and pegs at -90° in LandscapeRight (level there is g = (-1, 0, 0)). Roll now goes through a pure `DeviceLevel.displayRoll(gravityX:gravityY:isPortrait:)` that selects screen-plane axes per interface orientation (portrait right/down = +x/−y, LandscapeRight = −y/−x), driven by the shell's `monitorIsPortrait`. Pitch is orientation-independent and unchanged. Second, the gauge seated the roll track at `feed.maxY - 104` — a landscape-chrome constant that stranded the track mid-image on the portrait 16:9 band; portrait now hugs the feed's bottom edge.

Swift Testing coverage added for the mapping in both supported orientations. Verified with `just native-check`, unit tests on-sim, and portrait + landscape screenshots of the live monitor with the gauge enabled. On-device sign calibration of the CW-positive convention remains a hardware check.

**Follow-up: seat the gauge against the visible feed area.** The gauge previously rode the feed *content* rect like the framing aids. That's correct for grid/crosshair/guides — they must stay pixel-exact with the picture, even the portrait-Fill content that's over-widened to `height × 16/9` and clipped — but the level gauge is a HUD instrument. In Fill the pitch track seated at the unclipped content edge, i.e. off-screen (the vanishing tilt axis), and the roll track hugged a feed-band edge overlaid by the capture strip. `FeedAlignedAssists` now computes the overlay's on-screen rect (content ∩ scene bounds) and hands it to the level view only; a pure `LevelGaugeView.seats` function seats both tracks against `feed ∩ visible` — roll centred and lifted off the visible bottom (landscape bottom bars / portrait Fill capture strip), pitch hugging the visible trailing edge. Landscape desqueeze only shrinks the content rect so it was never affected; Fill + desqueeze can still overflow and is covered by the same intersection. Playback excludes the level tool and is untouched. Adds `LevelGaugeSeatTests`; screenshot-verified across portrait Fit/Fill, landscape, and both desqueeze combinations.

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

