### PR TITLE
feat(android): PTP-IP transport foundations — NSD discovery, socket lifecycle, reconnect

### DIFF
--- a/Apps/Android/README.md
+++ b/Apps/Android/README.md
@@ -7,5 +7,11 @@ Production Jetpack Compose shell — early scaffold. One placeholder monitor scr
 - **Core seam:** `core-api/` is a pure-JVM module defining `CameraSession`, `LiveFrameSource`, and
   `CameraIdentity`. Either the shared Swift core (via JNI) or a Kotlin port plugs in behind it —
   the shell never sees which. Feasibility call tracked in
-  `docs/investigations/android-core-feasibility.md` (forthcoming).
+  `docs/investigations/android-core-feasibility.md`.
+- **Transport foundations:** `app/.../transport/` owns the platform byte layer — NSD/mDNS camera
+  discovery (`CameraDiscovery` over an `NsdBrowser` seam, `_ptp._tcp`, plus the fixed camera-AP
+  host) and `PtpIpSocketTransport` (command + event TCP sockets, graceful half-close teardown,
+  settle-then-backoff reconnect). PTP-IP protocol/session logic arrives later behind the seam;
+  this layer is bytes only. Debug hook to try it live:
+  `adb shell am start -n com.opencapture.openzcine/.MainActivity --ez openzcine.nsdTransport true`.
 - **Local SDK:** put `sdk.dir=<your Android SDK path>` in `Apps/Android/local.properties` (gitignored).

--- a/Apps/Android/app/build.gradle.kts
+++ b/Apps/Android/app/build.gradle.kts
@@ -46,4 +46,7 @@ dependencies {
     implementation(libs.androidx.activity.compose)
     implementation(libs.compose.material3)
     implementation(libs.kotlinx.coroutines.android)
+
+    testImplementation(libs.kotlin.test.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/Apps/Android/app/src/main/AndroidManifest.xml
+++ b/Apps/Android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- PTP-IP camera sockets (local network only; there is no server backend). -->
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:label="OpenZCine"
         android:supportsRtl="true"

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.opencapture.openzcine
 
+import android.content.pm.ApplicationInfo
+import android.net.nsd.NsdManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -18,6 +20,8 @@ import androidx.compose.ui.Modifier
 import com.opencapture.openzcine.core.CameraSession
 import com.opencapture.openzcine.core.CameraSessionState
 import com.opencapture.openzcine.core.FakeCameraSession
+import com.opencapture.openzcine.transport.AndroidNsdBrowser
+import com.opencapture.openzcine.transport.NsdCameraSessionFactory
 
 /**
  * App entry point: a full-screen placeholder monitor shell fed by the
@@ -25,19 +29,31 @@ import com.opencapture.openzcine.core.FakeCameraSession
  * this only proves the shell-to-core boundary end to end.
  */
 class MainActivity : ComponentActivity() {
-    // ponytail: fake backend held by the activity until a real core lands
-    // behind the seam; DI arrives with the first second implementation.
-    private val session: CameraSession = FakeCameraSession()
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        // ponytail: fake backend by default until the real core lands behind
+        // the seam; DI arrives with the first production implementation.
+        val session: CameraSession =
+            if (isNsdTransportRequested()) nsdTransportSession() else FakeCameraSession()
         setContent {
             OpenZCineTheme {
                 MonitorShell(session)
             }
         }
     }
+
+    /**
+     * Debug-only hook to exercise the real NSD discovery + socket transport:
+     * `adb shell am start -n com.opencapture.openzcine/.MainActivity --ez openzcine.nsdTransport true`
+     */
+    private fun isNsdTransportRequested(): Boolean =
+        (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0 &&
+            intent.getBooleanExtra("openzcine.nsdTransport", false)
+
+    private fun nsdTransportSession(): CameraSession =
+        NsdCameraSessionFactory(AndroidNsdBrowser(getSystemService(NsdManager::class.java)))
+            .create()
 }
 
 /**

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/AndroidNsdBrowser.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/AndroidNsdBrowser.kt
@@ -1,0 +1,95 @@
+package com.opencapture.openzcine.transport
+
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import java.io.IOException
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+/**
+ * [NsdBrowser] backed by the platform [NsdManager], insulated against its
+ * known callback quirks:
+ *
+ * - **One discovery per listener** — every collection creates a fresh
+ *   listener, and browsing stops when the collector cancels.
+ * - **Resolves must be serialized** — concurrent [NsdManager.resolveService]
+ *   calls fail with `FAILURE_ALREADY_ACTIVE`, so found services queue through
+ *   a single worker that resolves strictly one at a time.
+ * - **Stop-before-start is illegal** — [NsdManager.stopServiceDiscovery] on a
+ *   listener whose start failed throws `IllegalArgumentException`; teardown
+ *   swallows that case.
+ *
+ * Not JVM-testable (framework types throughout); the mapping logic it feeds
+ * lives in [CameraDiscovery], which is. Instrumented coverage is future work.
+ */
+class AndroidNsdBrowser(private val nsdManager: NsdManager) : NsdBrowser {
+    override fun events(serviceType: String): Flow<NsdEvent> = callbackFlow {
+        val resolveRequests = Channel<NsdServiceInfo>(Channel.UNLIMITED)
+        val resolver = launch {
+            for (service in resolveRequests) {
+                resolveOne(service)?.let(::trySend)
+            }
+        }
+
+        val listener =
+            object : NsdManager.DiscoveryListener {
+                override fun onDiscoveryStarted(serviceType: String) {}
+
+                override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {
+                    close(IOException("NSD discovery failed to start (error $errorCode)."))
+                }
+
+                override fun onDiscoveryStopped(serviceType: String) {}
+
+                override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {}
+
+                override fun onServiceFound(serviceInfo: NsdServiceInfo) {
+                    trySend(NsdEvent.ServiceFound(serviceInfo.serviceName))
+                    resolveRequests.trySend(serviceInfo)
+                }
+
+                override fun onServiceLost(serviceInfo: NsdServiceInfo) {
+                    trySend(NsdEvent.ServiceLost(serviceInfo.serviceName))
+                }
+            }
+
+        nsdManager.discoverServices(serviceType, NsdManager.PROTOCOL_DNS_SD, listener)
+
+        awaitClose {
+            resolver.cancel()
+            resolveRequests.close()
+            try {
+                nsdManager.stopServiceDiscovery(listener)
+            } catch (_: IllegalArgumentException) {
+                // Start failed, so the listener was never registered.
+            }
+        }
+    }
+
+    /** Resolves one service; returns null when resolution fails or lacks an address. */
+    private suspend fun resolveOne(service: NsdServiceInfo): NsdEvent.ServiceResolved? =
+        suspendCancellableCoroutine { continuation ->
+            nsdManager.resolveService(
+                service,
+                object : NsdManager.ResolveListener {
+                    override fun onServiceResolved(serviceInfo: NsdServiceInfo) {
+                        val host = serviceInfo.host?.hostAddress
+                        continuation.resume(
+                            host?.let {
+                                NsdEvent.ServiceResolved(serviceInfo.serviceName, it, serviceInfo.port)
+                            },
+                            onCancellation = null,
+                        )
+                    }
+
+                    override fun onResolveFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {
+                        continuation.resume(null, onCancellation = null)
+                    }
+                },
+            )
+        }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/CameraDiscovery.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/CameraDiscovery.kt
@@ -1,0 +1,98 @@
+package com.opencapture.openzcine.transport
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.scan
+
+/**
+ * A PTP-IP camera discovered on the network (or addressed directly in
+ * camera-AP mode).
+ *
+ * @property name Service/camera name as advertised over mDNS (for example
+ *   `"ZR_1234"`), or a fixed label for direct-host cameras.
+ * @property host IPv4 address the camera answers on.
+ * @property port TCP port of the PTP-IP responder (normally [CameraDiscovery.PTP_IP_PORT]).
+ */
+data class DiscoveredCamera(
+    val name: String,
+    val host: String,
+    val port: Int,
+)
+
+/**
+ * Platform-free mDNS browse events — the thin seam over [android.net.nsd.NsdManager]
+ * so discovery bookkeeping stays testable on the JVM.
+ */
+sealed interface NsdEvent {
+    /** A service appeared but has not resolved to a host yet. */
+    data class ServiceFound(val serviceName: String) : NsdEvent
+
+    /** A found service resolved to a reachable host/port. */
+    data class ServiceResolved(val serviceName: String, val host: String, val port: Int) : NsdEvent
+
+    /** A previously found service disappeared from the network. */
+    data class ServiceLost(val serviceName: String) : NsdEvent
+}
+
+/**
+ * Browses one mDNS service type, emitting [NsdEvent]s while collected.
+ *
+ * Production implementation is [AndroidNsdBrowser]; tests substitute a fake.
+ * Browsing stops when the collector cancels. One active collection at a time —
+ * the platform NSD stack only supports a single discovery per listener.
+ */
+interface NsdBrowser {
+    fun events(serviceType: String): Flow<NsdEvent>
+}
+
+/**
+ * Camera discovery over mDNS/NSD, mirroring the iOS Bonjour browse
+ * (`ios/Runner/NativeCameraDiscovery.swift`): the ZR advertises `_ptp._tcp`,
+ * and in camera-AP mode it always sits at a fixed address
+ * ([NIKON_ZR_ACCESS_POINT_HOST]) with no mDNS required.
+ */
+class CameraDiscovery(private val browser: NsdBrowser) {
+    /**
+     * Emits the current set of reachable cameras, updating as services
+     * resolve and disappear. Starts with an empty list; found-but-unresolved
+     * services are not cameras yet (no host to connect to).
+     */
+    fun cameras(): Flow<List<DiscoveredCamera>> =
+        browser.events(PTP_SERVICE_TYPE)
+            .scan(emptyMap<String, DiscoveredCamera>()) { known, event ->
+                when (event) {
+                    is NsdEvent.ServiceResolved ->
+                        known +
+                            (event.serviceName to
+                                DiscoveredCamera(event.serviceName, event.host, event.port))
+                    is NsdEvent.ServiceLost -> known - event.serviceName
+                    is NsdEvent.ServiceFound -> known
+                }
+            }
+            .map { known -> known.values.sortedBy(DiscoveredCamera::name) }
+            .distinctUntilChanged()
+
+    companion object {
+        /** mDNS service type the ZR advertises (same as the iOS browse). */
+        const val PTP_SERVICE_TYPE: String = "_ptp._tcp."
+
+        /** Standard PTP-IP TCP port (CIPA DC-005). */
+        const val PTP_IP_PORT: Int = 15740
+
+        /**
+         * Fixed camera address when the phone joins the ZR's own access
+         * point — mirrors `CameraDiscovery.nikonZRAccessPointHost` in the
+         * shared Swift core.
+         */
+        const val NIKON_ZR_ACCESS_POINT_HOST: String = "192.168.1.1"
+
+        /** Direct-host camera for the camera-AP case; no mDNS browse needed. */
+        fun accessPointCamera(): DiscoveredCamera =
+            DiscoveredCamera(
+                name = "Nikon ZR",
+                host = NIKON_ZR_ACCESS_POINT_HOST,
+                port = PTP_IP_PORT,
+            )
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/NsdCameraSessionFactory.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/NsdCameraSessionFactory.kt
@@ -1,0 +1,71 @@
+package com.opencapture.openzcine.transport
+
+import com.opencapture.openzcine.core.CameraIdentity
+import com.opencapture.openzcine.core.CameraSession
+import com.opencapture.openzcine.core.CameraSessionState
+import java.io.IOException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Sketch of the production seam wiring: NSD discovery plus the socket
+ * transport behind the core-api [CameraSession].
+ *
+ * This proves the byte path only — browse, pick a camera (falling back to the
+ * fixed camera-AP host when mDNS finds nothing), open the command socket. The
+ * PTP-IP Init handshake, session open, and real [CameraIdentity] arrive with
+ * the Swift-core JNI facade, which replaces [TransportCameraSession]'s
+ * "connected" claim with a protocol-verified one.
+ */
+class NsdCameraSessionFactory(
+    private val browser: NsdBrowser,
+    private val discoveryWindowMillis: Long = 5_000,
+) {
+    /** Builds a transport-backed [CameraSession]. */
+    fun create(): CameraSession =
+        TransportCameraSession(CameraDiscovery(browser), discoveryWindowMillis)
+}
+
+internal class TransportCameraSession(
+    private val discovery: CameraDiscovery,
+    private val discoveryWindowMillis: Long,
+) : CameraSession {
+    private val mutableState =
+        MutableStateFlow<CameraSessionState>(CameraSessionState.Disconnected)
+
+    override val state: StateFlow<CameraSessionState> = mutableState.asStateFlow()
+
+    private var transport: PtpIpSocketTransport? = null
+
+    override suspend fun connect() {
+        mutableState.value = CameraSessionState.Connecting
+        val camera =
+            withTimeoutOrNull(discoveryWindowMillis) {
+                discovery.cameras().first { it.isNotEmpty() }.first()
+            } ?: CameraDiscovery.accessPointCamera()
+
+        val candidate = PtpIpSocketTransport(camera.host, camera.port)
+        try {
+            candidate.connect()
+        } catch (_: IOException) {
+            mutableState.value = CameraSessionState.Disconnected
+            return
+        }
+        transport = candidate
+        // ponytail: identity from the mDNS name only — model/serial come from
+        // the protocol layer once the JNI facade lands.
+        mutableState.value =
+            CameraSessionState.Connected(
+                CameraIdentity(name = camera.name, model = camera.name, serialNumber = "")
+            )
+    }
+
+    override suspend fun disconnect() {
+        transport?.disconnect()
+        transport = null
+        mutableState.value = CameraSessionState.Disconnected
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/PtpIpSocketTransport.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/PtpIpSocketTransport.kt
@@ -1,0 +1,225 @@
+package com.opencapture.openzcine.transport
+
+import java.io.EOFException
+import java.io.IOException
+import java.net.InetSocketAddress
+import java.net.Socket
+import kotlin.random.Random
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+/** Connection lifecycle of a [PtpIpSocketTransport] (naming matches the core-api seam). */
+sealed interface TransportState {
+    /** No sockets open and no attempt in flight. */
+    data object Disconnected : TransportState
+
+    /** A connect attempt is in progress. */
+    data object Connecting : TransportState
+
+    /** The command socket is open. */
+    data object Connected : TransportState
+}
+
+/**
+ * Raw duplex byte channel over one TCP socket (PTP-IP command or event).
+ *
+ * The PTP-IP framing/protocol layer that consumes these bytes arrives later
+ * with the Swift-core JNI facade; this boundary is deliberately bytes-only.
+ * Sends and receives are each internally serialized; interleaving distinct
+ * logical messages across concurrent callers is the protocol layer's job.
+ */
+interface TransportChannel {
+    /** Sends all of [bytes]. Throws [IOException] when the channel is down. */
+    suspend fun send(bytes: ByteArray)
+
+    /**
+     * Receives between 1 and [maxBytes] bytes, suspending until data arrives.
+     * Throws [EOFException] when the peer closed the connection and
+     * [java.net.SocketTimeoutException] when no data arrives within the
+     * configured read timeout.
+     */
+    suspend fun receive(maxBytes: Int = DEFAULT_RECEIVE_LIMIT): ByteArray
+
+    companion object {
+        /** Default per-receive cap; bounds transient allocations like the iOS socket's recv cap. */
+        const val DEFAULT_RECEIVE_LIMIT: Int = 256 * 1024
+    }
+}
+
+/**
+ * TCP socket lifecycle for one PTP-IP camera connection — the Android twin of
+ * `ios/Runner/PTPIPTransport.swift`'s socket layer, minus the protocol.
+ *
+ * Owns the two-socket PTP-IP shape: [connect] opens the **command** socket;
+ * [openEventChannel] opens the **event** socket on demand, because CIPA
+ * DC-005 sequences it *after* the Init handshake on the command channel and
+ * that handshake belongs to the future protocol layer.
+ *
+ * Teardown is graceful: sockets are half-closed (FIN) before closing, so the
+ * camera observes an orderly shutdown instead of a reset — mirroring the iOS
+ * `shutdown(SHUT_RDWR)`-before-close fix from the connection-wedge work.
+ * [reconnect] additionally waits [Config.reconnectSettleMillis] before the
+ * fresh connect, because the ZR briefly holds its PTP slot after a close and
+ * a same-instant reconnect can wedge it.
+ *
+ * @property host Camera IPv4 address.
+ * @property port PTP-IP TCP port.
+ */
+class PtpIpSocketTransport(
+    private val host: String,
+    private val port: Int = CameraDiscovery.PTP_IP_PORT,
+    private val config: Config = Config(),
+    private val backoff: ReconnectBackoff = ReconnectBackoff(),
+    private val jitter: () -> Double = { Random.nextDouble() },
+) {
+    /**
+     * Transport tuning. Defaults mirror the iOS transport: 10s socket
+     * timeouts, a 1.2s reconnect settle (ZR slot-release time, verify on
+     * hardware), and a small bounded retry budget.
+     */
+    data class Config(
+        val connectTimeoutMillis: Int = 10_000,
+        val readTimeoutMillis: Int = 10_000,
+        val reconnectSettleMillis: Long = 1_200,
+        val maxReconnectAttempts: Int = 3,
+    )
+
+    private val mutableState = MutableStateFlow<TransportState>(TransportState.Disconnected)
+
+    /** Current transport lifecycle state. */
+    val state: StateFlow<TransportState> = mutableState.asStateFlow()
+
+    private val lifecycle = Mutex()
+    private var commandSocket: Socket? = null
+    private var eventSocket: Socket? = null
+
+    /**
+     * Opens the command socket and returns its byte channel. Throws
+     * [IOException] (including [java.net.SocketTimeoutException]) on failure,
+     * leaving [state] at [TransportState.Disconnected].
+     */
+    suspend fun connect(): TransportChannel =
+        lifecycle.withLock {
+            check(commandSocket == null) { "Transport already connected; disconnect() first." }
+            mutableState.value = TransportState.Connecting
+            try {
+                val socket = openSocket()
+                commandSocket = socket
+                mutableState.value = TransportState.Connected
+                SocketChannel(socket)
+            } catch (error: Exception) {
+                mutableState.value = TransportState.Disconnected
+                throw error
+            }
+        }
+
+    /**
+     * Opens the event socket and returns its byte channel. Requires a
+     * connected command socket first (the protocol layer calls this after the
+     * camera acknowledges the Init handshake).
+     */
+    suspend fun openEventChannel(): TransportChannel =
+        lifecycle.withLock {
+            check(commandSocket != null) { "Connect the command channel before the event channel." }
+            check(eventSocket == null) { "Event channel already open." }
+            val socket = openSocket()
+            eventSocket = socket
+            SocketChannel(socket)
+        }
+
+    /** Gracefully tears down both sockets and returns [state] to [TransportState.Disconnected]. */
+    suspend fun disconnect() {
+        lifecycle.withLock { teardown() }
+    }
+
+    /**
+     * Tears down any existing sockets, waits the reconnect settle, then
+     * retries [connect] up to [Config.maxReconnectAttempts] times with
+     * [backoff] between attempts. Returns the fresh command channel or throws
+     * the last [IOException] once the budget is exhausted.
+     */
+    suspend fun reconnect(): TransportChannel {
+        lifecycle.withLock { teardown() }
+        delay(config.reconnectSettleMillis)
+        var attempt = 0
+        while (true) {
+            try {
+                return connect()
+            } catch (error: IOException) {
+                if (attempt + 1 >= config.maxReconnectAttempts) throw error
+                delay(backoff.delayMillis(attempt, jitter()))
+                attempt += 1
+            }
+        }
+    }
+
+    /** Must be called with [lifecycle] held. */
+    private suspend fun teardown() {
+        val sockets = listOfNotNull(commandSocket, eventSocket)
+        commandSocket = null
+        eventSocket = null
+        mutableState.value = TransportState.Disconnected
+        if (sockets.isEmpty()) return
+        withContext(Dispatchers.IO) {
+            for (socket in sockets) {
+                // Half-close first so the peer sees FIN, not RST — the iOS
+                // shutdown()-before-close teardown that unwedged ZR reconnects.
+                runCatching { socket.shutdownOutput() }
+                runCatching { socket.shutdownInput() }
+                runCatching { socket.close() }
+            }
+        }
+    }
+
+    private suspend fun openSocket(): Socket =
+        withContext(Dispatchers.IO) {
+            val socket = Socket()
+            try {
+                socket.tcpNoDelay = true
+                // ponytail: plain SO_KEEPALIVE only — java.net cannot tune the
+                // probe timers the iOS transport sets; revisit with
+                // ExtendedSocketOptions if half-open links surface on hardware.
+                socket.keepAlive = true
+                socket.soTimeout = config.readTimeoutMillis
+                socket.connect(InetSocketAddress(host, port), config.connectTimeoutMillis)
+                socket
+            } catch (error: Exception) {
+                runCatching { socket.close() }
+                throw error
+            }
+        }
+}
+
+/** [TransportChannel] over a connected [Socket]; I/O runs on [Dispatchers.IO]. */
+private class SocketChannel(private val socket: Socket) : TransportChannel {
+    private val sendMutex = Mutex()
+    private val receiveMutex = Mutex()
+
+    override suspend fun send(bytes: ByteArray) {
+        sendMutex.withLock {
+            withContext(Dispatchers.IO) {
+                val output = socket.getOutputStream()
+                output.write(bytes)
+                output.flush()
+            }
+        }
+    }
+
+    override suspend fun receive(maxBytes: Int): ByteArray {
+        require(maxBytes > 0) { "maxBytes must be positive." }
+        return receiveMutex.withLock {
+            withContext(Dispatchers.IO) {
+                val buffer = ByteArray(maxBytes)
+                val count = socket.getInputStream().read(buffer)
+                if (count < 0) throw EOFException("PTP-IP peer closed the connection.")
+                buffer.copyOf(count)
+            }
+        }
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/ReconnectBackoff.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/ReconnectBackoff.kt
@@ -1,0 +1,40 @@
+package com.opencapture.openzcine.transport
+
+import kotlin.math.max
+import kotlin.math.pow
+import kotlin.math.roundToLong
+
+/**
+ * Jittered exponential backoff for reconnect retries — the Kotlin twin of the
+ * shared core's `ReconnectBackoff` (`Sources/OpenZCineCore/ReconnectBackoff.swift`).
+ *
+ * Plain doubling wakes every retry at the same instants and hammers a flaky
+ * access point with synchronized bursts; spreading each delay by a random
+ * fraction de-correlates them. The jitter sample is injected (`0.0..1.0`)
+ * rather than drawn internally so the schedule stays pure and unit-testable.
+ *
+ * @property baseMillis Delay for the very first retry (attempt 0).
+ * @property maxMillis Hard ceiling, applied before and after jitter.
+ * @property multiplier Per-attempt growth factor (2.0 = double each attempt).
+ * @property jitterFraction Proportional spread in `0.0..1.0` (0.3 = ±30%).
+ */
+data class ReconnectBackoff(
+    val baseMillis: Long = 500,
+    val maxMillis: Long = 30_000,
+    val multiplier: Double = 2.0,
+    val jitterFraction: Double = 0.3,
+) {
+    /**
+     * The delay in milliseconds before retry [attempt] (0 = first retry;
+     * negatives are treated as 0). [jitter] is a sample in `0.0..1.0`
+     * (clamped): 0 = lower bound, 0.5 = un-jittered, 1 = upper bound.
+     */
+    fun delayMillis(attempt: Int, jitter: Double): Long {
+        val exponent = max(0, attempt).toDouble()
+        val capped = minOf(maxMillis.toDouble(), baseMillis * multiplier.pow(exponent))
+        val clampedJitter = jitter.coerceIn(0.0, 1.0)
+        val signedSpread = (clampedJitter * 2 - 1) * jitterFraction
+        val jittered = capped * (1 + signedSpread)
+        return jittered.coerceIn(0.0, maxMillis.toDouble()).roundToLong()
+    }
+}

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/transport/CameraDiscoveryTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/transport/CameraDiscoveryTest.kt
@@ -1,0 +1,92 @@
+package com.opencapture.openzcine.transport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+
+/** Discovery bookkeeping against a scripted [NsdBrowser] (no Android framework). */
+class CameraDiscoveryTest {
+    private class FakeNsdBrowser(private val scripted: List<NsdEvent>) : NsdBrowser {
+        var requestedServiceType: String? = null
+
+        override fun events(serviceType: String): Flow<NsdEvent> {
+            requestedServiceType = serviceType
+            return scripted.asFlow()
+        }
+    }
+
+    private suspend fun snapshots(vararg events: NsdEvent): List<List<DiscoveredCamera>> =
+        CameraDiscovery(FakeNsdBrowser(events.toList())).cameras().toList()
+
+    @Test
+    fun `browses the ptp service type`() = runTest {
+        val browser = FakeNsdBrowser(emptyList())
+
+        CameraDiscovery(browser).cameras().toList()
+
+        assertEquals("_ptp._tcp.", browser.requestedServiceType)
+    }
+
+    @Test
+    fun `resolved service appears as a camera`() = runTest {
+        val snapshots =
+            snapshots(
+                NsdEvent.ServiceFound("ZR_1234"),
+                NsdEvent.ServiceResolved("ZR_1234", "192.168.1.7", 15740),
+            )
+
+        assertEquals(
+            listOf(emptyList(), listOf(DiscoveredCamera("ZR_1234", "192.168.1.7", 15740))),
+            snapshots,
+        )
+    }
+
+    @Test
+    fun `found but unresolved service is not a camera yet`() = runTest {
+        assertEquals(listOf(emptyList()), snapshots(NsdEvent.ServiceFound("ZR_1234")))
+    }
+
+    @Test
+    fun `lost service disappears from the set`() = runTest {
+        val snapshots =
+            snapshots(
+                NsdEvent.ServiceResolved("ZR_1234", "192.168.1.7", 15740),
+                NsdEvent.ServiceLost("ZR_1234"),
+            )
+
+        assertEquals(emptyList<DiscoveredCamera>(), snapshots.last())
+    }
+
+    @Test
+    fun `re-resolution updates a camera's address in place`() = runTest {
+        val snapshots =
+            snapshots(
+                NsdEvent.ServiceResolved("ZR_1234", "192.168.1.7", 15740),
+                NsdEvent.ServiceResolved("ZR_1234", "192.168.1.9", 15740),
+            )
+
+        assertEquals(listOf(DiscoveredCamera("ZR_1234", "192.168.1.9", 15740)), snapshots.last())
+    }
+
+    @Test
+    fun `multiple cameras sort by name`() = runTest {
+        val snapshots =
+            snapshots(
+                NsdEvent.ServiceResolved("ZR_B", "192.168.1.8", 15740),
+                NsdEvent.ServiceResolved("ZR_A", "192.168.1.7", 15740),
+            )
+
+        assertEquals(listOf("ZR_A", "ZR_B"), snapshots.last().map(DiscoveredCamera::name))
+    }
+
+    @Test
+    fun `access point camera targets the fixed ZR host`() {
+        assertEquals(
+            DiscoveredCamera("Nikon ZR", "192.168.1.1", 15740),
+            CameraDiscovery.accessPointCamera(),
+        )
+    }
+}

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/transport/PtpIpSocketTransportTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/transport/PtpIpSocketTransportTest.kt
@@ -1,0 +1,210 @@
+package com.opencapture.openzcine.transport
+
+import java.io.EOFException
+import java.io.IOException
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.SocketTimeoutException
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+
+/** Exercises the transport state machine against a local [ServerSocket] fixture. */
+class PtpIpSocketTransportTest {
+    private fun transport(
+        port: Int,
+        config: PtpIpSocketTransport.Config = PtpIpSocketTransport.Config(),
+        jitter: () -> Double = { 0.5 },
+    ) = PtpIpSocketTransport("127.0.0.1", port, config, jitter = jitter)
+
+    @Test
+    fun `connect opens the command socket and reaches connected`() = runTest {
+        ServerSocket(0).use { server ->
+            val subject = transport(server.localPort)
+            val accepted = async(Dispatchers.IO) { server.accept() }
+
+            val command = subject.connect()
+
+            accepted.await().use { peer ->
+                assertEquals(TransportState.Connected, subject.state.value)
+                command.send(byteArrayOf(1, 2, 3))
+                assertContentEquals(byteArrayOf(1, 2, 3), peer.readExactly(3))
+            }
+            subject.disconnect()
+        }
+    }
+
+    @Test
+    fun `receive returns bytes the camera sends`() = runTest {
+        ServerSocket(0).use { server ->
+            val subject = transport(server.localPort)
+            val accepted = async(Dispatchers.IO) { server.accept() }
+            val command = subject.connect()
+
+            accepted.await().use { peer ->
+                peer.getOutputStream().apply {
+                    write(byteArrayOf(9, 8, 7, 6))
+                    flush()
+                }
+                val received = command.receive()
+                assertContentEquals(byteArrayOf(9, 8, 7, 6), received)
+            }
+            subject.disconnect()
+        }
+    }
+
+    @Test
+    fun `event channel opens a second connection after the command channel`() = runTest {
+        ServerSocket(0).use { server ->
+            val subject = transport(server.localPort)
+            val firstAccept = async(Dispatchers.IO) { server.accept() }
+            subject.connect()
+            firstAccept.await().use {
+                val secondAccept = async(Dispatchers.IO) { server.accept() }
+                val event = subject.openEventChannel()
+
+                secondAccept.await().use { peer ->
+                    event.send(byteArrayOf(42))
+                    assertContentEquals(byteArrayOf(42), peer.readExactly(1))
+                }
+            }
+            subject.disconnect()
+        }
+    }
+
+    @Test
+    fun `event channel before connect is rejected`() = runTest {
+        assertFailsWith<IllegalStateException> { transport(port = 1).openEventChannel() }
+    }
+
+    @Test
+    fun `refused connection throws and returns state to disconnected`() = runTest {
+        val deadPort = ServerSocket(0).use { it.localPort }
+        val subject = transport(deadPort)
+
+        assertFailsWith<IOException> { subject.connect() }
+
+        assertEquals(TransportState.Disconnected, subject.state.value)
+    }
+
+    @Test
+    fun `receive times out when the camera goes silent`() = runTest {
+        ServerSocket(0).use { server ->
+            val subject =
+                transport(server.localPort, PtpIpSocketTransport.Config(readTimeoutMillis = 100))
+            val accepted = async(Dispatchers.IO) { server.accept() }
+            val command = subject.connect()
+
+            accepted.await().use {
+                assertFailsWith<SocketTimeoutException> { command.receive() }
+            }
+            subject.disconnect()
+        }
+    }
+
+    @Test
+    fun `receive throws EOF when the peer closes`() = runTest {
+        ServerSocket(0).use { server ->
+            val subject = transport(server.localPort)
+            val accepted = async(Dispatchers.IO) { server.accept() }
+            val command = subject.connect()
+
+            accepted.await().close()
+
+            assertFailsWith<EOFException> { command.receive() }
+            subject.disconnect()
+        }
+    }
+
+    @Test
+    fun `disconnect tears down gracefully with an orderly EOF at the peer`() = runTest {
+        ServerSocket(0).use { server ->
+            val subject = transport(server.localPort)
+            val accepted = async(Dispatchers.IO) { server.accept() }
+            subject.connect()
+
+            accepted.await().use { peer ->
+                subject.disconnect()
+
+                assertEquals(TransportState.Disconnected, subject.state.value)
+                // FIN, not RST: the peer's read observes a clean end of stream.
+                assertEquals(-1, peer.getInputStream().read())
+            }
+        }
+    }
+
+    @Test
+    fun `transport can connect again after disconnect`() = runTest {
+        ServerSocket(0).use { server ->
+            val subject = transport(server.localPort)
+            val firstAccept = async(Dispatchers.IO) { server.accept() }
+            subject.connect()
+            firstAccept.await().use { subject.disconnect() }
+
+            val secondAccept = async(Dispatchers.IO) { server.accept() }
+            subject.connect()
+
+            secondAccept.await().use {
+                assertEquals(TransportState.Connected, subject.state.value)
+            }
+            subject.disconnect()
+        }
+    }
+
+    @Test
+    fun `reconnect tears down the old connection and establishes a fresh one`() = runTest {
+        ServerSocket(0).use { server ->
+            val subject = transport(server.localPort)
+            val firstAccept = async(Dispatchers.IO) { server.accept() }
+            subject.connect()
+            firstAccept.await().use {
+                val secondAccept = async(Dispatchers.IO) { server.accept() }
+
+                val command = subject.reconnect()
+
+                secondAccept.await().use { peer ->
+                    assertEquals(TransportState.Connected, subject.state.value)
+                    command.send(byteArrayOf(5))
+                    assertContentEquals(byteArrayOf(5), peer.readExactly(1))
+                }
+            }
+            subject.disconnect()
+        }
+    }
+
+    @Test
+    fun `reconnect exhausts its retry budget with backoff between attempts`() = runTest {
+        val deadPort = ServerSocket(0).use { it.localPort }
+        var jitterSamples = 0
+        val subject =
+            transport(
+                deadPort,
+                PtpIpSocketTransport.Config(maxReconnectAttempts = 3),
+                jitter = {
+                    jitterSamples += 1
+                    0.5
+                },
+            )
+
+        assertFailsWith<IOException> { subject.reconnect() }
+
+        // Backoff (and its jitter sample) sits between attempts: attempts - 1.
+        assertEquals(2, jitterSamples)
+        assertEquals(TransportState.Disconnected, subject.state.value)
+    }
+
+    private fun Socket.readExactly(count: Int): ByteArray {
+        val bytes = ByteArray(count)
+        var offset = 0
+        while (offset < count) {
+            val read = getInputStream().read(bytes, offset, count - offset)
+            check(read >= 0) { "Peer stream ended after $offset bytes." }
+            offset += read
+        }
+        return bytes
+    }
+}

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/transport/ReconnectBackoffTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/transport/ReconnectBackoffTest.kt
@@ -1,0 +1,40 @@
+package com.opencapture.openzcine.transport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** Mirrors the Swift core's ReconnectBackoff semantics. */
+class ReconnectBackoffTest {
+    private val backoff = ReconnectBackoff()
+
+    @Test
+    fun `midpoint jitter doubles from the base each attempt`() {
+        assertEquals(500, backoff.delayMillis(attempt = 0, jitter = 0.5))
+        assertEquals(1_000, backoff.delayMillis(attempt = 1, jitter = 0.5))
+        assertEquals(2_000, backoff.delayMillis(attempt = 2, jitter = 0.5))
+    }
+
+    @Test
+    fun `delay is capped at the maximum`() {
+        assertEquals(30_000, backoff.delayMillis(attempt = 20, jitter = 0.5))
+        // Upper-bound jitter never pushes past the cap either.
+        assertEquals(30_000, backoff.delayMillis(attempt = 20, jitter = 1.0))
+    }
+
+    @Test
+    fun `jitter spreads the delay by the configured fraction`() {
+        assertEquals(350, backoff.delayMillis(attempt = 0, jitter = 0.0))
+        assertEquals(650, backoff.delayMillis(attempt = 0, jitter = 1.0))
+    }
+
+    @Test
+    fun `out-of-range jitter samples are clamped`() {
+        assertEquals(350, backoff.delayMillis(attempt = 0, jitter = -3.0))
+        assertEquals(650, backoff.delayMillis(attempt = 0, jitter = 7.0))
+    }
+
+    @Test
+    fun `negative attempts are treated as the first retry`() {
+        assertEquals(500, backoff.delayMillis(attempt = -5, jitter = 0.5))
+    }
+}

--- a/Apps/Android/gradle/libs.versions.toml
+++ b/Apps/Android/gradle/libs.versions.toml
@@ -10,6 +10,9 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+# The android-application module needs the explicit JUnit variant: AGP's built-in
+# Kotlin support does not apply the framework inference the kotlin-jvm plugin does.
+kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
 compose-material3 = { module = "androidx.compose.material3:material3" }


### PR DESCRIPTION
Part of #69 (Kaneo OPE-26). Adds the Android platform byte layer behind the core-api seam:

- **NSD/mDNS camera discovery** (`_ptp._tcp`, port 15740, plus the fixed camera-AP host for direct mode) with NsdManager's callback quirks (single active discovery, serialized resolves, failed-start stop) isolated behind a JVM-testable `NsdBrowser` seam.
- **`PtpIpSocketTransport`** — command + event TCP sockets, suspend connect with timeout, raw duplex byte channels, graceful half-close teardown mirroring the iOS reconnect-wedge fix (FIN, not RST — test-verified), and settle-then-jittered-backoff reconnect (Kotlin twin of the core's backoff semantics, hardware-tunable settle).
- `FakeCameraSession` stays the app default; the real transport is reachable via a debug-only intent extra.
- 23 new JVM unit tests against a local ServerSocket fixture (27 total green); instrumented NSD tests are future work.

The PTP-IP protocol layer arrives with the Swift-core JNI facade — this PR's boundary is bytes.

`just android-check` and `just check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
