### PR TITLE
fix: clear iPadOS 26 window-control pill from top-leading chrome

### DIFF
--- a/Sources/OpenZCineCore/MonitorZoneLayout.swift
+++ b/Sources/OpenZCineCore/MonitorZoneLayout.swift
@@ -128,10 +128,15 @@ public enum MonitorZoneLayout {
     /// `mode`, `aspect`, and `scopeCount` only affect the portrait branch; landscape results are
     /// stable across modes. `bottomBarHeight` and `horizontalDirection` only affect the landscape
     /// branch.
+    ///
+    /// `chromeInsets` lets the shell pass margins that carry platform exclusions the safe area
+    /// does not (the iPadOS 26 window-control pill); `nil` derives them from `safeArea` via
+    /// `MonitorChromeLayout.insets`, as before.
     public static func map(
         viewportWidth: Double,
         viewportHeight: Double,
         safeArea: MonitorEdgeInsets,
+        chromeInsets: MonitorEdgeInsets? = nil,
         mode: DispMode,
         isPortrait: Bool,
         aspect: PortraitFeedAspect,
@@ -154,6 +159,7 @@ public enum MonitorZoneLayout {
             viewportWidth: viewportWidth,
             viewportHeight: viewportHeight,
             safeArea: safeArea,
+            chromeInsets: chromeInsets,
             horizontalDirection: horizontalDirection,
             bottomBarHeight: bottomBarHeight
         )
@@ -168,10 +174,11 @@ public enum MonitorZoneLayout {
         viewportWidth: Double,
         viewportHeight: Double,
         safeArea: MonitorEdgeInsets,
+        chromeInsets: MonitorEdgeInsets? = nil,
         horizontalDirection: MonitorHorizontalLayoutDirection,
         bottomBarHeight: Double
     ) -> MonitorZoneMap {
-        let chromeInsets = MonitorChromeLayout.insets(feedSafeArea: safeArea)
+        let chromeInsets = chromeInsets ?? MonitorChromeLayout.insets(feedSafeArea: safeArea)
         let legacy = MonitorLiveViewModuleLayout.fit(
             viewportWidth: viewportWidth,
             viewportHeight: viewportHeight,

--- a/ios/Runner/DesignShared.swift
+++ b/ios/Runner/DesignShared.swift
@@ -170,6 +170,45 @@ extension GeometryProxy {
     }
 }
 
+extension MonitorEdgeInsets {
+    /// Floors the top inset so top-leading chrome clears the iPadOS 26 window-control pill.
+    ///
+    /// In iPadOS 26's default "Windowed Apps" mode the system floats a close/minimize capsule
+    /// over every scene's top-leading corner — including this app's, which opts out of window
+    /// resizing (`UIRequiresFullScreen` + fixed orientations) and therefore runs as a scaled
+    /// full-screen canvas. In that compatibility mode the pill is composited by the system and
+    /// is invisible to the process: safe areas, the iOS 26 corner-adapted layout regions
+    /// (`UIView.LayoutRegion`), and `UIWindowScene.effectiveGeometry` all report plain
+    /// full-screen values (verified on the iPadOS 26.2 simulator — top inset 0, corner
+    /// adaptation 9.5pt display-corner only, scene == screen bounds). The system's own
+    /// compatibility placement parks the pill in the status-bar band, but this app hides the
+    /// status bar, so the band must be reserved manually.
+    ///
+    /// Apply this ONLY to chrome-placement insets — never to `feedSafeArea`/viewport math,
+    /// which must restore physical-screen geometry from real insets.
+    @MainActor var clearingWindowControls: MonitorEdgeInsets {
+        let clearance = MonitorWindowControlsClearance.top
+        guard clearance > top else { return self }
+        return MonitorEdgeInsets(
+            top: clearance, leading: leading, bottom: bottom, trailing: trailing)
+    }
+}
+
+/// Top band reserved for the iPadOS 26 window-control pill (see `clearingWindowControls`).
+@MainActor
+enum MonitorWindowControlsClearance {
+    /// 40pt clears the ~26pt-tall (screen points) pill across the canvas scales the system
+    /// actually uses for this app's window (~0.65–1.0, measured). The scale is not observable
+    /// in-process, so a user-shrunk tiny window can still graze the pill — the same ceiling
+    /// Apple's own 32pt status-bar-band placement has.
+    static let top: Double = {
+        guard #available(iOS 26.0, *), UIDevice.current.userInterfaceIdiom == .pad else {
+            return 0
+        }
+        return 40
+    }()
+}
+
 extension OperatorPreferences.StreamPreset {
     var next: OperatorPreferences.StreamPreset {
         switch self {

--- a/ios/Runner/MonitorExperience.swift
+++ b/ios/Runner/MonitorExperience.swift
@@ -103,12 +103,15 @@ struct LiveViewLayoutContext {
     /// horizontally). Passing the safe-area height double-counts the insets: ~96pt dead band.
     let viewportHeight: Double
 
+    @MainActor
     init(proxy: GeometryProxy, deviceOrientation: MonitorDeviceOrientation, screenWidth: Double?) {
         feedSafeArea = proxy.monitorEdgeInsets
         isPortrait = proxy.size.height > proxy.size.width
         viewportHeight =
             Double(proxy.size.height) + max(0, feedSafeArea.top) + max(0, feedSafeArea.bottom)
-        chromeInsets = MonitorChromeLayout.insets(feedSafeArea: feedSafeArea)
+        chromeInsets =
+            MonitorChromeLayout.insets(feedSafeArea: feedSafeArea)
+            .clearingWindowControls
         horizontalDirection = MonitorHorizontalLayoutDirection.resolve(
             deviceOrientation: deviceOrientation,
             safeArea: feedSafeArea

--- a/ios/Runner/MonitorOverlays.swift
+++ b/ios/Runner/MonitorOverlays.swift
@@ -32,7 +32,7 @@ struct FeedAssistOverlayModule: View {
             // `landscapeBottomBarHeight` in MonitorUnified.swift).
             let chromeClearance = EdgeInsets(
                 top: CGFloat(
-                    MonitorChromeLayout.insets(feedSafeArea: safeArea).top
+                    MonitorChromeLayout.insets(feedSafeArea: safeArea).clearingWindowControls.top
                         + MonitorLiveViewModuleLayout.topInfoDeckHeight),
                 leading: 0,
                 bottom: CGFloat(MonitorLiveViewModuleLayout.bottomBarBottomInset)

--- a/ios/Runner/MonitorUnified.swift
+++ b/ios/Runner/MonitorUnified.swift
@@ -893,6 +893,9 @@ struct MonitorShell: View {
             viewportWidth: context.viewportWidth,
             viewportHeight: fullHeight,
             safeArea: context.feedSafeArea,
+            // Carries the iPadOS 26 window-control clearance the safe area lacks (see
+            // `clearingWindowControls`), so the lock button and top deck render below the pill.
+            chromeInsets: context.chromeInsets,
             mode: model.displayMode,
             isPortrait: false,
             aspect: model.preferences.portraitFeedAspect,
@@ -1445,12 +1448,13 @@ struct MonitorFullScreenPanelOverlay: View {
     /// surface hugs that bezel while clearing the Dynamic Island on the side it sits. Portrait
     /// passes the safe area straight through.
     private var fullScreenPanelSafeArea: MonitorEdgeInsets {
-        guard !context.isPortrait else { return context.feedSafeArea }
+        guard !context.isPortrait else { return context.feedSafeArea.clearingWindowControls }
         let islandOnLeading = context.horizontalDirection != .mirrored
         return MonitorEdgeInsets(
             top: context.feedSafeArea.top,
             leading: islandOnLeading ? context.feedSafeArea.leading : 0,
             bottom: context.feedSafeArea.bottom,
-            trailing: islandOnLeading ? 0 : context.feedSafeArea.trailing)
+            trailing: islandOnLeading ? 0 : context.feedSafeArea.trailing
+        ).clearingWindowControls
     }
 }

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -6236,7 +6236,7 @@ struct NativeAppRoot: View {
                         leading: islandOnLeading ? Double(insets.leading) : 0,
                         bottom: Double(insets.bottom),
                         trailing: islandOnLeading ? 0 : Double(insets.trailing)
-                    )
+                    ).clearingWindowControls
                 )
                 .environment(model)
                 .environment(deliveryCoordinator)
@@ -6265,7 +6265,7 @@ struct NativeAppRoot: View {
                         leading: islandOnLeading ? Double(insets.leading) : 0,
                         bottom: Double(insets.bottom),
                         trailing: islandOnLeading ? 0 : Double(insets.trailing)
-                    )
+                    ).clearingWindowControls
                 )
                 .environment(model)
             }


### PR DESCRIPTION
On iPadOS 26, when the app runs windowed, the system window-control pill (the ●●● capsule at the window's top-leading corner) overlays app content — the Operator Setup eyebrow/title and the monitor's top-leading chrome (lock button, STBY deck).

**Root cause.** Because the app sets `UIRequiresFullScreen` + fixed orientations, iPadOS 26 runs it as a scaled full-screen compatibility canvas — and in that mode the pill is completely invisible to the process. Measured live on an iPadOS 26.2 simulator while windowed: SwiftUI top inset 0, `window.safeAreaInsets.top` 0, iOS 26 corner-adapted layout regions report only the 9.5pt display-corner adaptation, `scene.screen.bounds == scene.bounds`, and `preferredWindowingControlStyle` has no effect. The app cannot even detect that it is windowed. Apple's own compat mechanism parks the pill in the status-bar band (`UIStatusBarHidden=false` yields a 32pt top inset containing it), but this app deliberately hides the status bar (the clock would overlay the monitor full-screen — previously reverted).

**Fix.** One primitive, applied at the chrome-inset capture/derivation sites rather than per-view patches: `MonitorEdgeInsets.clearingWindowControls` (DesignShared.swift) floors the top inset to 40pt on iPad + iOS 26 (0 everywhere else). Applied to `LiveViewLayoutContext.chromeInsets`, the landscape zone map (via a new additive optional `chromeInsets:` on `MonitorZoneLayout.map()` — core stays UI-free), `fullScreenPanelSafeArea`, scope-panel chrome, and both standalone covers (settings, media). Feed/viewport math keeps real insets — flooring those would corrupt the physical-height restoration.

**Known tradeoff.** In true full screen the pill auto-hides, but the 40pt band still applies on iPad, so top chrome sits 26pt lower than before there. The windowed state is provably undetectable in-process; the only detector (device-vs-interface orientation mismatch) would make the HUD jump 26pt when the operator tilts the iPad mid-shoot, so a stable constant won. Alternatives considered and rejected: un-hiding the status bar, `.unified` windowing-control style, the orientation-mismatch heuristic.

**Verification.** `just native-check` green (639 tests). Screenshot matrix: iPad windowed landscape (settings + monitor + home, pill now cleared), iPad true full-screen landscape + portrait, iPhone 17 Pro landscape (pixel-identical, clearance 0). The remaining X-button/title overlap visible in settings shots is the pre-existing #51 collision, fixed orthogonally in #87.

Kaneo: OPE-39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
