### PR TITLE
feat: second-pass iPad 4:3 live-view layout — corner chrome + full-width feed

### DIFF
--- a/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
+++ b/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
@@ -360,6 +360,15 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
     /// Diameter of the top-leading lock button.
     public static let lockButtonSize = 40.0
 
+    /// Trailing chrome width reserved on width-constrained (4:3 iPad) landscape layouts for the
+    /// inline bottom-corner record + DISP pair: both buttons plus a bar gap and the inter-button
+    /// gap, so the shortened bottom bars end clear of the cluster.
+    public static var constrainedBottomCornerReservedWidth: Double {
+        MonitorSideRailControlLayout.recordButtonSize
+            + MonitorSideRailControlLayout.displayButtonWidth
+            + 2 * bottomModuleSpacing
+    }
+
     /// Feed frame. This is the only module affected by feed safe-area cutout avoidance.
     public let feed: MonitorFeedFrame
 
@@ -426,14 +435,24 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
         let screen = MonitorLayoutRegion.viewport(width: viewportWidth, height: viewportHeight)
         let chrome = screen.inset(chromeInsets)
         let bottomBarHeight = max(0, bottomBarHeight)
-        let bottomModuleWidth = max(0, (chrome.width - bottomModuleSpacing) / 2)
+        // Width-constrained (4:3-ish iPad) landscape: the record + DISP pair sits inline in the
+        // bottom-trailing corner, so the bottom bars shorten to leave that corner free.
+        let constrained = MonitorFeedLayout.isWidthConstrained(
+            viewportWidth: viewportWidth,
+            viewportHeight: viewportHeight
+        )
+        let bottomBarsWidth =
+            constrained
+            ? max(0, chrome.width - Self.constrainedBottomCornerReservedWidth)
+            : chrome.width
+        let bottomModuleWidth = max(0, (bottomBarsWidth - bottomModuleSpacing) / 2)
         // The chrome viewport now spans the full screen height, so the screen edge is the true
         // bottom; hug the bars to it, tighter than the chrome inset.
         let bottomBarBottom = screen.maxY - bottomBarBottomInset
         let bottomRegion = MonitorLayoutRegion(
             x: chrome.x,
             y: max(chrome.y, bottomBarBottom - bottomBarHeight),
-            width: chrome.width,
+            width: bottomBarsWidth,
             height: bottomBarHeight
         )
         let bottomCaptureRegion = MonitorLayoutRegion(
@@ -460,13 +479,8 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
         let deckLeft = feed.x + topInfoDeckSideInset
         let deckRight = feed.x + feed.width - topInfoDeckSideInset
 
-        // Width-constrained (4:3-ish iPad) landscape: no side lanes exist, so the battery
-        // indicators sit inline beside the lock button in the top chrome band instead of
-        // stacking in a leading rail.
-        let constrained = MonitorFeedLayout.isWidthConstrained(
-            viewportWidth: viewportWidth,
-            viewportHeight: viewportHeight
-        )
+        // Width-constrained landscape also inlines the battery indicators beside the lock button
+        // in the top chrome band instead of stacking them in a leading rail (no side lanes exist).
         let batteryRail =
             constrained
             ? MonitorModuleFrame(

--- a/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
+++ b/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
@@ -184,11 +184,6 @@ public enum MonitorFeedLayout {
     /// Native monitor preview aspect ratio.
     public static let aspectRatio = 16.0 / 9.0
 
-    /// Symmetric side lane reserved when the landscape viewport is narrower than 16:9 (4:3-ish
-    /// iPads): sized so the right control rail (record button plus margins) — and, mirrored, the
-    /// left battery rail — sits on the black bar beside the letterboxed feed instead of over it.
-    public static let constrainedSideLaneWidth = MonitorSideRailControlLayout.recordButtonSize + 30
-
     /// True for landscape viewports narrower than 16:9 (4:3-ish iPads), where the full-height
     /// feed would overflow the width. On these screens the side-rail chrome moves into the
     /// corners (battery inline beside the lock, settings/media top-trailing, record/DISP
@@ -233,16 +228,17 @@ public enum MonitorFeedLayout {
 
         // Landscape viewport narrower than 16:9 (4:3-ish iPads): the full-height frame would
         // overflow the right edge — and drag the feed-spanning top deck off-center with it.
-        // Shrink to leave symmetric rail lanes and center the letterboxed frame. The tolerance
-        // keeps exact-16:9 mounts (portrait fit/fill hand this function their own 16:9 box, where
-        // width == viewportWidth up to float drift) on the untouched full-height path.
+        // With the side-rail chrome relocated into the corners (see `isWidthConstrained`), the
+        // letterboxed frame spans the full width, vertically centered between the corner chrome
+        // bands. The tolerance keeps exact-16:9 mounts (portrait fit/fill hand this function
+        // their own 16:9 box, where width == viewportWidth up to float drift) on the untouched
+        // full-height path.
         if width > viewportWidth + 0.5 {
-            let lanedWidth = max(0, viewportWidth - 2 * constrainedSideLaneWidth)
-            let lanedHeight = lanedWidth / aspectRatio
+            let lanedHeight = viewportWidth / aspectRatio
             return MonitorFeedFrame(
-                x: (viewportWidth - lanedWidth) / 2,
+                x: 0,
                 y: (viewportHeight - lanedHeight) / 2,
-                width: lanedWidth,
+                width: viewportWidth,
                 height: lanedHeight
             )
         }

--- a/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
+++ b/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
@@ -189,6 +189,19 @@ public enum MonitorFeedLayout {
     /// left battery rail — sits on the black bar beside the letterboxed feed instead of over it.
     public static let constrainedSideLaneWidth = MonitorSideRailControlLayout.recordButtonSize + 30
 
+    /// True for landscape viewports narrower than 16:9 (4:3-ish iPads), where the full-height
+    /// feed would overflow the width. On these screens the side-rail chrome moves into the
+    /// corners (battery inline beside the lock, settings/media top-trailing, record/DISP
+    /// bottom-trailing) so the letterboxed feed can span the full width. False for every
+    /// wider-than-16:9 landscape phone and for portrait, keeping those layouts untouched.
+    public static func isWidthConstrained(viewportWidth: Double, viewportHeight: Double) -> Bool {
+        let viewportWidth = max(0, viewportWidth)
+        let viewportHeight = max(0, viewportHeight)
+
+        return viewportHeight <= viewportWidth
+            && viewportHeight * aspectRatio > viewportWidth + 0.5
+    }
+
     /// Keeps the feed clear of a landscape-left side notch.
     public static func leadingInset(for safeArea: MonitorEdgeInsets) -> Double {
         let cutout = StartupSideCutoutAvoidance.resolve(for: safeArea)
@@ -447,13 +460,31 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
         let deckLeft = feed.x + topInfoDeckSideInset
         let deckRight = feed.x + feed.width - topInfoDeckSideInset
 
+        // Width-constrained (4:3-ish iPad) landscape: no side lanes exist, so the battery
+        // indicators sit inline beside the lock button in the top chrome band instead of
+        // stacking in a leading rail.
+        let constrained = MonitorFeedLayout.isWidthConstrained(
+            viewportWidth: viewportWidth,
+            viewportHeight: viewportHeight
+        )
+        let batteryRail =
+            constrained
+            ? MonitorModuleFrame(
+                x: chrome.x + lockButtonSize + MonitorBatteryRailLayout.inlineLeadingGap,
+                y: chrome.y + (topInfoDeckHeight - lockButtonSize) / 2,
+                width: MonitorBatteryRailLayout.inlineClusterWidth,
+                height: lockButtonSize
+            )
+            : MonitorModuleFrame(
+                x: chrome.x,
+                y: chrome.y,
+                width: MonitorBatteryRailLayout.indicatorWidth,
+                height: chrome.height
+            )
+
         let layout = MonitorLiveViewModuleLayout(
             feed: feed,
-            batteryRail: chrome.place(
-                width: MonitorBatteryRailLayout.indicatorWidth,
-                height: chrome.height,
-                anchor: .leading
-            ),
+            batteryRail: batteryRail,
             topInfoDeck: MonitorModuleFrame(
                 x: deckLeft,
                 y: chrome.y,
@@ -605,6 +636,14 @@ public struct MonitorBatteryRailLayout: Equatable, Sendable {
     /// Horizontal nudge that aligns the indicators with the Dynamic Island, which sits slightly
     /// inboard of the chrome's leading inset.
     public static let notchAlignmentInsetX = 3.0
+
+    /// Gap between the lock button and the inline battery cluster on width-constrained
+    /// (4:3-ish iPad) landscape layouts.
+    public static let inlineLeadingGap = 12.0
+
+    /// Nominal frame width for the inline battery cluster (two single-row indicators). The shell's
+    /// content hugs the frame's leading edge, so slack here never shifts the indicators.
+    public static let inlineClusterWidth = 190.0
 
     // Indicator centers.
     public let phoneCenterX: Double

--- a/Sources/OpenZCineCore/MonitorZoneLayout.swift
+++ b/Sources/OpenZCineCore/MonitorZoneLayout.swift
@@ -179,6 +179,12 @@ public enum MonitorZoneLayout {
         bottomBarHeight: Double
     ) -> MonitorZoneMap {
         let chromeInsets = chromeInsets ?? MonitorChromeLayout.insets(feedSafeArea: safeArea)
+        // Width-constrained (4:3-ish iPad) landscape moves the side-rail chrome into the corners;
+        // the battery cluster renders as an inline row beside the lock button (`.batteryInline`).
+        let constrained = MonitorFeedLayout.isWidthConstrained(
+            viewportWidth: viewportWidth,
+            viewportHeight: viewportHeight
+        )
         let legacy = MonitorLiveViewModuleLayout.fit(
             viewportWidth: viewportWidth,
             viewportHeight: viewportHeight,
@@ -214,7 +220,7 @@ public enum MonitorZoneLayout {
             systemSlots: landscapeSlots(legacy: legacy, rail: rail),
             batteryCluster: MonitorZone(
                 frame: legacy.batteryRail,
-                style: .batteryRail,
+                style: constrained ? .batteryInline : .batteryRail,
                 collapsible: false
             ),
             scopes: nil,

--- a/Sources/OpenZCineCore/MonitorZoneLayout.swift
+++ b/Sources/OpenZCineCore/MonitorZoneLayout.swift
@@ -220,7 +220,6 @@ public enum MonitorZoneLayout {
             systemSlots: constrained
                 ? constrainedLandscapeSlots(
                     legacy: legacy,
-                    rail: rail,
                     viewportWidth: viewportWidth,
                     viewportHeight: viewportHeight,
                     chromeInsets: chromeInsets,
@@ -282,19 +281,18 @@ public enum MonitorZoneLayout {
 
     /// Corner slot frames for width-constrained (4:3 iPad) landscape: settings and media form a
     /// horizontal row tucked into the top-trailing chrome corner, vertically centered on the top
-    /// info bar band so they read as one line with it (settings outermost, media on its left).
-    /// The lock keeps its legacy top-leading frame; record and DISP keep their rail frames.
-    /// Frames are built in standard orientation and mirrored as a final step, matching
-    /// `MonitorLiveViewModuleLayout.mirroredChromeHorizontally`.
+    /// info bar band so they read as one line with it (settings outermost, media on its left);
+    /// record hugs the bottom-trailing corner (bottom-aligned with the shortened bottom bars)
+    /// with DISP inline on its left, vertically centered on the record button. The lock keeps
+    /// its legacy top-leading frame. Frames are built in standard orientation and mirrored as a
+    /// final step, matching `MonitorLiveViewModuleLayout.mirroredChromeHorizontally`.
     private static func constrainedLandscapeSlots(
         legacy: MonitorLiveViewModuleLayout,
-        rail: MonitorSideRailControlLayout,
         viewportWidth: Double,
         viewportHeight: Double,
         chromeInsets: MonitorEdgeInsets,
         horizontalDirection: MonitorHorizontalLayoutDirection
     ) -> MonitorSystemSlotFrames {
-        let railSlots = landscapeSlots(legacy: legacy, rail: rail)
         let chrome =
             MonitorLayoutRegion
             .viewport(width: viewportWidth, height: viewportHeight)
@@ -314,12 +312,31 @@ public enum MonitorZoneLayout {
             width: aux,
             height: aux
         )
+        // Bottom-aligned with the bottom bars' shared bottom edge (screen bottom minus the bar
+        // inset), keeping home-indicator clearance identical to the bars'.
+        let rec = MonitorSideRailControlLayout.recordButtonSize
+        let dispWidth = MonitorSideRailControlLayout.displayButtonWidth
+        let dispHeight = MonitorSideRailControlLayout.displayButtonHeight
+        let recordBottom = viewportHeight - MonitorLiveViewModuleLayout.bottomBarBottomInset
+        let record = MonitorModuleFrame(
+            x: chrome.maxX - rec,
+            y: recordBottom - rec,
+            width: rec,
+            height: rec
+        )
+        let disp = MonitorModuleFrame(
+            x: record.x - gap - dispWidth,
+            y: record.midY - dispHeight / 2,
+            width: dispWidth,
+            height: dispHeight
+        )
         let mirrored = horizontalDirection == .mirrored
 
         return MonitorSystemSlotFrames(
-            lock: railSlots.lock,
-            disp: railSlots.disp,
-            record: railSlots.record,
+            // The lock frame off `legacy` is already mirrored when the layout is.
+            lock: legacy.lockButton,
+            disp: mirrored ? disp.mirroredHorizontally(in: viewportWidth) : disp,
+            record: mirrored ? record.mirroredHorizontally(in: viewportWidth) : record,
             media: mirrored ? media.mirroredHorizontally(in: viewportWidth) : media,
             settings: mirrored ? settings.mirroredHorizontally(in: viewportWidth) : settings
         )

--- a/Sources/OpenZCineCore/MonitorZoneLayout.swift
+++ b/Sources/OpenZCineCore/MonitorZoneLayout.swift
@@ -217,7 +217,16 @@ public enum MonitorZoneLayout {
                 style: .axisVertical,
                 collapsible: false
             ),
-            systemSlots: landscapeSlots(legacy: legacy, rail: rail),
+            systemSlots: constrained
+                ? constrainedLandscapeSlots(
+                    legacy: legacy,
+                    rail: rail,
+                    viewportWidth: viewportWidth,
+                    viewportHeight: viewportHeight,
+                    chromeInsets: chromeInsets,
+                    horizontalDirection: horizontalDirection
+                )
+                : landscapeSlots(legacy: legacy, rail: rail),
             batteryCluster: MonitorZone(
                 frame: legacy.batteryRail,
                 style: constrained ? .batteryInline : .batteryRail,
@@ -268,6 +277,51 @@ public enum MonitorZoneLayout {
                 width: aux,
                 height: aux
             )
+        )
+    }
+
+    /// Corner slot frames for width-constrained (4:3 iPad) landscape: settings and media form a
+    /// horizontal row tucked into the top-trailing chrome corner, vertically centered on the top
+    /// info bar band so they read as one line with it (settings outermost, media on its left).
+    /// The lock keeps its legacy top-leading frame; record and DISP keep their rail frames.
+    /// Frames are built in standard orientation and mirrored as a final step, matching
+    /// `MonitorLiveViewModuleLayout.mirroredChromeHorizontally`.
+    private static func constrainedLandscapeSlots(
+        legacy: MonitorLiveViewModuleLayout,
+        rail: MonitorSideRailControlLayout,
+        viewportWidth: Double,
+        viewportHeight: Double,
+        chromeInsets: MonitorEdgeInsets,
+        horizontalDirection: MonitorHorizontalLayoutDirection
+    ) -> MonitorSystemSlotFrames {
+        let railSlots = landscapeSlots(legacy: legacy, rail: rail)
+        let chrome =
+            MonitorLayoutRegion
+            .viewport(width: viewportWidth, height: viewportHeight)
+            .inset(chromeInsets)
+        let aux = MonitorSideRailControlLayout.auxiliaryButtonSize
+        let gap = MonitorLiveViewModuleLayout.bottomModuleSpacing
+        let bandCenterY = chrome.y + MonitorLiveViewModuleLayout.topInfoDeckHeight / 2
+        let settings = MonitorModuleFrame(
+            x: chrome.maxX - aux,
+            y: bandCenterY - aux / 2,
+            width: aux,
+            height: aux
+        )
+        let media = MonitorModuleFrame(
+            x: settings.x - gap - aux,
+            y: bandCenterY - aux / 2,
+            width: aux,
+            height: aux
+        )
+        let mirrored = horizontalDirection == .mirrored
+
+        return MonitorSystemSlotFrames(
+            lock: railSlots.lock,
+            disp: railSlots.disp,
+            record: railSlots.record,
+            media: mirrored ? media.mirroredHorizontally(in: viewportWidth) : media,
+            settings: mirrored ? settings.mirroredHorizontally(in: viewportWidth) : settings
         )
     }
 

--- a/Sources/OpenZCineCore/MonitorZoneLayout.swift
+++ b/Sources/OpenZCineCore/MonitorZoneLayout.swift
@@ -198,10 +198,28 @@ public enum MonitorZoneLayout {
             railHeight: legacy.rightRailControls.height,
             bottomBarHeight: bottomBarHeight
         )
+        let slots =
+            constrained
+            ? constrainedLandscapeSlots(
+                legacy: legacy,
+                viewportWidth: viewportWidth,
+                viewportHeight: viewportHeight,
+                chromeInsets: chromeInsets,
+                horizontalDirection: horizontalDirection
+            )
+            : landscapeSlots(legacy: legacy, rail: rail)
+        // Constrained layouts fill the top band's corners with chrome (battery inline leading,
+        // settings/media trailing), so the info bar narrows to the band between those clusters.
+        // The legacy feed-anchored span let the centered pill run under the battery cluster on
+        // shallow-letterbox viewports (iPad mini: pill left edge crossed the camera battery icon).
+        let infoBarFrame =
+            constrained
+            ? constrainedInfoBarFrame(legacy: legacy, slots: slots)
+            : legacy.topInfoDeck
 
         return MonitorZoneMap(
             feed: legacy.feed,
-            infoBar: MonitorZone(frame: legacy.topInfoDeck, style: .infoPill, collapsible: false),
+            infoBar: MonitorZone(frame: infoBarFrame, style: .infoPill, collapsible: false),
             captureStrip: MonitorZone(
                 frame: legacy.bottomCaptureSettings,
                 style: .axisHorizontal,
@@ -217,15 +235,7 @@ public enum MonitorZoneLayout {
                 style: .axisVertical,
                 collapsible: false
             ),
-            systemSlots: constrained
-                ? constrainedLandscapeSlots(
-                    legacy: legacy,
-                    viewportWidth: viewportWidth,
-                    viewportHeight: viewportHeight,
-                    chromeInsets: chromeInsets,
-                    horizontalDirection: horizontalDirection
-                )
-                : landscapeSlots(legacy: legacy, rail: rail),
+            systemSlots: slots,
             batteryCluster: MonitorZone(
                 frame: legacy.batteryRail,
                 style: constrained ? .batteryInline : .batteryRail,
@@ -339,6 +349,31 @@ public enum MonitorZoneLayout {
             record: mirrored ? record.mirroredHorizontally(in: viewportWidth) : record,
             media: mirrored ? media.mirroredHorizontally(in: viewportWidth) : media,
             settings: mirrored ? settings.mirroredHorizontally(in: viewportWidth) : settings
+        )
+    }
+
+    /// Info-bar band for width-constrained (4:3-ish iPad) landscape: the free span between the
+    /// inline battery cluster and the settings/media corner row, one module gap clear of each, at
+    /// the legacy deck's vertical band. Works in final (possibly mirrored) coordinates — the
+    /// battery sits leading and the row trailing in standard orientation, swapped when mirrored —
+    /// so the band never needs its own mirror pass.
+    private static func constrainedInfoBarFrame(
+        legacy: MonitorLiveViewModuleLayout,
+        slots: MonitorSystemSlotFrames
+    ) -> MonitorModuleFrame {
+        let gap = MonitorLiveViewModuleLayout.bottomModuleSpacing
+        let battery = legacy.batteryRail
+        let rowLeading = Swift.min(slots.media.x, slots.settings.x)
+        let rowTrailing = Swift.max(
+            slots.media.x + slots.media.width, slots.settings.x + slots.settings.width)
+        let left = battery.x < rowLeading ? battery.x + battery.width : rowTrailing
+        let right = battery.x < rowLeading ? rowLeading : battery.x
+
+        return MonitorModuleFrame(
+            x: left + gap,
+            y: legacy.topInfoDeck.y,
+            width: Swift.max(0, right - left - 2 * gap),
+            height: legacy.topInfoDeck.height
         )
     }
 

--- a/Tests/OpenZCineCoreTests/MonitorLayoutPolicyTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorLayoutPolicyTests.swift
@@ -128,20 +128,19 @@ import Testing
     #expect(frame.height == 390)
 }
 
-@Test func feedLayoutLetterboxesAndCentersOnNarrowerThanSixteenByNineViewports() {
+@Test func feedLayoutLetterboxesFullWidthOnNarrowerThanSixteenByNineViewports() {
     // 11" iPad landscape (4:3-ish): the full-height 16:9 frame (1482.7pt) would overflow the
-    // 1194pt viewport. Expect a centered letterboxed frame with symmetric rail lanes.
+    // 1194pt viewport. With the side-rail chrome relocated into the corners, the letterboxed
+    // frame spans the full width, vertically centered.
     let frame = MonitorFeedLayout.fullBleedFrame(
         viewportWidth: 1194,
         viewportHeight: 834,
         safeArea: .zero
     )
 
-    let lane = MonitorFeedLayout.constrainedSideLaneWidth
-    #expect(abs(frame.x - lane) < 0.001)
-    #expect(abs(frame.width - (1194 - 2 * lane)) < 0.001)
+    #expect(frame.x == 0)
+    #expect(frame.width == 1194)
     #expect(abs(frame.width / frame.height - 16.0 / 9.0) < 0.001)
-    #expect(frame.x + frame.width <= 1194)
     #expect(abs(frame.y - (834 - frame.height) / 2) < 0.001)
 }
 

--- a/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
@@ -450,6 +450,87 @@ private enum PadViewport {
     #expect(assist.x == PadViewport.chromeInsets.leading)
 }
 
+/// iPad mini (A17 Pro) landscape points: 1133×744 ≈ 1.52:1 — still narrower than 16:9, so the
+/// constrained corner layout fires, but with far shallower letterbox bands than the Pro 11"
+/// (~53pt vs ~77pt), making it the tightest shipping viewport for the corner clusters.
+private enum PadMiniViewport {
+    static let width = 1133.0
+    static let height = 744.0
+    static let safeArea = MonitorEdgeInsets(top: 24, leading: 0, bottom: 20, trailing: 0)
+    static let chromeInsets = MonitorEdgeInsets(top: 40, leading: 16, bottom: 12, trailing: 18)
+
+    static func map(
+        bottomBarHeight: Double = 58,
+        direction: MonitorHorizontalLayoutDirection = .standard
+    ) -> MonitorZoneMap {
+        MonitorZoneLayout.map(
+            viewportWidth: width,
+            viewportHeight: height,
+            safeArea: safeArea,
+            chromeInsets: chromeInsets,
+            mode: .live,
+            isPortrait: false,
+            aspect: .fill,
+            scopeCount: 0,
+            horizontalDirection: direction,
+            bottomBarHeight: bottomBarHeight
+        )
+    }
+}
+
+@Test func padMiniLandscapeCornerClustersStayCollisionFreeInShallowLetterbox() throws {
+    #expect(
+        MonitorFeedLayout.isWidthConstrained(
+            viewportWidth: PadMiniViewport.width, viewportHeight: PadMiniViewport.height))
+
+    let map = PadMiniViewport.map()
+    let slots = map.systemSlots
+    let gap = MonitorLiveViewModuleLayout.bottomModuleSpacing
+
+    // Feed spans the full width, vertically centered.
+    #expect(map.feed.x == 0)
+    #expect(map.feed.width == PadMiniViewport.width)
+    #expect(abs(map.feed.y - (PadMiniViewport.height - map.feed.height) / 2) < 0.0001)
+
+    // Battery cluster sits inline beside the lock, clear of the settings/media corner row.
+    #expect(map.batteryCluster?.style == .batteryInline)
+    let battery = try #require(map.batteryCluster?.frame)
+    #expect(
+        battery.x == slots.lock.x + slots.lock.width + MonitorBatteryRailLayout.inlineLeadingGap)
+    #expect(battery.x + battery.width <= slots.media.x)
+
+    // The info bar narrows to the free band between the corner clusters, one gap clear of each,
+    // so the centered pill can never run under the battery icons or the settings/media row.
+    let infoBar = map.infoBar.frame
+    #expect(infoBar.x == battery.x + battery.width + gap)
+    #expect(infoBar.x + infoBar.width == slots.media.x - gap)
+    #expect(infoBar.midY == slots.lock.midY)
+
+    // Shortened bottom bars end clear of the DISP + record corner cluster.
+    let capture = try #require(map.captureStrip?.frame)
+    #expect(capture.x + capture.width <= slots.disp.x - gap + 0.0001)
+    #expect(slots.disp.x + slots.disp.width <= slots.record.x - gap + 0.0001)
+
+    // Record keeps the bars' 14pt bottom clearance and every corner control stays on-screen.
+    let barBottom = PadMiniViewport.height - MonitorLiveViewModuleLayout.bottomBarBottomInset
+    #expect(slots.record.y + slots.record.height == barBottom)
+    for frame in [slots.lock, slots.disp, slots.record, slots.media, slots.settings, battery] {
+        #expect(frame.x >= 0)
+        #expect(frame.y >= 0)
+        #expect(frame.x + frame.width <= PadMiniViewport.width)
+        #expect(frame.y + frame.height <= PadMiniViewport.height)
+    }
+}
+
+@Test func padMiniMirroredInfoBarBandMirrorsWithTheCornerClusters() {
+    let standard = PadMiniViewport.map()
+    let mirrored = PadMiniViewport.map(direction: .mirrored)
+
+    #expect(
+        mirrored.infoBar.frame
+            == standard.infoBar.frame.mirroredHorizontally(in: PadMiniViewport.width))
+}
+
 @Test func phoneLandscapeBatteryClusterStaysALeadingRail() {
     let map = MonitorZoneLayout.map(
         viewportWidth: 874,

--- a/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
@@ -427,6 +427,29 @@ private enum PadViewport {
     #expect(media.midY == map.infoBar.frame.midY)
 }
 
+@Test func padLandscapeRecordAndDispFormABottomTrailingRowAndTheBarsShorten() throws {
+    let map = PadViewport.map()
+    let record = map.systemSlots.record
+    let disp = map.systemSlots.disp
+    let chromeTrailing = PadViewport.width - PadViewport.chromeInsets.trailing
+    let gap = MonitorLiveViewModuleLayout.bottomModuleSpacing
+    let barBottom = PadViewport.height - MonitorLiveViewModuleLayout.bottomBarBottomInset
+
+    // Record hugs the bottom-trailing chrome corner, bottom-aligned with the bars.
+    #expect(record.x + record.width == chromeTrailing)
+    #expect(record.y + record.height == barBottom)
+    // DISP sits inline on the record button's left, centered on it.
+    #expect(disp.x + disp.width == record.x - gap)
+    #expect(disp.midY == record.midY)
+
+    // The bottom bars shorten so they end clear of the DISP + record cluster.
+    let capture = try #require(map.captureStrip?.frame)
+    #expect(capture.x + capture.width <= disp.x - gap + 0.0001)
+    // And they still start at the chrome leading edge.
+    let assist = try #require(map.assistStrip?.frame)
+    #expect(assist.x == PadViewport.chromeInsets.leading)
+}
+
 @Test func phoneLandscapeBatteryClusterStaysALeadingRail() {
     let map = MonitorZoneLayout.map(
         viewportWidth: 874,

--- a/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
@@ -412,6 +412,21 @@ private enum PadViewport {
     #expect(battery.height == MonitorLiveViewModuleLayout.lockButtonSize)
 }
 
+@Test func padLandscapeSettingsAndMediaFormATopTrailingRowAlignedWithTheInfoBar() {
+    let map = PadViewport.map()
+    let settings = map.systemSlots.settings
+    let media = map.systemSlots.media
+    let chromeTrailing = PadViewport.width - PadViewport.chromeInsets.trailing
+    let gap = MonitorLiveViewModuleLayout.bottomModuleSpacing
+
+    // Settings hugs the top-trailing chrome corner; media sits inline on its left.
+    #expect(settings.x + settings.width == chromeTrailing)
+    #expect(media.x + media.width == settings.x - gap)
+    // Both are vertically centered on the top info bar band.
+    #expect(settings.midY == map.infoBar.frame.midY)
+    #expect(media.midY == map.infoBar.frame.midY)
+}
+
 @Test func phoneLandscapeBatteryClusterStaysALeadingRail() {
     let map = MonitorZoneLayout.map(
         viewportWidth: 874,

--- a/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
@@ -363,6 +363,72 @@ func portraitFillNeverProducesAssistStripRegardlessOfToolbarHeight(mode: DispMod
     #expect(map.systemSlots == expected)
 }
 
+// MARK: - Width-constrained (4:3 iPad) landscape corner layout (OPE-2)
+
+/// iPad Pro 11" landscape points with the runtime chrome insets (window-control clearance top).
+private enum PadViewport {
+    static let width = 1210.0
+    static let height = 834.0
+    static let safeArea = MonitorEdgeInsets(top: 24, leading: 0, bottom: 20, trailing: 0)
+    static let chromeInsets = MonitorEdgeInsets(top: 40, leading: 16, bottom: 12, trailing: 18)
+
+    static func map(bottomBarHeight: Double = 58) -> MonitorZoneMap {
+        MonitorZoneLayout.map(
+            viewportWidth: width,
+            viewportHeight: height,
+            safeArea: safeArea,
+            chromeInsets: chromeInsets,
+            mode: .live,
+            isPortrait: false,
+            aspect: .fill,
+            scopeCount: 0,
+            horizontalDirection: .standard,
+            bottomBarHeight: bottomBarHeight
+        )
+    }
+}
+
+@Test func widthConstrainedDiscriminatorSelects4x3PadsNotPhones() {
+    // iPad Pro 11" landscape: 16:9 at full height (1482.7pt) overflows the 1210pt width.
+    #expect(
+        MonitorFeedLayout.isWidthConstrained(viewportWidth: 1210, viewportHeight: 834))
+    // iPhone 17 Pro landscape is wider than 16:9.
+    #expect(
+        !MonitorFeedLayout.isWidthConstrained(viewportWidth: 874, viewportHeight: 402))
+    // Portrait never constrains (its feed box is handed in as exact 16:9).
+    #expect(
+        !MonitorFeedLayout.isWidthConstrained(viewportWidth: 834, viewportHeight: 1210))
+}
+
+@Test func padLandscapeBatteryClusterIsInlineBesideLock() throws {
+    let map = PadViewport.map()
+    let lock = map.systemSlots.lock
+
+    #expect(map.batteryCluster?.style == .batteryInline)
+    let battery = try #require(map.batteryCluster?.frame)
+    // Right of the lock button, in the same top chrome band.
+    #expect(battery.x == lock.x + lock.width + MonitorBatteryRailLayout.inlineLeadingGap)
+    #expect(battery.midY == lock.midY)
+    #expect(battery.height == MonitorLiveViewModuleLayout.lockButtonSize)
+}
+
+@Test func phoneLandscapeBatteryClusterStaysALeadingRail() {
+    let map = MonitorZoneLayout.map(
+        viewportWidth: 874,
+        viewportHeight: 402,
+        safeArea: MonitorEdgeInsets(top: 0, leading: 59, bottom: 0, trailing: 0),
+        mode: .live,
+        isPortrait: false,
+        aspect: .fill,
+        scopeCount: 0,
+        horizontalDirection: .standard,
+        bottomBarHeight: 58
+    )
+
+    #expect(map.batteryCluster?.style == .batteryRail)
+    #expect(map.batteryCluster?.frame.width == MonitorBatteryRailLayout.indicatorWidth)
+}
+
 @Test func landscapeSystemSlotsCenterOnLegacyRailCenters() {
     let viewportWidth = 874.0
     let viewportHeight = 402.0

--- a/ios/Runner/MonitorExperience.swift
+++ b/ios/Runner/MonitorExperience.swift
@@ -760,6 +760,32 @@ struct BatteryRailModule: View {
     }
 }
 
+/// Inline phone + camera battery row for width-constrained (4:3-ish iPad) landscape layouts,
+/// mounted beside the lock button at the zone map's `.batteryInline` cluster frame. Reuses the
+/// portrait top bar's single-row `BatteryIndicator` presentation.
+struct BatteryInlineCluster: View {
+    @Environment(NativeAppModel.self) private var model
+
+    var body: some View {
+        HStack(spacing: 14) {
+            BatteryIndicator(
+                percent: model.cameraState.phoneBatteryPercent,
+                deviceSystemName: "iphone",
+                isCamera: false,
+                isCharging: model.phoneBatteryCharging,
+                layout: .inline
+            )
+            BatteryIndicator(
+                percent: model.cameraState.cameraBatteryPercent,
+                deviceSystemName: "camera",
+                isCamera: true,
+                isCharging: model.cameraBatteryCharging,
+                layout: .inline
+            )
+        }
+    }
+}
+
 /// A single tappable exposure readout (label + value) that opens its picker above the capture bar.
 /// While that picker is open it lights up gold so the operator can see which setting is being edited.
 struct CaptureSettingButton: View {

--- a/ios/Runner/MonitorUnified.swift
+++ b/ios/Runner/MonitorUnified.swift
@@ -948,9 +948,17 @@ struct MonitorShell: View {
                 if chrome.sideRailsVisible {
                     canvasLayer {
                         if let battery = map.batteryCluster {
-                            BatteryRailModule()
-                                .environment(model)
-                                .monitorModuleFrame(battery.frame)
+                            if battery.style == .batteryInline {
+                                // Width-constrained (iPad): inline row beside the lock button.
+                                // The frame is a nominal band; content hugs its leading edge.
+                                BatteryInlineCluster()
+                                    .environment(model)
+                                    .monitorModuleFrame(battery.frame, alignment: .leading)
+                            } else {
+                                BatteryRailModule()
+                                    .environment(model)
+                                    .monitorModuleFrame(battery.frame)
+                            }
                         }
                         MonitorSystemCluster(slots: map.systemSlots, axis: .axisVertical)
                             .environment(model)
@@ -1040,7 +1048,13 @@ struct MonitorShell: View {
             {
                 let rail = battery.frame
                 let size: CGFloat = 40
-                let x = CGFloat(rail.x + rail.width) + 24
+                // Inline battery (iPad) sits in the top band, so its frame no longer marks the
+                // bottom-left lane; fall back to the assist bar's leading edge plus the same
+                // clearance the rail layout produced (indicator width 38 + 24).
+                let x =
+                    battery.style == .batteryInline
+                    ? CGFloat(assist.frame.x) + 62
+                    : CGFloat(rail.x + rail.width) + 24
                 let y = model.focusResetButtonClearY(
                     centerX: x, baseY: CGFloat(assist.frame.y) - 30, size: size)
                 Button {


### PR DESCRIPTION
On 4:3 iPad landscape the live view kept the iPhone's side-rail layout, wasting the letterbox lanes. This pass moves the side chrome into the corners and gives the reclaimed width back to the feed:

1. Battery indicators render inline beside the lock button in the top band (#93)
2. Settings + media form a horizontal row in the top-right corner, aligned with the top bar (#94)
3. Record + DISP sit inline in the bottom-right corner (record outermost); the bottom bars shorten to fit (#95)
4. The 16:9 feed scales up to span the full viewport width (#96)

Gated on a geometry-derived width-constrained discriminator in the UI-free core ("landscape viewport narrower than 16:9"), so iPhone landscape and portrait are pixel-identical (verified by screenshot diff — residual diff proven to be build nondeterminism on two raster icons). New Swift Testing coverage for the iPad zone map; iPadOS 26 window-control pill clearance preserved.

**iPad mini verified** (1133×744, ~53pt letterbox bands vs ~77pt on the Pro 11"): the shallow deck exposed a latent collision — the feed-anchored top info pill ran under the camera battery glyph. The constrained-landscape info bar now narrows to the free band between the inline battery cluster and the corner button row (mirror-aware, no device special-cases); mini + Pro screenshot-verified, with mini collision-free zone tests added.

Kaneo: OPE-2, OPE-40..43.

Closes #44, closes #93, closes #94, closes #95, closes #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
