### PR TITLE
build: Android cross-compile experiment — core-reuse decision confirmed

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -24,6 +24,8 @@
     "ios/**",
     "android/**",
     "build/**",
+    // SwiftPM dependency checkouts and build products.
+    ".build/**",
     "**/node_modules/**"
   ]
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,24 @@
+{
+  "originHash" : "74e2410c78e5294eef274b0e4d3004ea303cb8b8d4759496010d8d624dc068ec",
+  "pins" : [
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,19 @@ let package = Package(
     products: [
         .library(name: "OpenZCineCore", targets: ["OpenZCineCore"])
     ],
+    dependencies: [
+        // Non-Darwin SHA256 for PKCE (FrameioOAuth); Darwin builds keep using CryptoKit.
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0")
+    ],
     targets: [
-        .target(name: "OpenZCineCore"),
+        .target(
+            name: "OpenZCineCore",
+            dependencies: [
+                .product(
+                    name: "Crypto", package: "swift-crypto",
+                    condition: .when(platforms: [.linux, .android]))
+            ]
+        ),
         .testTarget(
             name: "OpenZCineCoreTests",
             dependencies: ["OpenZCineCore"]

--- a/Sources/OpenZCineCore/Frameio/FrameioOAuth.swift
+++ b/Sources/OpenZCineCore/Frameio/FrameioOAuth.swift
@@ -1,5 +1,11 @@
-import CryptoKit
 import Foundation
+
+#if canImport(CryptoKit)
+    import CryptoKit
+#else
+    // Non-Darwin platforms (e.g. Android): swift-crypto provides an API-compatible SHA256.
+    import Crypto
+#endif
 
 /// Configuration for the Frame.io V4 OAuth + API integration.
 ///
@@ -126,34 +132,6 @@ public enum FrameioOAuth {
         return comps.url!
     }
 
-    /// The token-exchange POST that trades the authorization `code` (+ PKCE verifier) for tokens.
-    public static func tokenExchangeRequest(
-        config: FrameioConfiguration, code: String, verifier: String
-    ) -> URLRequest {
-        formRequest(
-            url: publicClientTokenURL(config: config),
-            fields: [
-                "grant_type": "authorization_code",
-                "client_id": config.clientID,
-                "code": code,
-                "code_verifier": verifier,
-                "redirect_uri": config.redirectURI,
-            ])
-    }
-
-    /// The refresh POST that trades a refresh token for a new access token.
-    public static func refreshRequest(config: FrameioConfiguration, refreshToken: String)
-        -> URLRequest
-    {
-        formRequest(
-            url: publicClientTokenURL(config: config),
-            fields: [
-                "grant_type": "refresh_token",
-                "client_id": config.clientID,
-                "refresh_token": refreshToken,
-            ])
-    }
-
     /// Extracts the authorization `code` from the IMS redirect, validating `state` and surfacing
     /// `error` responses.
     public static func parseRedirect(_ url: URL, expectedState: String) throws -> String {
@@ -167,22 +145,57 @@ public enum FrameioOAuth {
         return code
     }
 
-    /// Builds an `application/x-www-form-urlencoded` POST, percent-encoding each field with the
-    /// RFC 3986 unreserved set (so `:`, `/`, `+` in values are encoded correctly).
-    private static func formRequest(url: URL, fields: [String: String]) -> URLRequest {
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-        var allowed = CharacterSet.alphanumerics
-        allowed.insert(charactersIn: "-._~")
-        let body = fields.map { key, value in
-            let encodedKey = key.addingPercentEncoding(withAllowedCharacters: allowed) ?? key
-            let encodedValue = value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
-            return "\(encodedKey)=\(encodedValue)"
-        }.joined(separator: "&")
-        request.httpBody = Data(body.utf8)
-        return request
-    }
+    // On Android `URLRequest` lives in FoundationNetworking, which drags libcurl/ICU into the
+    // packaged app; the Android shell owns HTTP (OkHttp) and builds its own requests, so the
+    // URLRequest builders are Darwin-only. The pure pieces above compile everywhere.
+    #if !os(Android)
+        /// The token-exchange POST that trades the authorization `code` (+ PKCE verifier) for tokens.
+        public static func tokenExchangeRequest(
+            config: FrameioConfiguration, code: String, verifier: String
+        ) -> URLRequest {
+            formRequest(
+                url: publicClientTokenURL(config: config),
+                fields: [
+                    "grant_type": "authorization_code",
+                    "client_id": config.clientID,
+                    "code": code,
+                    "code_verifier": verifier,
+                    "redirect_uri": config.redirectURI,
+                ])
+        }
+
+        /// The refresh POST that trades a refresh token for a new access token.
+        public static func refreshRequest(config: FrameioConfiguration, refreshToken: String)
+            -> URLRequest
+        {
+            formRequest(
+                url: publicClientTokenURL(config: config),
+                fields: [
+                    "grant_type": "refresh_token",
+                    "client_id": config.clientID,
+                    "refresh_token": refreshToken,
+                ])
+        }
+
+        /// Builds an `application/x-www-form-urlencoded` POST, percent-encoding each field with the
+        /// RFC 3986 unreserved set (so `:`, `/`, `+` in values are encoded correctly).
+        private static func formRequest(url: URL, fields: [String: String]) -> URLRequest {
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue(
+                "application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+            var allowed = CharacterSet.alphanumerics
+            allowed.insert(charactersIn: "-._~")
+            let body = fields.map { key, value in
+                let encodedKey = key.addingPercentEncoding(withAllowedCharacters: allowed) ?? key
+                let encodedValue =
+                    value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+                return "\(encodedKey)=\(encodedValue)"
+            }.joined(separator: "&")
+            request.httpBody = Data(body.utf8)
+            return request
+        }
+    #endif
 }
 
 /// A decoded OAuth token response from Adobe IMS. The absolute expiry is computed by the shell when

--- a/Tests/OpenZCineCoreTests/FrameioOAuthTests.swift
+++ b/Tests/OpenZCineCoreTests/FrameioOAuthTests.swift
@@ -39,28 +39,32 @@ private let config = FrameioConfiguration(
     #expect(items["scope"]?.isEmpty == false)
 }
 
-@Test func tokenExchangeRequestIsFormPost() throws {
-    let req = FrameioOAuth.tokenExchangeRequest(config: config, code: "auth-code", verifier: "v123")
-    #expect(req.httpMethod == "POST")
-    #expect(
-        req.url?.absoluteString
-            == "https://ims-na1.adobelogin.com/ims/token/v3?client_id=test-client-id")
-    #expect(
-        req.value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
-    let body = String(decoding: req.httpBody ?? Data(), as: UTF8.self)
-    #expect(body.contains("grant_type=authorization_code"))
-    #expect(body.contains("code=auth-code"))
-    #expect(body.contains("code_verifier=v123"))
-    #expect(body.contains("client_id=test-client-id"))
-}
+// The URLRequest builders are Darwin-only (see FrameioOAuth.swift); Android shells own HTTP.
+#if !os(Android)
+    @Test func tokenExchangeRequestIsFormPost() throws {
+        let req = FrameioOAuth.tokenExchangeRequest(
+            config: config, code: "auth-code", verifier: "v123")
+        #expect(req.httpMethod == "POST")
+        #expect(
+            req.url?.absoluteString
+                == "https://ims-na1.adobelogin.com/ims/token/v3?client_id=test-client-id")
+        #expect(
+            req.value(forHTTPHeaderField: "Content-Type") == "application/x-www-form-urlencoded")
+        let body = String(decoding: req.httpBody ?? Data(), as: UTF8.self)
+        #expect(body.contains("grant_type=authorization_code"))
+        #expect(body.contains("code=auth-code"))
+        #expect(body.contains("code_verifier=v123"))
+        #expect(body.contains("client_id=test-client-id"))
+    }
 
-@Test func refreshRequestUsesRefreshGrant() throws {
-    let req = FrameioOAuth.refreshRequest(config: config, refreshToken: "r456")
-    let body = String(decoding: req.httpBody ?? Data(), as: UTF8.self)
-    #expect(body.contains("grant_type=refresh_token"))
-    #expect(body.contains("refresh_token=r456"))
-    #expect(body.contains("client_id=test-client-id"))
-}
+    @Test func refreshRequestUsesRefreshGrant() throws {
+        let req = FrameioOAuth.refreshRequest(config: config, refreshToken: "r456")
+        let body = String(decoding: req.httpBody ?? Data(), as: UTF8.self)
+        #expect(body.contains("grant_type=refresh_token"))
+        #expect(body.contains("refresh_token=r456"))
+        #expect(body.contains("client_id=test-client-id"))
+    }
+#endif
 
 @Test func urlSchemeExtractsAdobeNativeAppRedirect() {
     let uri = "adobe+abc123://adobeid/727e9081b73a46b286d6f491ed0ff602"

--- a/docs/investigations/android-core-feasibility.md
+++ b/docs/investigations/android-core-feasibility.md
@@ -1,6 +1,6 @@
 # Android core feasibility: Swift core reuse vs Kotlin PTP-IP port
 
-Status: decision pending a local cross-compile experiment (recommendation below).
+Status: **CONFIRMED** — the cross-compile experiment passed (see the addendum at the end).
 Scope: gates the Android epic ([discussion #19](https://github.com/erik-sutton95/OpenZCine/discussions/19),
 issues #69–#81). Tracked as issue #68 / Kaneo OPE-25.
 
@@ -272,3 +272,93 @@ near-copy, not new design.
 
 swift.org sources span Oct 2025 – Mar 2026; skip.dev porting docs and the CI action are
 current 2026; binary-size figures are 2026 third-party blogs, not official numbers.
+
+## Experiment results (2026-07-14) — decision CONFIRMED
+
+The Phase 0 confirmation experiment was run locally on an Apple Silicon Mac. Every unknown listed
+in the decision section was retired; none flipped the decision.
+
+### Versions used
+
+| Component | Version |
+| --- | --- |
+| Swift toolchain (swiftly, swift.org open source) | 6.3.3 (`swift-6.3.3-RELEASE`) — the bundle requires an exact match; Xcode's 6.3.2 cannot drive it |
+| Swift-on-Android artifactbundle | `swift-6.3.3-RELEASE_android` from download.swift.org (checksum-verified `swift sdk install`) |
+| Android NDK | r27d (`setup-android-sdk.sh` links `ndk-sysroot` into the bundle) |
+| Target triple | `aarch64-unknown-linux-android28` |
+| swift-crypto | 3.15.1 (resolved from `from: "3.0.0"`) |
+| Test device | Android emulator, API 28 `default;arm64-v8a` image, arm64 host (native, no translation) |
+
+### Build outcome
+
+`swift build --swift-sdk aarch64-unknown-linux-android28` (debug and release) **succeeds** for the
+whole package — all 55 core files plus the 58 test files — after a three-file diff:
+
+1. `Package.swift` — add `apple/swift-crypto` with the `Crypto` product gated
+   `.when(platforms: [.linux, .android])`, so Darwin builds do not link it (a `Package.resolved`
+   pin is the only Darwin-visible artifact).
+2. `Sources/OpenZCineCore/Frameio/FrameioOAuth.swift` — `#if canImport(CryptoKit)` / `import
+   Crypto` for the one SHA256 call, exactly as planned. **One surprise beyond the plan:** the
+   audit missed that `URLRequest` (used by the three Frame.io token-request builders in this same
+   file) lives in FoundationNetworking on non-Darwin. Importing FoundationNetworking works but
+   drags libcurl/ICU into the payload and its static variant is missing from the 6.3.3 bundle
+   (`-l_CFURLSessionInterface` link failure under `--static-swift-stdlib`). Since the Android
+   shell owns HTTP (OkHttp) and would never consume `URLRequest`, the three builders are now
+   `#if !os(Android)` instead; the pure PKCE/URL/parse logic compiles everywhere.
+3. `Tests/OpenZCineCoreTests/FrameioOAuthTests.swift` — the two tests covering those builders get
+   the same gate.
+
+Darwin behavior is untouched: `just check` and `just native-check` are green, all 650 tests pass
+on macOS.
+
+### Binary size (release, arm64, stripped with `llvm-strip`)
+
+| Artifact | Size |
+| --- | --- |
+| `libOpenZCineCore.so` (entire core + statically linked swift-crypto) | **3.9 MB** (20 MB unstripped) |
+| Required runtime `.so` set from the bundle (as currently linked, incl. ICU) | 76.9 MB |
+| — of which `lib_FoundationICU.so` 40.6 MB + `libFoundation.so` 8.6 MB + `libFoundationInternationalization.so` 3.6 MB | 52.8 MB |
+| Same payload gzip-compressed (≈ download cost) | 26.6 MB |
+| Runtime subset if the umbrella-Foundation symbols are migrated (see ICU below) | 24.1 MB |
+
+`--static-swift-stdlib` does not apply when the product is a dynamic library (it silently keeps
+dynamic runtime linking), so the shipped-runtime numbers above are the realistic packaging shape —
+the same one the official swift-android-examples use (runtime `.so` files in `jniLibs`).
+
+### ICU finding
+
+ICU **is** currently linked, but not for the suspected reason. The 8 `String(format:)` sites (and
+everything else) bind **zero** symbols from `libFoundationInternationalization.so` directly; the
+`NEEDED` entries come from the umbrella `libFoundation.so`, which the build autolinks because 18
+symbols resolve there rather than in `libFoundationEssentials.so` (which serves the other 88):
+`String(format:)`, the static `CharacterSet` sets (`.whitespaces`, `.newlines`, …),
+`NSString.pathExtension`/`lastPathComponent`/`deletingPathExtension`,
+`StringProtocol.components(separatedBy:)`/`trimmingCharacters(in:)`/`caseInsensitiveCompare`/
+`range(of:)`, and `Error.localizedDescription`. The umbrella hard-depends on Internationalization
+and ICU, so they ride along (~53 MB uncompressed). All 18 call sites are mechanically replaceable
+with Essentials-only equivalents, which would drop the per-ABI payload from ~82 MB to ~30 MB
+uncompressed — worthwhile Phase 5 (size-audit) work, **not** a feasibility blocker.
+
+### Test run on Android
+
+The full core test suite was executed **on an Android 28 arm64 emulator** (headless, local): the
+cross-built `OpenZCinePackageTests.xctest` executable plus the runtime `.so` set were pushed via
+`adb` to `/data/local/tmp` and run with `--testing-library swift-testing`.
+
+Result: **648 of 648 tests in 22 suites passed** (1.2 s) — the two gated URLRequest-builder tests
+are Darwin-only by design, all other 648 run identically to macOS. Byte-exact protocol codecs,
+layout golden-parity suites, and colorimetry curves all pass unmodified on Android. This also
+retires the strict-concurrency-runtime unknown for everything the tests exercise.
+
+### Verdict
+
+**CONFIRMED — Option A stands.** The core cross-compiles with a three-file, Darwin-identical diff;
+the artifact is 3.9 MB; the test suite passes on-device unmodified. Caveats carried forward:
+
+- The runtime payload is ~82 MB/ABI uncompressed (~27 MB gzipped) until the 18 umbrella-Foundation
+  call sites are migrated to Essentials-only APIs (→ ~30 MB); track under the Phase 5 size audit.
+- `--static-swift-stdlib` is not usable for the `.so` packaging shape today; plan on shipping the
+  runtime `.so` set like the official examples do.
+- Do not reintroduce `import FoundationNetworking` into the core — it adds 16 MB, re-links ICU
+  transitively, and its static archives are incomplete in the 6.3.3 bundle.
+- swift-java/JNI facade and on-device debugging remain untested (Phase 1 scope, as planned).


### PR DESCRIPTION
Runs the Phase 0 confirmation experiment for the Android core-feasibility decision (#68 / OPE-25, follows #103). **Verdict: CONFIRMED.**

- The shared core cross-compiles for `aarch64-unknown-linux-android28` with the official Swift 6.3.3 Android toolchain after a three-file diff: conditional swift-crypto import (linked only on Linux/Android — Darwin links nothing new), and the three Frame.io `URLRequest` builders gated Darwin-only (`URLRequest` lives in FoundationNetworking on non-Darwin; the Android shell will own HTTP).
- **648/648 runnable core tests pass on a real API 28 arm64 emulator** (the remaining 2 of 650 are Darwin-only by design), in 1.2s.
- Stripped release `.so` of the entire core + static swift-crypto: **3.9 MB**. ICU root cause documented: 18 umbrella-Foundation call sites pull `libFoundation.so` → ICU (~77 MB runtime payload today, ~24 MB after a mechanical Essentials-only migration — tracked as later size-audit work, not a blocker).
- Adds the experiment-results addendum to docs/investigations/android-core-feasibility.md (versions, sizes, caveats: runtime `.so` packaging, swift-java/JNI facade still Phase 1).

macOS unchanged: `just check` + `just native-check` green, 650/650 tests.

Kaneo: OPE-25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
