### PR TITLE
feat: publish Privacy and Terms pages and link them from the startup header

### DIFF
--- a/ios/Runner/StartupDesign.swift
+++ b/ios/Runner/StartupDesign.swift
@@ -108,6 +108,8 @@ enum StartupColors {
 }
 
 struct StartupHeader: View {
+    @Environment(\.openURL) private var openURL
+
     var title: String = "Connection setup"
     let statusTitle: String
     let isBusy: Bool
@@ -119,11 +121,15 @@ struct StartupHeader: View {
                     .font(.system(size: 10, weight: .semibold, design: .rounded))
                     .tracking(1.3)
                     .foregroundStyle(StartupColors.muted)
-                Text(title)
-                    .font(.system(size: 17, weight: .bold, design: .rounded))
-                    .foregroundStyle(StartupColors.ink)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
+                HStack(alignment: .firstTextBaseline, spacing: 14) {
+                    Text(title)
+                        .font(.system(size: 17, weight: .bold, design: .rounded))
+                        .foregroundStyle(StartupColors.ink)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.8)
+                    legalLink("Privacy", path: "privacy")
+                    legalLink("Terms", path: "terms")
+                }
             }
 
             Spacer(minLength: 8)
@@ -142,6 +148,21 @@ struct StartupHeader: View {
             .background(StartupColors.surface.opacity(0.50), in: Capsule())
             .overlay(Capsule().stroke(statusColor.opacity(0.40), lineWidth: 1))
         }
+    }
+
+    /// Quiet utility text link to a policy page on openzcine.app — deliberately dimmer than the
+    /// title so it never competes with it.
+    private func legalLink(_ label: String, path: String) -> some View {
+        Button(label) {
+            guard let url = URL(string: "https://openzcine.app/\(path)") else { return }
+            openURL(url)
+        }
+        .font(.system(size: 11, weight: .medium, design: .rounded))
+        .foregroundStyle(StartupColors.dim)
+        .lineLimit(1)
+        .fixedSize()
+        .buttonStyle(.zcTapTarget)
+        .accessibilityLabel("Open the OpenZCine \(label) page")
     }
 
     private var statusColor: Color {

--- a/site/privacy/index.html
+++ b/site/privacy/index.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>OpenZCine Privacy Policy</title>
+  <meta name="description" content="OpenZCine collects no personal data and operates no servers. Camera control and live view stay on your local network.">
+  <meta name="theme-color" content="#0A0908">
+  <meta name="referrer" content="no-referrer">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'none'; upgrade-insecure-requests">
+  <link rel="canonical" href="https://openzcine.app/privacy/">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="OpenZCine Privacy Policy">
+  <meta property="og:description" content="No personal data collected, no servers operated. Everything stays between your device and your camera.">
+  <meta property="og:url" content="https://openzcine.app/privacy/">
+  <link rel="icon" href="../assets/icon.png">
+  <link rel="apple-touch-icon" href="../assets/icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&amp;family=Geist+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/app.css">
+  <style>
+    /* Long-form legal article: quieter scale than the marketing sections. */
+    .legal-hero { padding: clamp(88px, 12vw, 140px) 0 clamp(28px, 4vw, 44px); }
+    .legal-hero h1 { font-size: clamp(34px, 5vw, 56px); margin: 10px 0 18px; }
+    .legal-hero .legal-article { padding-bottom: 0; }
+    .legal-updated { font: 500 13px/1.4 var(--mono); color: var(--faint); letter-spacing: .04em; }
+    .legal-article { max-width: 720px; padding-bottom: clamp(64px, 9vw, 110px); }
+    .legal-article h2 { font-size: clamp(21px, 2.6vw, 27px); margin: clamp(36px, 5vw, 52px) 0 14px; }
+    .legal-article p, .legal-article li { color: var(--muted); font-size: 15.5px; line-height: 1.65; }
+    .legal-article p + p { margin-top: 12px; }
+    .legal-article strong { color: var(--ink); }
+    .legal-article ul { list-style: disc; padding-left: 20px; display: flex; flex-direction: column; gap: 12px; }
+    .legal-article li::marker { color: var(--accent); }
+    .legal-article a { color: var(--accent); }
+    .legal-article a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body class="support-page">
+  <a class="skip-link" href="#legal-content">Skip to content</a>
+  <div class="bg-glow" aria-hidden="true"></div>
+  <div class="grain" aria-hidden="true"></div>
+
+  <header class="support-nav">
+    <div class="container support-nav__inner">
+      <a href="/" class="nav__brand" aria-label="OpenZCine home">
+        <img src="../assets/icon.png" alt="" width="28" height="28">
+        <span>OpenZCine</span>
+      </a>
+      <nav class="support-nav__links" aria-label="Page navigation">
+        <a href="/">Home</a>
+        <a href="/support/">Support</a>
+        <a href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">GitHub</a>
+        <a class="btn btn--primary" href="TESTFLIGHT_URL"><span class="btn__rec" aria-hidden="true"></span>Join the beta</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="legal-content">
+    <section class="legal-hero">
+      <div class="container legal-article">
+        <span class="section-label"><span class="rec-dot"></span> Privacy Policy</span>
+        <h1>Your footage is nobody's business.</h1>
+        <p class="legal-updated">Last updated: July 2, 2026</p>
+      </div>
+    </section>
+
+    <div class="container legal-article">
+      <p>
+        OpenZCine is an open-source camera monitor and remote control for Nikon Z cinema-line
+        cameras. <strong>The app collects no personal data, and the project operates no servers
+        that receive data from the app.</strong>
+      </p>
+
+      <h2>What the app does with data</h2>
+      <ul>
+        <li>
+          <strong>Camera control and live view</strong> happen entirely over your local Wi-Fi
+          network between your device and your camera. Video frames and camera settings never
+          leave your device.
+        </li>
+        <li>
+          <strong>Settings, camera pairing profiles, and the reconnect identity</strong> are
+          stored only in app-local storage on your device.
+        </li>
+        <li>
+          <strong>Saving clips to Photos</strong> only happens when you choose &ldquo;Save to
+          Photos&rdquo;, using add-only photo library access.
+        </li>
+      </ul>
+
+      <h2>Optional third-party services</h2>
+      <ul>
+        <li>
+          <strong>Frame.io upload (optional).</strong> If you connect your own Frame.io account,
+          the app talks directly to Adobe's sign-in service and the Frame.io API to upload clips
+          you select. Your sign-in token is stored in the iOS Keychain on your device only.
+          Uploads go directly from your device to Frame.io &mdash; never through us. Adobe's
+          handling of your account is governed by the
+          <a href="https://www.adobe.com/privacy/policy.html" target="_blank" rel="noopener">Adobe
+          Privacy Policy</a>.
+        </li>
+        <li>
+          <strong>RED LUT download (optional).</strong> If you choose to download RED's IPP2
+          output presets, the app opens RED's website. That visit is governed by RED's own
+          privacy policy.
+        </li>
+      </ul>
+
+      <h2>What the app does not do</h2>
+      <ul>
+        <li>No analytics, telemetry, or crash-reporting SDKs.</li>
+        <li>No advertising or tracking of any kind.</li>
+        <li>No account with us &mdash; the app has no sign-up.</li>
+        <li>No collection, sale, or sharing of personal data.</li>
+      </ul>
+
+      <h2>Changes and contact</h2>
+      <p>
+        Changes to this policy are published on this page and in the project's public repository.
+        Questions: open an issue at
+        <a href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">github.com/erik-sutton95/OpenZCine</a>.
+      </p>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container footer__inner">
+      <div class="footer__brand"><img src="../assets/icon.png" alt="" width="24" height="24"><span>OpenZCine</span></div>
+      <p class="footer__meta"><a href="/">Home</a> · <a href="/support/">Support</a> · <a href="/terms/">Terms</a> · <a href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">Source</a></p>
+      <p class="footer__disclaimer">OpenZCine is not affiliated with or endorsed by Nikon Corporation, Adobe, or RED Digital Cinema.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/site/terms/index.html
+++ b/site/terms/index.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>OpenZCine Terms of Use</title>
+  <meta name="description" content="Plain-language terms for OpenZCine: free and open source under Apache-2.0, no accounts, no fees, provided as is.">
+  <meta name="theme-color" content="#0A0908">
+  <meta name="referrer" content="no-referrer">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'none'; upgrade-insecure-requests">
+  <link rel="canonical" href="https://openzcine.app/terms/">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="OpenZCine Terms of Use">
+  <meta property="og:description" content="Free and open source under Apache-2.0. No accounts, no fees, no subscriptions.">
+  <meta property="og:url" content="https://openzcine.app/terms/">
+  <link rel="icon" href="../assets/icon.png">
+  <link rel="apple-touch-icon" href="../assets/icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&amp;family=Geist+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/app.css">
+  <style>
+    /* Long-form legal article: quieter scale than the marketing sections. */
+    .legal-hero { padding: clamp(88px, 12vw, 140px) 0 clamp(28px, 4vw, 44px); }
+    .legal-hero h1 { font-size: clamp(34px, 5vw, 56px); margin: 10px 0 18px; }
+    .legal-hero .legal-article { padding-bottom: 0; }
+    .legal-updated { font: 500 13px/1.4 var(--mono); color: var(--faint); letter-spacing: .04em; }
+    .legal-article { max-width: 720px; padding-bottom: clamp(64px, 9vw, 110px); }
+    .legal-article h2 { font-size: clamp(21px, 2.6vw, 27px); margin: clamp(36px, 5vw, 52px) 0 14px; }
+    .legal-article p, .legal-article li { color: var(--muted); font-size: 15.5px; line-height: 1.65; }
+    .legal-article p + p { margin-top: 12px; }
+    .legal-article strong { color: var(--ink); }
+    .legal-article ul { list-style: disc; padding-left: 20px; display: flex; flex-direction: column; gap: 12px; }
+    .legal-article li::marker { color: var(--accent); }
+    .legal-article a { color: var(--accent); }
+    .legal-article a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body class="support-page">
+  <a class="skip-link" href="#legal-content">Skip to content</a>
+  <div class="bg-glow" aria-hidden="true"></div>
+  <div class="grain" aria-hidden="true"></div>
+
+  <header class="support-nav">
+    <div class="container support-nav__inner">
+      <a href="/" class="nav__brand" aria-label="OpenZCine home">
+        <img src="../assets/icon.png" alt="" width="28" height="28">
+        <span>OpenZCine</span>
+      </a>
+      <nav class="support-nav__links" aria-label="Page navigation">
+        <a href="/">Home</a>
+        <a href="/support/">Support</a>
+        <a href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">GitHub</a>
+        <a class="btn btn--primary" href="TESTFLIGHT_URL"><span class="btn__rec" aria-hidden="true"></span>Join the beta</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="legal-content">
+    <section class="legal-hero">
+      <div class="container legal-article">
+        <span class="section-label"><span class="rec-dot"></span> Terms of Use</span>
+        <h1>Short, because there's not much to agree to.</h1>
+        <p class="legal-updated">Last updated: July 14, 2026</p>
+      </div>
+    </section>
+
+    <div class="container legal-article">
+      <h2>Acceptance</h2>
+      <p>
+        By using the OpenZCine app or this website, you agree to these terms. If you don't agree,
+        don't use them.
+      </p>
+
+      <h2>License and source</h2>
+      <p>
+        OpenZCine is free and open source, licensed under the
+        <a href="https://github.com/erik-sutton95/OpenZCine/blob/main/LICENSE" target="_blank" rel="noopener">Apache
+        License 2.0</a>. The full source code is public. There are no accounts, no fees, and no
+        subscriptions.
+      </p>
+      <p>
+        If you install the app from the App Store, that binary is additionally subject to Apple's
+        standard
+        <a href="https://www.apple.com/legal/internet-services/itunes/dev/stdeula/" target="_blank" rel="noopener">Licensed
+        Application End User License Agreement</a>.
+      </p>
+
+      <h2>Camera control disclaimer</h2>
+      <p>
+        OpenZCine remotely controls physical camera equipment. Wireless links drop, settings
+        writes can be rejected, and displays can lag the camera's real state. <strong>Always
+        verify critical settings &mdash; recording state, exposure, and media &mdash; on the
+        camera itself.</strong> Use on productions is at your own risk.
+      </p>
+
+      <h2>No warranty and limitation of liability</h2>
+      <p>
+        OpenZCine is provided <strong>&ldquo;AS IS&rdquo;</strong>, without warranties or
+        conditions of any kind, as set out in the warranty disclaimer and limitation of liability
+        of the Apache License 2.0. To the maximum extent permitted by law, the project and its
+        contributors are not liable for any damages arising from use of the app, including lost
+        footage, missed takes, or equipment issues.
+      </p>
+
+      <h2>Third-party services</h2>
+      <p>
+        The project operates no services of its own. Two optional features connect you directly
+        to third parties:
+      </p>
+      <ul>
+        <li>
+          <strong>Frame.io upload.</strong> If you connect your own Frame.io account, your use of
+          that service is governed by
+          <a href="https://www.adobe.com/legal/terms.html" target="_blank" rel="noopener">Adobe's
+          terms</a>.
+        </li>
+        <li>
+          <strong>RED LUT downloads.</strong> If you choose to download RED's IPP2 output presets,
+          the app opens RED's website, and RED's own terms govern that visit and those files.
+        </li>
+      </ul>
+
+      <h2>Trademarks and affiliation</h2>
+      <p>
+        Nikon, RED, Adobe, Frame.io, Apple, and other names used in the app or on this site
+        belong to their respective owners and are used for identification only. OpenZCine is an
+        independent open-source project, not affiliated with or endorsed by any of them.
+      </p>
+
+      <h2>Changes and contact</h2>
+      <p>
+        Changes to these terms are published on this page and in the project's public repository.
+        Questions: open an issue at
+        <a href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">github.com/erik-sutton95/OpenZCine</a>.
+      </p>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container footer__inner">
+      <div class="footer__brand"><img src="../assets/icon.png" alt="" width="24" height="24"><span>OpenZCine</span></div>
+      <p class="footer__meta"><a href="/">Home</a> · <a href="/support/">Support</a> · <a href="/privacy/">Privacy</a> · <a href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">Source</a></p>
+      <p class="footer__disclaimer">OpenZCine is not affiliated with or endorsed by Nikon Corporation, Adobe, or RED Digital Cinema.</p>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
Adds openzcine.app/privacy and openzcine.app/terms to the GitHub Pages site, restyled in the site's shared design (nav, typography, footer, CSP). The privacy text is the existing policy verbatim; the terms are plain-language for a free, Apache-2.0 app: acceptance, license and source, camera-control disclaimer, AS-IS warranty and liability limits, optional third-party services, trademarks, and contact.

The startup header gains two quiet Privacy/Terms text links after the title (all startup states), opening the pages via `openURL`, with 44pt tap targets and accessibility labels.

Kaneo: OPE-44.

Verified with `just check`, `just native-check`, and a portrait+landscape simulator screenshot pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
