### PR TITLE
feat: bridge the shared Swift core into the Android app over JNI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,9 @@ build/
 .gradle/
 **/android/.gradle/
 
+# Cross-compiled Swift core .so set staged by `just android-core` — build artifacts.
+Apps/Android/app/src/main/jniLibs/
+
 # ── Retired agent clients ──────────────────────────────────────────────────────
 # OpenZCine supports Claude Code and Codex only. Keep other client-specific
 # instructions and caches out of the public repository.

--- a/Apps/Android/README.md
+++ b/Apps/Android/README.md
@@ -4,14 +4,19 @@ Production Jetpack Compose shell — early scaffold. One placeholder monitor scr
 (black feed area, "No camera" state) wired through the camera-core seam.
 
 - **Build:** `just android-build` from the repo root (or `just android-check` for build + tests + lint).
+- **Swift core:** the camera brain is the shared Swift core (`Sources/OpenZCineCore`), cross-compiled
+  to `libOpenZCineAndroid.so` and bound via JNI (`bridge/SwiftCore.kt` ↔
+  `Sources/OpenZCineAndroidFacade`). Run **`just android-core` before installing** — it stages the
+  `.so` set into `app/src/main/jniLibs/` (gitignored build artifacts, never committed). Plain
+  `android-build`/`android-check` work without it; the app then logs a warning instead of loading
+  the core. CI does not cross-compile yet (follow-up: `swift-android-action`).
 - **Core seam:** `core-api/` is a pure-JVM module defining `CameraSession`, `LiveFrameSource`, and
-  `CameraIdentity`. Either the shared Swift core (via JNI) or a Kotlin port plugs in behind it —
-  the shell never sees which. Feasibility call tracked in
+  `CameraIdentity`; the Swift core plugs in behind it. Decision record:
   `docs/investigations/android-core-feasibility.md`.
 - **Transport foundations:** `app/.../transport/` owns the platform byte layer — NSD/mDNS camera
   discovery (`CameraDiscovery` over an `NsdBrowser` seam, `_ptp._tcp`, plus the fixed camera-AP
   host) and `PtpIpSocketTransport` (command + event TCP sockets, graceful half-close teardown,
-  settle-then-backoff reconnect). PTP-IP protocol/session logic arrives later behind the seam;
+  settle-then-backoff reconnect). PTP-IP protocol/session logic arrives behind the JNI facade;
   this layer is bytes only. Debug hook to try it live:
   `adb shell am start -n com.opencapture.openzcine/.MainActivity --ez openzcine.nsdTransport true`.
 - **Local SDK:** put `sdk.dir=<your Android SDK path>` in `Apps/Android/local.properties` (gitignored).

--- a/Apps/Android/app/build.gradle.kts
+++ b/Apps/Android/app/build.gradle.kts
@@ -56,7 +56,7 @@ android {
 
     buildFeatures {
         compose = true
-        // BuildConfig.DEBUG gates the feed pacing logs.
+        // BuildConfig.DEBUG gates the feed pacing logs and the Swift-core smoke check.
         buildConfig = true
     }
 

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.opencapture.openzcine.core.CameraSession
 import com.opencapture.openzcine.core.CameraSessionState
+import com.opencapture.openzcine.bridge.SwiftCoreSmoke
 import com.opencapture.openzcine.core.FakeCameraSession
 import com.opencapture.openzcine.core.LiveFrameSource
 import com.opencapture.openzcine.transport.AndroidNsdBrowser
@@ -32,6 +33,7 @@ import com.opencapture.openzcine.transport.NsdCameraSessionFactory
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (BuildConfig.DEBUG) SwiftCoreSmoke.run()
         enableEdgeToEdge()
         // ponytail: fake backend by default until the real core lands behind
         // the seam; DI arrives with the first production implementation. Two

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCore.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCore.kt
@@ -1,0 +1,50 @@
+package com.opencapture.openzcine.bridge
+
+/**
+ * JNI binding to `libOpenZCineAndroid.so` — the shared Swift core
+ * (`Sources/OpenZCineCore`) plus its facade (`Sources/OpenZCineAndroidFacade`).
+ *
+ * The native library is a build artifact staged into `jniLibs/` by
+ * `just android-core`; it is never committed. Every `external fun` here must
+ * have a matching `@_cdecl` shim in
+ * `Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift`.
+ */
+object SwiftCore {
+    /**
+     * True when the Swift core library is bundled and loaded. False (with no
+     * crash) when the APK was built without running `just android-core` first.
+     */
+    val isAvailable: Boolean by lazy {
+        try {
+            System.loadLibrary("OpenZCineAndroid")
+            true
+        } catch (_: UnsatisfiedLinkError) {
+            false
+        }
+    }
+
+    /** Receives connection-phase updates pushed from Swift (non-main thread). */
+    fun interface ConnectionPhaseListener {
+        /** Called once per phase with operator-facing copy resolved by the core. */
+        fun onPhase(title: String, detail: String)
+    }
+
+    /** Core build identity string, resolved inside the Swift library. */
+    external fun coreVersion(): String
+
+    /**
+     * Derives the camera access-point SSID from a PTP friendly name
+     * (`ZR_6001234` → `NIKON_ZR_01234`), or null when the name is not a ZR.
+     */
+    external fun deriveAccessPointSSID(cameraName: String): String?
+
+    /** Operator-facing device title for a raw PTP name (`ZR_6001234` → `Nikon ZR`). */
+    external fun resolveDisplayName(rawName: String): String
+
+    /**
+     * Registers [listener] and has Swift push a canned connection-phase
+     * sequence from a background thread — the callback shape session events
+     * and live-view frames will use.
+     */
+    external fun startConnectionDemo(listener: ConnectionPhaseListener)
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreSmoke.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreSmoke.kt
@@ -1,0 +1,42 @@
+package com.opencapture.openzcine.bridge
+
+import android.util.Log
+
+/**
+ * Debug-only smoke check proving the Swift core answers over JNI: logs the
+ * core version, one real protocol-logic round trip, and callback deliveries
+ * under the `SwiftCoreSmoke` logcat tag.
+ */
+object SwiftCoreSmoke {
+    private const val TAG = "SwiftCoreSmoke"
+
+    /** Sample PTP friendly name a Nikon ZR reports over PTP-IP discovery. */
+    const val SAMPLE_CAMERA_NAME = "ZR_6001234"
+
+    /**
+     * Formats the smoke-report lines. Pure — unit-testable without the
+     * native library.
+     */
+    fun formatReport(version: String, ssid: String?, displayName: String): List<String> =
+        listOf(
+            "core: $version",
+            "ssid($SAMPLE_CAMERA_NAME): ${ssid ?: "<none>"}",
+            "displayName($SAMPLE_CAMERA_NAME): $displayName",
+        )
+
+    /** Runs the smoke check; logs a warning instead of crashing when the .so is absent. */
+    fun run() {
+        if (!SwiftCore.isAvailable) {
+            Log.w(TAG, "libOpenZCineAndroid.so not bundled — run `just android-core` before installing")
+            return
+        }
+        formatReport(
+            version = SwiftCore.coreVersion(),
+            ssid = SwiftCore.deriveAccessPointSSID(SAMPLE_CAMERA_NAME),
+            displayName = SwiftCore.resolveDisplayName(SAMPLE_CAMERA_NAME),
+        ).forEach { Log.i(TAG, it) }
+        SwiftCore.startConnectionDemo { title, detail ->
+            Log.i(TAG, "phase: $title — $detail")
+        }
+    }
+}

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/SwiftCoreSmokeTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/SwiftCoreSmokeTest.kt
@@ -1,0 +1,30 @@
+package com.opencapture.openzcine.bridge
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SwiftCoreSmokeTest {
+    @Test
+    fun `formatReport renders all three lines in order`() {
+        val lines =
+            SwiftCoreSmoke.formatReport(
+                version = "OpenZCineCore swift-android/arm64",
+                ssid = "NIKON_ZR_01234",
+                displayName = "Nikon ZR",
+            )
+        assertEquals(
+            listOf(
+                "core: OpenZCineCore swift-android/arm64",
+                "ssid(ZR_6001234): NIKON_ZR_01234",
+                "displayName(ZR_6001234): Nikon ZR",
+            ),
+            lines,
+        )
+    }
+
+    @Test
+    fun `formatReport marks a missing ssid`() {
+        val lines = SwiftCoreSmoke.formatReport("v", null, "Nikon camera")
+        assertEquals("ssid(ZR_6001234): <none>", lines[1])
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,12 @@ let package = Package(
         .watchOS(.v10),
     ],
     products: [
-        .library(name: "OpenZCineCore", targets: ["OpenZCineCore"])
+        .library(name: "OpenZCineCore", targets: ["OpenZCineCore"]),
+        // JNI facade consumed by the Android app (`just android-core`). The facade
+        // sources are fully `#if os(Android)`-gated, so on Darwin this product
+        // compiles to an empty module and iOS/macOS behavior is unchanged.
+        .library(
+            name: "OpenZCineAndroid", type: .dynamic, targets: ["OpenZCineAndroidFacade"]),
     ],
     dependencies: [
         // Non-Darwin SHA256 for PKCE (FrameioOAuth); Darwin builds keep using CryptoKit.
@@ -27,6 +32,12 @@ let package = Package(
         .testTarget(
             name: "OpenZCineCoreTests",
             dependencies: ["OpenZCineCore"]
+        ),
+        // Header-only shim exposing the NDK's <jni.h> to Swift; empty on Darwin.
+        .target(name: "CJNI"),
+        .target(
+            name: "OpenZCineAndroidFacade",
+            dependencies: ["OpenZCineCore", "CJNI"]
         ),
     ]
 )

--- a/Sources/CJNI/CJNI.c
+++ b/Sources/CJNI/CJNI.c
@@ -1,0 +1,1 @@
+// Header-only target; SwiftPM requires at least one source file.

--- a/Sources/CJNI/include/CJNI.h
+++ b/Sources/CJNI/include/CJNI.h
@@ -1,0 +1,11 @@
+// Exposes the Android NDK's JNI interface to Swift. On Darwin there is no
+// <jni.h> in the search path, so the module is deliberately empty there —
+// the facade target that imports it is `#if os(Android)`-gated as well.
+#ifndef OZC_CJNI_H
+#define OZC_CJNI_H
+
+#ifdef __ANDROID__
+#include <jni.h>
+#endif
+
+#endif /* OZC_CJNI_H */

--- a/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
+++ b/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
@@ -1,0 +1,155 @@
+// JNI facade over OpenZCineCore for the Android app.
+//
+// Hand-written `@_cdecl` shims (not swift-java/jextract — see
+// docs/investigations/android-core-feasibility.md, Phase 1 note) matching the
+// `external fun` declarations in
+// Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCore.kt.
+// Coarse boundary rules apply: strings/byte arrays and primitives only.
+//
+// This file compiles empty on Darwin so `just native-check` is unaffected.
+#if os(Android)
+
+    import CJNI
+    import Foundation
+    import OpenZCineCore
+
+    // MARK: - JNI plumbing
+
+    /// Returns the JNI function table for an env handle.
+    ///
+    /// SAFETY: The JVM always passes a non-nil env with a fully populated
+    /// function table to native methods (JNI spec); the same guarantee applies to
+    /// every function-pointer slot force-unwrapped below.
+    private func table(_ env: UnsafeMutablePointer<JNIEnv?>) -> JNINativeInterface {
+        env.pointee!.pointee
+    }
+
+    /// Converts a Swift string to a JVM-owned `jstring` local reference.
+    private func javaString(
+        _ env: UnsafeMutablePointer<JNIEnv?>, _ value: String
+    ) -> jstring? {
+        value.withCString { table(env).NewStringUTF!(env, $0) }
+    }
+
+    /// Copies a `jstring` into a Swift `String`.
+    private func swiftString(
+        _ env: UnsafeMutablePointer<JNIEnv?>, _ value: jstring?
+    ) -> String? {
+        guard let value,
+            let chars = table(env).GetStringUTFChars!(env, value, nil)
+        else { return nil }
+        defer { table(env).ReleaseStringUTFChars!(env, value, chars) }
+        return String(cString: chars)
+    }
+
+    // MARK: - Info
+
+    /// `SwiftCore.coreVersion(): String` — proves the Swift core is alive in-process.
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_coreVersion")
+    public func swiftCoreVersion(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?
+    ) -> jstring? {
+        #if arch(arm64)
+            let arch = "arm64"
+        #elseif arch(x86_64)
+            let arch = "x86_64"
+        #else
+            let arch = "unknown"
+        #endif
+        return javaString(env, "OpenZCineCore swift-android/\(arch)")
+    }
+
+    // MARK: - Protocol logic
+
+    /// `SwiftCore.deriveAccessPointSSID(cameraName): String?` — real core call:
+    /// PTP friendly name `ZR_6001234` → camera-AP SSID `NIKON_ZR_01234`.
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_deriveAccessPointSSID")
+    public func swiftCoreDeriveAccessPointSSID(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?, cameraName: jstring?
+    ) -> jstring? {
+        guard let name = swiftString(env, cameraName),
+            let ssid = CameraWiFiSSID.deriveSSID(fromCameraName: name)
+        else { return nil }
+        return javaString(env, ssid)
+    }
+
+    /// `SwiftCore.resolveDisplayName(rawName): String` — operator-facing device
+    /// title from the raw PTP name (`ZR_6001234` → `Nikon ZR`).
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_resolveDisplayName")
+    public func swiftCoreResolveDisplayName(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?, rawName: jstring?
+    ) -> jstring? {
+        let name = swiftString(env, rawName) ?? ""
+        let display = ConnectionProgressCopy.resolveDisplayName(
+            rawName: name, savedCamera: nil)
+        return javaString(env, display)
+    }
+
+    // MARK: - Callback / streaming shape
+
+    /// Listener state that crosses to the pushing thread.
+    ///
+    /// The raw pointers are a JNI global reference, a process-wide `jmethodID`,
+    /// and the process-wide `JavaVM*` — all explicitly valid across threads per
+    /// the JNI spec, hence `@unchecked Sendable`.
+    private struct ListenerHandle: @unchecked Sendable {
+        let vm: UnsafeMutablePointer<JavaVM?>
+        let listener: jobject
+        let method: jmethodID
+    }
+
+    /// `SwiftCore.startConnectionDemo(listener)` — registers a Kotlin listener and
+    /// pushes a canned connection-phase sequence from a Swift background thread.
+    /// Proves the callback/streaming pattern (attach thread → upcall → detach)
+    /// that session events and live-view frames will use.
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_startConnectionDemo")
+    public func swiftCoreStartConnectionDemo(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?, listener: jobject?
+    ) {
+        let fns = table(env)
+        var vm: UnsafeMutablePointer<JavaVM?>?
+        guard fns.GetJavaVM!(env, &vm) == JNI_OK, let vm else { return }
+        guard let listener, let global = fns.NewGlobalRef!(env, listener) else { return }
+        guard let cls = fns.GetObjectClass!(env, global),
+            let method = fns.GetMethodID!(
+                env, cls, "onPhase", "(Ljava/lang/String;Ljava/lang/String;)V")
+        else {
+            fns.DeleteGlobalRef!(env, global)
+            return
+        }
+
+        let handle = ListenerHandle(vm: vm, listener: global, method: method)
+        Thread.detachNewThread { pushDemoPhases(handle) }
+    }
+
+    /// Pushes `discovering → handshaking → connected` copy from the core to the
+    /// registered listener, then releases it.
+    private func pushDemoPhases(_ handle: ListenerHandle) {
+        // SAFETY: JavaVM handle and invoke table are JVM-provided and non-nil.
+        let invoke = handle.vm.pointee!.pointee
+        var envOut: UnsafeMutablePointer<JNIEnv?>?
+        guard invoke.AttachCurrentThread!(handle.vm, &envOut, nil) == JNI_OK,
+            let env = envOut
+        else { return }
+        defer { _ = invoke.DetachCurrentThread!(handle.vm) }
+
+        let fns = table(env)
+        defer { fns.DeleteGlobalRef!(env, handle.listener) }
+
+        let phases: [CameraConnectionPhase] = [.discovering, .handshaking, .connected]
+        for phase in phases {
+            let title = ConnectionProgressCopy.statusTitle(phase: phase, isUSB: false)
+            let detail = ConnectionProgressCopy.statusDetail(
+                phase: phase, deviceName: "Nikon ZR", friendlyError: nil)
+            guard let jTitle = javaString(env, title),
+                let jDetail = javaString(env, detail)
+            else { continue }
+            var args = [jvalue(l: jTitle), jvalue(l: jDetail)]
+            fns.CallVoidMethodA!(env, handle.listener, handle.method, &args)
+            fns.DeleteLocalRef!(env, jTitle)
+            fns.DeleteLocalRef!(env, jDetail)
+            Thread.sleep(forTimeInterval: 0.15)
+        }
+    }
+
+#endif

--- a/docs/investigations/android-core-feasibility.md
+++ b/docs/investigations/android-core-feasibility.md
@@ -362,3 +362,14 @@ the artifact is 3.9 MB; the test suite passes on-device unmodified. Caveats carr
 - Do not reintroduce `import FoundationNetworking` into the core — it adds 16 MB, re-links ICU
   transitively, and its static archives are incomplete in the 6.3.3 bundle.
 - swift-java/JNI facade and on-device debugging remain untested (Phase 1 scope, as planned).
+
+### Phase 1 note (2026-07-14) — facade shape decided: manual JNI shims
+
+swift-java/jextract was evaluated first, as planned, and set aside for now: the newest release is
+0.4.2 (2026-06-26, pre-1.0, no API-stability guarantee), and its supporting Java libraries are
+**not published to Maven Central** — consumers must clone swift-java and `./gradlew
+publishToMavenLocal`, which is unacceptable as a build prerequisite for this repo's Gradle CI. For
+a facade of a dozen coarse functions, hand-written `@_cdecl` shims
+(`Sources/OpenZCineAndroidFacade`, importing the NDK's `<jni.h>` through the header-only `CJNI`
+target) cost ~150 lines and zero new dependencies. Revisit jextract when its runtime jars reach
+Maven Central and the API stabilizes; the facade surface is deliberately small enough to migrate.

--- a/justfile
+++ b/justfile
@@ -192,6 +192,43 @@ android-keystore:
     echo "  3. Local signed build: export ANDROID_KEYSTORE_PATH=\"\$PWD/$out\" plus the three vars above,"
     echo "     then: cd Apps/Android && ./gradlew bundleRelease"
 
+# Cross-compile the shared Swift core + JNI facade for Android (arm64) and stage the
+# .so set into Apps/Android/app/src/main/jniLibs/ (gitignored build artifacts — never
+# committed; APKs that need the Swift core must run this first, see Apps/Android/README.md).
+# Requires the swiftly 6.3.3 toolchain + swift-6.3.3-RELEASE_android artifactbundle
+# (setup + verified invocation: docs/investigations/android-core-feasibility.md addendum).
+# ponytail: arm64-only — no x86_64 device/emulator in play; add a second ABI loop when one is.
+android-core:
+    #!/usr/bin/env bash
+    set -eo pipefail
+    TRIPLE=aarch64-unknown-linux-android28
+    BUNDLE="$HOME/Library/org.swift.swiftpm/swift-sdks/swift-6.3.3-RELEASE_android.artifactbundle/swift-android"
+    RUNTIME="$BUNDLE/swift-resources/usr/lib/swift-aarch64/android"
+    NDKLIB="$BUNDLE/ndk-sysroot/usr/lib/aarch64-linux-android"
+    TC="$HOME/Library/Developer/Toolchains/swift-6.3.3-RELEASE.xctoolchain/usr/bin"
+    OUT="Apps/Android/app/src/main/jniLibs/arm64-v8a"
+    swiftly run swift build +6.3.3 --swift-sdk "$TRIPLE" -c release --product OpenZCineAndroid
+    rm -rf "$OUT" && mkdir -p "$OUT"
+    "$TC/llvm-objcopy" --strip-all ".build/$TRIPLE/release/libOpenZCineAndroid.so" "$OUT/libOpenZCineAndroid.so"
+    # Stage the transitive NEEDED closure from the artifactbundle runtime; deps that
+    # resolve in neither directory are bionic system libs already on the device.
+    # ponytail: fixpoint rescan is O(n^2) over ~15 libs — fine at this scale.
+    changed=1
+    while [ "$changed" = 1 ]; do
+        changed=0
+        for lib in "$OUT"/*.so; do
+            for dep in $("$TC/llvm-objdump" -p "$lib" | awk '/NEEDED/{print $2}'); do
+                if [ ! -e "$OUT/$dep" ]; then
+                    if [ -e "$RUNTIME/$dep" ]; then cp "$RUNTIME/$dep" "$OUT/$dep"; changed=1
+                    elif [ -e "$NDKLIB/$dep" ]; then cp "$NDKLIB/$dep" "$OUT/$dep"; changed=1
+                    fi
+                fi
+            done
+        done
+    done
+    ls -l "$OUT" | awk 'NR>1 {printf "%8.1f MB  %s\n", $5/1048576, $9}'
+    echo "Staged $(ls "$OUT" | wc -l | tr -d ' ') libraries → $OUT"
+
 # Build and install the debug APK on a connected device/emulator, then launch it.
 # With several devices attached, pass the serial: `just android-install R58R92BL76K`.
 android-install serial="":


### PR DESCRIPTION
Phase 1 of the Android epic, part of #52. Bridges the shared Swift core into the Android app over JNI:

- **Android-only facade** (`Sources/OpenZCineAndroidFacade`, `#if os(Android)`) over `Sources/OpenZCineCore` via hand-written `@_cdecl` shims — swift-java/jextract evaluated and deferred (pre-1.0, runtime jars not on Maven Central; revisit condition documented in the feasibility doc's Phase 1 note). Header-only `CJNI` target exposes the NDK's `<jni.h>`; both targets compile empty on Darwin.
- **`just android-core`**: cross-compiles the core for arm64 with the Swift-on-Android toolchain, strips, resolves the transitive `.so` closure, and stages it into gitignored `jniLibs/` (core+facade = 4.0 MB; full runtime ~82 MB pending the known ICU trim, tracked as later size work).
- **Kotlin `SwiftCore` binding** + debug-only smoke check.

Device-verified on an SM-A127F — the Swift core answering inside the Android app:

```
SwiftCoreSmoke: core: OpenZCineCore swift-android/arm64
SwiftCoreSmoke: ssid(ZR_6001234): NIKON_ZR_01234
SwiftCoreSmoke: displayName(ZR_6001234): Nikon ZR
SwiftCoreSmoke: phase: Searching… — Looking for Nikon ZR on your network.
SwiftCoreSmoke: phase: Connecting… — Establishing a secure link with Nikon ZR.
SwiftCoreSmoke: phase: Connected — Nikon ZR is ready.
```

The three phase lines are listener callbacks delivered from a Swift background thread (attach/upcall/detach) — the exact pattern session events and live-view frames will use.

Darwin unchanged: `just check`, `just native-check` (650 tests), `just android-check` all green. CI cross-compilation is a named follow-up (swift-android-action).

Kaneo: OPE-10 (Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
