### PR TITLE
fix: read app version and build number from the bundle

### DIFF
--- a/ios/Runner/MonitorPanels.swift
+++ b/ios/Runner/MonitorPanels.swift
@@ -3203,6 +3203,15 @@ struct OperatorSettingsPanel: View {
         )
     }
 
+    /// Marketing version + build number from the bundle, e.g. "0.2.0 (9)", matching what
+    /// TestFlight shows for the installed build (CI stamps CFBundleVersion per upload).
+    static var appVersionText: String {
+        let info = Bundle.main.infoDictionary
+        let version = info?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = info?["CFBundleVersion"] as? String ?? "?"
+        return "\(version) (\(build))"
+    }
+
     @ViewBuilder private var systemRows: some View {
         SettingsRowCard {
             SettingsInlineRow(
@@ -3223,7 +3232,7 @@ struct OperatorSettingsPanel: View {
                 title: "App Version",
                 help: "Current OpenZCine build from the native project metadata."
             ) {
-                SettingsValueText(value: "0.0.1+1")
+                SettingsValueText(value: Self.appVersionText)
             }
             SettingsInlineRow(
                 title: "Support",


### PR DESCRIPTION
The System settings "App Version" row was a hardcoded `"0.0.1+1"`, so it never matched the TestFlight build. The pipeline was already correct — Info.plist maps to `MARKETING_VERSION`/`CURRENT_PROJECT_VERSION` from `ios/Config/Version.xcconfig` and CI bumps the build number per upload — only the display site ignored it.

The row now reads `CFBundleShortVersionString` and `CFBundleVersion` from `Bundle.main` at runtime and renders them as `0.2.0 (9)`, the same shape TestFlight shows, so the settings screen maps 1:1 to the installed build.

Kaneo: OPE-8.

Verified with `just native-check` plus portrait/landscape simulator screenshots of the System tab.

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)
