### PR TITLE
ci(android): prepare Play internal testing distribution

### DIFF
--- a/.github/workflows/play-internal.yml
+++ b/.github/workflows/play-internal.yml
@@ -1,0 +1,95 @@
+name: Play Internal
+
+# Uploads a signed .aab to the Google Play internal testing track. Deliberate
+# releases only: manual dispatch or an `android-v*` tag — never plain merges.
+# Prerequisites (Play console app, `play` environment secrets, and the first
+# MANUAL .aab upload Google requires) are in docs/android-distribution.md.
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "android-v*"
+
+permissions:
+  contents: read
+
+# Never cancel an in-progress upload; queue instead (mirrors testflight.yml).
+concurrency:
+  group: play-internal-${{ github.repository }}
+  cancel-in-progress: false
+
+env:
+  # versionCode = offset + run number, monotonic across uploads. Raise the offset
+  # if it ever falls behind the highest versionCode in the Play console.
+  ANDROID_VERSION_CODE_OFFSET: "100"
+
+jobs:
+  play-internal:
+    name: Build & upload
+    if: github.repository == 'erik-sutton95/openzcine'
+    runs-on: ubuntu-latest
+    environment: play
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      # Gradle caching; the runner's preinstalled Android SDK provides platform/build-tools.
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+
+      - name: Run Android checks
+        working-directory: Apps/Android
+        run: ./gradlew test lint
+
+      - name: Compute version code
+        id: version
+        run: |
+          echo "version_code=$(( ANDROID_VERSION_CODE_OFFSET + GITHUB_RUN_NUMBER ))" >> "$GITHUB_OUTPUT"
+
+      - name: Decode upload keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$ANDROID_KEYSTORE_BASE64" ]; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 is not set — add it to the 'play' environment (docs/android-distribution.md)."
+            exit 1
+          fi
+          printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/upload-keystore.jks"
+
+      - name: Build signed release bundle
+        working-directory: Apps/Android
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/upload-keystore.jks
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          VERSION_CODE: ${{ steps.version.outputs.version_code }}
+        run: ./gradlew bundleRelease "-PversionCode=$VERSION_CODE"
+
+      # r0adkll/upload-google-play over alternatives: Google publishes no official
+      # GitHub Action for Play uploads (its official paths are Gradle Play Publisher
+      # or the raw Publishing API), and this action is the de-facto standard — most
+      # widely used, actively maintained, and a minimal wrapper over the Publishing
+      # API, matching how testflight.yml keeps the upload step thin.
+      - name: Upload to Play internal track
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.opencapture.openzcine
+          releaseFiles: Apps/Android/app/build/outputs/bundle/release/app-release.aab
+          track: internal
+          status: completed
+
+      - name: Summary
+        run: |
+          {
+            echo "### Play internal upload"
+            echo ""
+            echo "- **Version code:** ${{ steps.version.outputs.version_code }}"
+            echo "- **Commit:** \`${{ github.sha }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Apps/Android/app/build.gradle.kts
+++ b/Apps/Android/app/build.gradle.kts
@@ -3,6 +3,19 @@ plugins {
     alias(libs.plugins.kotlin.compose)
 }
 
+// Single version source: gradle.properties (mirrors ios/Config/Version.xcconfig).
+// CI overrides the code per build with `-PversionCode=<n>`; the name changes only
+// through a reviewed edit to gradle.properties. See docs/android-distribution.md.
+val resolvedVersionCode: Int =
+    (findProperty("versionCode") ?: property("openzcine.versionCode")).toString().toInt()
+val resolvedVersionName: String = property("openzcine.versionName").toString()
+
+// Release signing comes STRICTLY from environment variables so no keystore or
+// password can ever land in the repo. When they are unset, release builds stay
+// buildable but UNSIGNED (structure checks, `bundleRelease` locally); CI decodes
+// the keystore secret and exports these before building.
+val keystorePath: String? = System.getenv("ANDROID_KEYSTORE_PATH")
+
 android {
     namespace = "com.opencapture.openzcine"
     compileSdk = 36
@@ -13,13 +26,31 @@ android {
         // camera-AP Wi-Fi join flow needs; anything older cannot pair anyway.
         minSdk = 29
         targetSdk = 36
-        versionCode = 1
-        versionName = "0.1.0"
+        versionCode = resolvedVersionCode
+        versionName = resolvedVersionName
+    }
+
+    signingConfigs {
+        if (keystorePath != null) {
+            create("release") {
+                storeFile = file(keystorePath)
+                storePassword = System.getenv("ANDROID_KEYSTORE_PASSWORD")
+                keyAlias = System.getenv("ANDROID_KEY_ALIAS")
+                keyPassword = System.getenv("ANDROID_KEY_PASSWORD")
+            }
+        }
     }
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+            // Null (unsigned) when ANDROID_KEYSTORE_PATH is unset; never blocks debug.
+            signingConfig = signingConfigs.findByName("release")
         }
     }
 

--- a/Apps/Android/app/proguard-rules.pro
+++ b/Apps/Android/app/proguard-rules.pro
@@ -1,0 +1,7 @@
+# App-specific R8/ProGuard rules for release builds.
+#
+# Keep the camera-core seam (Apps/Android/core-api) intact. That module is the
+# deliberate public boundary where the shared camera core plugs in (JNI bridge or
+# Kotlin port later); shrinking or renaming its surface would break the seam
+# contract, and reflection/JNI lookups against it must keep working.
+-keep class com.opencapture.openzcine.core.** { *; }

--- a/Apps/Android/gradle.properties
+++ b/Apps/Android/gradle.properties
@@ -3,3 +3,10 @@ org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 org.gradle.configuration-cache=true
 android.useAndroidX=true
 kotlin.code.style=official
+
+# Single version source (mirrors ios/Config/Version.xcconfig on the iOS side).
+# CI overrides the version code per build with `-PversionCode=<n>`; bump the
+# name here in a reviewed PR when starting a new version train.
+# See docs/android-distribution.md.
+openzcine.versionCode=1
+openzcine.versionName=0.1.0

--- a/docs/android-distribution.md
+++ b/docs/android-distribution.md
@@ -1,0 +1,109 @@
+# Android distribution (Google Play internal testing)
+
+Signed Android App Bundles are built and uploaded to the Google Play **internal testing** track by
+[`play-internal.yml`](../.github/workflows/play-internal.yml). Releases are deliberate: the workflow
+runs on manual dispatch or an `android-v*` tag — never on plain merges.
+
+## Flow
+
+```text
+feature PR → CI (Gradle build + tests + lint) → merge to main
+→ tag android-v* (or Actions → Play Internal → Run workflow)
+→ signed .aab → Play internal track
+```
+
+The track goes live only after the [one-time Play console setup](#one-time-play-console-setup)
+below, including Google's rule that the **first** `.aab` reaches the track through a manual console
+upload.
+
+## Version numbers
+
+| Field | Source | Example |
+| --- | --- | --- |
+| **Version name** (Play "Release name") | `openzcine.versionName` in `Apps/Android/gradle.properties` | `0.1.0` |
+| **Version code** (Play's monotonic build id) | `100 + workflow run number`, passed as `-PversionCode` | `101`, `102`, … |
+
+This mirrors the iOS pattern ([TestFlight CI](testflight-ci.md)): the human-readable version lives
+in one committed file and changes only through a reviewed PR; the machine version code is stamped
+per CI build and never committed back. Local builds without `-PversionCode` fall back to
+`openzcine.versionCode` in `gradle.properties`.
+
+Adjust `ANDROID_VERSION_CODE_OFFSET` in `play-internal.yml` if it ever falls below the highest
+version code already in the Play console (for example after the manual first upload).
+
+## One-time Play console setup
+
+Erik's checklist, in order:
+
+1. **Create the app** — [Play Console](https://play.google.com/console) → **Create app**, package
+   name `com.opencapture.openzcine` (must match `applicationId`; it is permanent).
+2. **Generate the upload keystore** — locally, `just android-keystore`. It writes
+   `.local/android/upload-keystore.jks` (gitignored) and prints the follow-up steps. Back up the
+   file and password; enroll in **Play App Signing** (the default) so this is only the *upload*
+   key and Google holds the app signing key.
+3. **Service account for the API** — in [Google Cloud Console](https://console.cloud.google.com):
+   create (or pick) a project, enable the **Google Play Android Developer API**, create a service
+   account, and download its **JSON key**. Then in Play Console → **Users and permissions** →
+   invite the service account's email and grant it release permissions (release-manager level:
+   "Release apps to testing tracks" and app access for OpenZCine).
+4. **First upload is manual** — Google requires the first bundle on a track to be uploaded through
+   the console. Build one locally ([Local signed build](#local-signed-build)), then Play Console →
+   **Testing → Internal testing → Create new release** and upload
+   `Apps/Android/app/build/outputs/bundle/release/app-release.aab`. Add the internal-tester email
+   list while there.
+5. **Create the GitHub environment** — repo **Settings → Environments → New environment** named
+   `play` (mirrors the `testflight` environment), with the secrets below. Optionally restrict it
+   to `main` and tags, or require approval.
+
+## GitHub `play` environment secrets
+
+| Secret | Value |
+| --- | --- |
+| `ANDROID_KEYSTORE_BASE64` | `base64 -i .local/android/upload-keystore.jks \| pbcopy` |
+| `ANDROID_KEYSTORE_PASSWORD` | Store password entered during `just android-keystore` |
+| `ANDROID_KEY_ALIAS` | `upload` (the alias the recipe creates) |
+| `ANDROID_KEY_PASSWORD` | Same as the store password (PKCS12 keystores share it) |
+| `PLAY_SERVICE_ACCOUNT_JSON` | Full contents of the service-account JSON key file |
+
+No keystore, password, or service-account JSON is ever committed — `.gitignore` blocks `*.jks`,
+`*.keystore`, and `.local/`, and `just check` runs gitleaks over history.
+
+## Running the workflow
+
+- **Tag release** — `git tag android-v0.1.0 && git push origin android-v0.1.0` (any `android-v*`
+  tag).
+- **Manual** — **Actions → Play Internal → Run workflow**.
+
+Either way the workflow runs Gradle tests + lint, computes the version code, decodes the keystore
+secret to a runner temp file, builds `bundleRelease` signed via the `ANDROID_KEYSTORE_*`
+environment variables, and uploads to the `internal` track with
+[r0adkll/upload-google-play](https://github.com/r0adkll/upload-google-play) (pinned by digest;
+Google publishes no official Play-upload action, and this is the best-maintained community one).
+
+## Local signed build
+
+```bash
+just android-keystore                     # once; writes .local/android/upload-keystore.jks
+export ANDROID_KEYSTORE_PATH="$PWD/.local/android/upload-keystore.jks"
+export ANDROID_KEYSTORE_PASSWORD='...'
+export ANDROID_KEY_ALIAS=upload
+export ANDROID_KEY_PASSWORD='...'
+cd Apps/Android && ./gradlew bundleRelease
+# → app/build/outputs/bundle/release/app-release.aab
+```
+
+With the `ANDROID_KEYSTORE_*` variables unset, `bundleRelease` still succeeds and produces an
+**unsigned** bundle — useful for structure checks; Play will reject it, so signing is required for
+any real upload. The debug path (`just android-build` / `android-check`) never needs signing
+variables.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| Workflow skipped | Fork — it only runs on `erik-sutton95/openzcine` |
+| `ANDROID_KEYSTORE_BASE64 is not set` | `play` environment or its secrets missing |
+| Upload fails with 403 / "not found" | Service account lacks release permission, or the app was never created in the console |
+| "Package not found" on first CI upload | The mandatory manual first upload (step 4) hasn't happened yet |
+| "Version code already used" | Raise `ANDROID_VERSION_CODE_OFFSET` in `play-internal.yml` |
+| Play rejects the bundle signature | Wrong keystore secrets, or Play App Signing expects a different upload key — reset the upload key via Play support |

--- a/justfile
+++ b/justfile
@@ -165,6 +165,33 @@ android-test:
 android-check:
     cd Apps/Android && JAVA_HOME="${JAVA_HOME:-/opt/homebrew/opt/openjdk}" ./gradlew assembleDebug test lint
 
+# Generate the Play upload keystore into gitignored .local/ (never committed;
+# refuses to overwrite). keytool prompts for the store password interactively.
+android-keystore:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    out=".local/android/upload-keystore.jks"
+    if [ -e "$out" ]; then
+        echo "Refusing to overwrite existing $out — move it aside first if you really mean to regenerate." >&2
+        exit 1
+    fi
+    mkdir -p "$(dirname "$out")"
+    export JAVA_HOME="${JAVA_HOME:-/opt/homebrew/opt/openjdk}"
+    "$JAVA_HOME/bin/keytool" -genkeypair -v \
+        -keystore "$out" -alias upload \
+        -keyalg RSA -keysize 2048 -validity 9125 \
+        -dname "CN=OpenZCine Upload"
+    echo ""
+    echo "Created $out (gitignored). Next steps (details: docs/android-distribution.md):"
+    echo "  1. Back the file + password up somewhere safe (losing it means a Play support reset)."
+    echo "  2. GitHub 'play' environment secrets:"
+    echo "       ANDROID_KEYSTORE_BASE64   base64 -i $out | pbcopy"
+    echo "       ANDROID_KEYSTORE_PASSWORD the password you just entered"
+    echo "       ANDROID_KEY_ALIAS         upload"
+    echo "       ANDROID_KEY_PASSWORD      same as the store password"
+    echo "  3. Local signed build: export ANDROID_KEYSTORE_PATH=\"\$PWD/$out\" plus the three vars above,"
+    echo "     then: cd Apps/Android && ./gradlew bundleRelease"
+
 # Build and install the debug APK on a connected device/emulator, then launch it.
 # With several devices attached, pass the serial: `just android-install R58R92BL76K`.
 android-install serial="":


### PR DESCRIPTION
Part of #81 (Kaneo OPE-38).

Repo-side prep for the Google Play internal testing track:

- Release build config: R8 minify + resource shrinking, proguard rules preserving the core-api seam, signing strictly from `ANDROID_KEYSTORE_*` env vars (unsigned-but-buildable when unset)
- Version single-sourced in `gradle.properties`, CI-overridable `-PversionCode`
- `Play Internal` workflow (manual dispatch + `android-v*` tags): temurin 21, checks, signed `.aab`, upload via pinned `r0adkll/upload-google-play`, secrets in a `play` GitHub environment
- `just android-keystore` recipe (gitignored output, refuses to overwrite)
- `docs/android-distribution.md` with the full console + secrets setup

The track goes live only after the Play console app is created, the `play` environment secrets exist, and the first bundle is uploaded manually in the console (Google requirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
