### PR TITLE
feat: drive live-view signal indicator from transport health

### DIFF
--- a/Sources/OpenZCineCore/LinkSignalBars.swift
+++ b/Sources/OpenZCineCore/LinkSignalBars.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Maps the 0–100 `CameraLinkHealthScorer` score onto 0–4 signal bars with hysteresis, so the
+/// top-bar signal indicator reads steadily instead of flickering when the score hovers at a band
+/// boundary.
+///
+/// Raw bands are health quartiles (matching the connection panel's meter): 1–25 → 1 bar,
+/// 26–50 → 2, 51–75 → 3, 76–100 → 4; score 0 → 0 bars. Changing bands requires the score to
+/// clear the target band's floor by the hysteresis margin (going up) or drop that margin below
+/// the current band's floor (going down). Zero is immediate in both directions — losing or
+/// gaining the link should never be damped.
+///
+/// Pure value type — fully testable without a live camera.
+public struct LinkSignalBars: Sendable {
+    /// Currently displayed bar count (0–4).
+    public private(set) var bars: Int = 0
+
+    private let margin: Int
+
+    /// - Parameter hysteresisMargin: Score points a band boundary must be cleared by before the
+    ///   displayed bar count changes (default 6).
+    public init(hysteresisMargin: Int = 6) {
+        margin = max(0, hysteresisMargin)
+    }
+
+    /// Lowest score that maps to `bars` without hysteresis.
+    private static func floorScore(of bars: Int) -> Int { 25 * (bars - 1) + 1 }
+
+    /// Raw quartile band for a score, ignoring hysteresis.
+    private static func rawBars(score: Int) -> Int {
+        guard score > 0 else { return 0 }
+        return min(4, max(1, Int((Double(score) / 25.0).rounded(.up))))
+    }
+
+    /// Feeds the latest link-health score and returns the (possibly damped) bar count.
+    public mutating func update(score: Int) -> Int {
+        let raw = Self.rawBars(score: score)
+        switch (bars, raw) {
+        case (let current, let raw) where raw == current:
+            break
+        case (_, 0), (0, _):
+            // Link lost or first score after a reset — reflect it immediately.
+            bars = raw
+        case (let current, let raw) where raw > current:
+            if score >= Self.floorScore(of: raw) + margin { bars = raw }
+        default:
+            if score < Self.floorScore(of: bars) - margin { bars = raw }
+        }
+        return bars
+    }
+}

--- a/Tests/OpenZCineCoreTests/LinkSignalBarsTests.swift
+++ b/Tests/OpenZCineCoreTests/LinkSignalBarsTests.swift
@@ -1,0 +1,49 @@
+import Testing
+
+@testable import OpenZCineCore
+
+@Suite("LinkSignalBars")
+struct LinkSignalBarsTests {
+    @Test("Quartile thresholds map to 0–4 bars from a reset state")
+    func quartileThresholds() {
+        // From bars == 0 the first score seeds the raw band immediately (no hysteresis).
+        for (score, expected) in [
+            (0, 0), (1, 1), (25, 1), (26, 2), (50, 2), (51, 3), (75, 3), (76, 4), (100, 4),
+        ] {
+            var filter = LinkSignalBars()
+            #expect(filter.update(score: score) == expected, "score \(score)")
+        }
+    }
+
+    @Test("Score hovering at a band boundary does not flicker")
+    func hysteresisHolds() {
+        var filter = LinkSignalBars()
+        #expect(filter.update(score: 74) == 3)
+        // Crossing into the 4-bar band without clearing the margin holds at 3…
+        #expect(filter.update(score: 77) == 3)
+        #expect(filter.update(score: 74) == 3)
+        #expect(filter.update(score: 81) == 3)
+        // …and clearing it commits.
+        #expect(filter.update(score: 82) == 4)
+        // Dropping just below the 4-bar floor holds at 4…
+        #expect(filter.update(score: 74) == 4)
+        #expect(filter.update(score: 70) == 4)
+        // …until the score falls the margin below the current band's floor.
+        #expect(filter.update(score: 69) == 3)
+    }
+
+    @Test("A multi-band collapse lands on the raw band once committed")
+    func multiBandDrop() {
+        var filter = LinkSignalBars()
+        #expect(filter.update(score: 95) == 4)
+        #expect(filter.update(score: 30) == 2)
+    }
+
+    @Test("Link loss and recovery bypass hysteresis")
+    func zeroIsImmediate() {
+        var filter = LinkSignalBars()
+        #expect(filter.update(score: 90) == 4)
+        #expect(filter.update(score: 0) == 0)
+        #expect(filter.update(score: 85) == 4)
+    }
+}

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		C0DE0000000000000000003C /* LiveViewWatchdog.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE0000000000000000003D /* LiveViewWatchdog.swift */; };
 		C0DE0000000000000000003E /* RecordDurationEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE0000000000000000003F /* RecordDurationEstimator.swift */; };
 		C0DE00000000000000000040 /* CameraLinkHealth.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000041 /* CameraLinkHealth.swift */; };
+		C0DE000000000000000000CA /* LinkSignalBars.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE000000000000000000CB /* LinkSignalBars.swift */; };
 		C0DE00000000000000000042 /* PTPEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000043 /* PTPEvent.swift */; };
 		C0DE00000000000000000044 /* CameraWarningStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000045 /* CameraWarningStatus.swift */; };
 		C0DE00000000000000000050 /* ConnectionProgressSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000051 /* ConnectionProgressSheet.swift */; };
@@ -242,6 +243,7 @@
 		C0DE0000000000000000003D /* LiveViewWatchdog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LiveViewWatchdog.swift; path = ../Sources/OpenZCineCore/LiveViewWatchdog.swift; sourceTree = SOURCE_ROOT; };
 		C0DE0000000000000000003F /* RecordDurationEstimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = RecordDurationEstimator.swift; path = ../Sources/OpenZCineCore/RecordDurationEstimator.swift; sourceTree = SOURCE_ROOT; };
 		C0DE00000000000000000041 /* CameraLinkHealth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CameraLinkHealth.swift; path = ../Sources/OpenZCineCore/CameraLinkHealth.swift; sourceTree = SOURCE_ROOT; };
+		C0DE000000000000000000CB /* LinkSignalBars.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LinkSignalBars.swift; path = ../Sources/OpenZCineCore/LinkSignalBars.swift; sourceTree = SOURCE_ROOT; };
 		C0DE00000000000000000043 /* PTPEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PTPEvent.swift; path = ../Sources/OpenZCineCore/PTPEvent.swift; sourceTree = SOURCE_ROOT; };
 		C0DE00000000000000000045 /* CameraWarningStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CameraWarningStatus.swift; path = ../Sources/OpenZCineCore/CameraWarningStatus.swift; sourceTree = SOURCE_ROOT; };
 		C0DE00000000000000000051 /* ConnectionProgressSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionProgressSheet.swift; sourceTree = "<group>"; };
@@ -438,6 +440,7 @@
 				C0DE0000000000000000003B /* FrameRateSampler.swift */,
 				C0DE0000000000000000003D /* LiveViewWatchdog.swift */,
 				C0DE00000000000000000041 /* CameraLinkHealth.swift */,
+				C0DE000000000000000000CB /* LinkSignalBars.swift */,
 				C0DE0000000000000000003F /* RecordDurationEstimator.swift */,
 				4A371B3334DBAAA71593727B /* AssistToolActivation.swift */,
 				C08D59A4E8FE339FD74256B9 /* CubeLUT.swift */,
@@ -679,6 +682,7 @@
 				C0DE0000000000000000003A /* FrameRateSampler.swift in Sources */,
 				C0DE0000000000000000003C /* LiveViewWatchdog.swift in Sources */,
 				C0DE00000000000000000040 /* CameraLinkHealth.swift in Sources */,
+				C0DE000000000000000000CA /* LinkSignalBars.swift in Sources */,
 				C0DE0000000000000000003E /* RecordDurationEstimator.swift in Sources */,
 				C0DE00000000000000000014 /* PTPDeviceInfo.swift in Sources */,
 				7884E8682EC3CC0700C636F2 /* SceneDelegate.swift in Sources */,

--- a/ios/Runner/MonitorControls.swift
+++ b/ios/Runner/MonitorControls.swift
@@ -76,12 +76,24 @@ struct RecordChip: View {
 
 struct FPSChip: View {
     let fps: String
+    /// Live link quality (0–4 bars) from `NativeAppModel.liveSignalBars` — transport health, not
+    /// radio RSSI (which iOS apps can't read without special entitlements).
+    let signalBars: Int
+
+    private var signalTint: Color {
+        switch signalBars {
+        case 3...: LiveDesign.good
+        case 2: LiveDesign.accent
+        case 1: LiveDesign.rec
+        default: LiveDesign.faint
+        }
+    }
 
     var body: some View {
         HStack(spacing: 6) {
-            Image(systemName: "cellularbars")
+            Image(systemName: "cellularbars", variableValue: Double(signalBars) / 4.0)
                 .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(LiveDesign.good)
+                .foregroundStyle(signalTint)
             Text("FPS")
                 .font(.system(size: 8, weight: .bold, design: .monospaced))
                 .foregroundStyle(LiveDesign.faint)

--- a/ios/Runner/MonitorPanels.swift
+++ b/ios/Runner/MonitorPanels.swift
@@ -273,7 +273,7 @@ struct CommandHealthStrip: View {
             CommandStatusBlock(label: "Lens", value: Text(model.cameraState.lens))
             Spacer(minLength: 4)
             // Hold the FPS chip at its natural size; the wider status blocks scale down first.
-            FPSChip(fps: model.liveFPS)
+            FPSChip(fps: model.liveFPS, signalBars: model.liveSignalBars)
                 .fixedSize()
                 .layoutPriority(1)
         }

--- a/ios/Runner/MonitorUnified.swift
+++ b/ios/Runner/MonitorUnified.swift
@@ -52,7 +52,7 @@ struct MonitorInfoBar: View {
                         }
                     }
                     if chrome.fpsReadoutVisible {
-                        FPSChip(fps: model.liveFPS)
+                        FPSChip(fps: model.liveFPS, signalBars: model.liveSignalBars)
                     }
                 }
             }

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -552,6 +552,10 @@ final class NativeAppModel {
     // never invalidates every view observing the heavy HUD struct — only the readouts re-render.
     var liveTimecode = CameraDisplayState.preview.timecode
     var liveFPS = CameraDisplayState.preview.liveFPS
+    /// Top-bar signal indicator level (0–4 bars), derived from the continuously-scored
+    /// `linkHealth` transport health with hysteresis (`LinkSignalBars`) so it reads steadily.
+    /// USB-C sessions pin to full bars while linked — frame timing there isn't radio quality.
+    var liveSignalBars = 0
     /// Host-device thermal pressure, mirrored from `ProcessInfo.thermalState`. Gates graceful
     /// cosmetic load-shedding of the feed + scope refresh cadence (see `ThermalTier`). A no-op until
     /// the device is genuinely hot (`.serious`+); it never touches the camera stream or networking.
@@ -1986,6 +1990,7 @@ final class NativeAppModel {
     @ObservationIgnored private var consecutiveBadLiveFrames = 0
     @ObservationIgnored private var recentKeepaliveFailures = 0
     @ObservationIgnored private var isStreamRecovering = false
+    @ObservationIgnored private var signalBarsFilter = LinkSignalBars()
     private var eventDrainTask: Task<Void, Never>?
     /// The fire-and-forget `stopLiveView()` started on background, tracked so a quick return to the
     /// foreground awaits it before restarting the stream (otherwise the stop can land after the
@@ -3074,12 +3079,20 @@ final class NativeAppModel {
         isStreamRecovering = false
         linkHealth = 0
         linkHealthDetail = "Not connected"
+        signalBarsFilter = LinkSignalBars()
+        liveSignalBars = 0
     }
 
     private func refreshLinkHealth() {
         let snapshot = CameraLinkHealthScorer.score(currentLinkHealthInputs())
         linkHealth = snapshot.linkHealthScore
         linkHealthDetail = snapshot.detailCaption
+        // USB-C: frame timing isn't radio quality — show full bars whenever the link is alive.
+        let bars =
+            cameraSession?.transportKind == .usb
+            ? (linkHealth > 0 ? 4 : 0)
+            : signalBarsFilter.update(score: linkHealth)
+        if bars != liveSignalBars { liveSignalBars = bars }
     }
 
     private func currentLinkHealthInputs() -> CameraLinkHealthInputs {


### PR DESCRIPTION
The signal bars in the live-view top bar were decorative — hardcoded full/green. They now reflect the live link.

- Reuses the existing `CameraLinkHealthScorer` 0–100 score (live-view FPS vs target, PTP RTT, frame freshness, bad frames, keep-alive failures), already refreshed on the 1s link-health timer.
- New `LinkSignalBars` core type maps the score to 0–4 bars in health quartiles with a 6-point hysteresis margin so the indicator doesn't flicker at band boundaries; link loss/regain bypasses hysteresis.
- USB-C sessions pin to full bars while linked — frame timing over USB isn't radio quality. No Wi-Fi RSSI APIs (unavailable to iOS apps without special entitlements).
- Chip renders via `cellularbars` `variableValue` with good/accent/rec tint; covered by Swift Testing cases for thresholds + hysteresis.

Verified with `just native-check` and a landscape simulator screenshot pass (demo session, all edges clean). Pending on-device: degraded-Wi-Fi step-down on a real ZR and the USB-C pinned state.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)
