### PR TITLE
feat: add Privacy and Terms links to the landing page footer

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -321,6 +321,8 @@
       </div>
       <p class="footer__meta">
         <a href="/support/">Support</a> ·
+        <a href="/privacy/">Privacy</a> ·
+        <a href="/terms/">Terms</a> ·
         Free &amp; open source · <a href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">Apache-2.0</a>
       </p>
       <p class="footer__disclaimer">


### PR DESCRIPTION
Adds Privacy and Terms links to the landing page footer, alongside Support — pointing at the /privacy/ and /terms/ pages shipped in #99.

(Originally pushed to the #99 branch moments after it merged; cherry-picked here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
