### PR TITLE
docs: require Kaneo in-review move whenever a PR opens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,3 +21,6 @@ instead of duplicating it in this client-specific file.
 - `.claude/settings.json` creates feature-task worktrees from the current branch. Agent changes must
   be verified in their isolated worktree, merged locally into the feature branch, and cleaned up
   afterward, as described in `AGENTS.md`.
+- **Opening or updating a PR always includes moving its Kaneo task to `in-review` in the same
+  step** (and to `done` only after merge + green default-branch CI). Never leave the board behind
+  the PR state — full contract in `AGENTS.md` → "Project management (Kaneo)".


### PR DESCRIPTION
## What & why

<!-- What does this PR change, and why? Link any related issue. -->

## Checklist

- [ ] `just check` passes.
- [ ] Native production changes: `just native-check` passes, or the relevant platform check is noted.
- [ ] Legacy prototype/reference changes are intentionally included or left local.
- [ ] Commits follow Conventional Commits.
- [ ] No proprietary assets (`vendor/`, `ref/`) are included.
- [ ] Docs/CHANGELOG updated if behavior or setup changed.
- [ ] iOS release PRs: bump `MARKETING_VERSION` in `ios/Config/Version.xcconfig` when appropriate.
