### PR TITLE
feat(android): bring the core PTP-IP session layer to Android through the facade

### DIFF
--- a/Apps/Android/README.md
+++ b/Apps/Android/README.md
@@ -19,4 +19,14 @@ Production Jetpack Compose shell — early scaffold. One placeholder monitor scr
   settle-then-backoff reconnect). PTP-IP protocol/session logic arrives behind the JNI facade;
   this layer is bytes only. Debug hook to try it live:
   `adb shell am start -n com.opencapture.openzcine/.MainActivity --ez openzcine.nsdTransport true`.
+- **Camera session (Swift core):** `bridge/SwiftCoreCameraSession` implements the `CameraSession`
+  seam over the Swift core's PTP-IP session layer
+  (`Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift`): Init handshake, the Nikon
+  open/pair/identify sequence, core-decoded property reads, and graceful `CloseSession` teardown
+  all run inside the `.so` — the facade owns the session sockets (decision record: the feasibility
+  doc's "Where sockets go"). Point the debug probe at a camera or fake server:
+  `adb shell am start -n com.opencapture.openzcine/.MainActivity --es zc.session.host <ipv4>`
+  (logcat tag `SwiftCoreCameraSession`). For a fake-ZR server on the development Mac (scripted
+  twin: `Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift`), forward the port with
+  `adb reverse tcp:15740 tcp:15740` and use host `127.0.0.1`.
 - **Local SDK:** put `sdk.dir=<your Android SDK path>` in `Apps/Android/local.properties` (gitignored).

--- a/Apps/Android/app/src/debug/kotlin/com/opencapture/openzcine/DemoHarness.kt
+++ b/Apps/Android/app/src/debug/kotlin/com/opencapture/openzcine/DemoHarness.kt
@@ -1,6 +1,7 @@
 package com.opencapture.openzcine
 
 import android.content.Intent
+import com.opencapture.openzcine.bridge.SwiftCoreSessionProbe
 import com.opencapture.openzcine.core.CameraIdentity
 import com.opencapture.openzcine.core.CameraSession
 import com.opencapture.openzcine.core.FakeCameraSession
@@ -23,9 +24,13 @@ object DemoHarness {
 
     /**
      * A demo session + synthetic 25 fps frame source when [intent] carries
-     * [EXTRA_DEMO_FEED]; null in a normal launch.
+     * [EXTRA_DEMO_FEED]; null in a normal launch. Also the debug intent entry
+     * point for the Swift-core session probe (`zc.session.host` — see
+     * [SwiftCoreSessionProbe]), which runs as a logcat side effect without
+     * replacing the shell's session.
      */
     fun demoLiveFeed(intent: Intent): Pair<CameraSession, LiveFrameSource>? {
+        SwiftCoreSessionProbe.maybeStart(intent)
         if (!intent.getBooleanExtra(EXTRA_DEMO_FEED, false)) return null
         val session =
             FakeCameraSession(

--- a/Apps/Android/app/src/debug/kotlin/com/opencapture/openzcine/bridge/SwiftCoreSessionProbe.kt
+++ b/Apps/Android/app/src/debug/kotlin/com/opencapture/openzcine/bridge/SwiftCoreSessionProbe.kt
@@ -1,0 +1,65 @@
+package com.opencapture.openzcine.bridge
+
+import android.content.Intent
+import android.util.Log
+import com.opencapture.openzcine.core.CameraSessionState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+/**
+ * Debug-only end-to-end session probe: connects [SwiftCoreCameraSession] to a
+ * camera (or fake-ZR server), reads real properties through the Swift core,
+ * and disconnects gracefully — the whole run logged under the
+ * `SwiftCoreCameraSession` logcat tag.
+ *
+ * Point it at a host:
+ * ```
+ * adb shell am start -n com.opencapture.openzcine/.MainActivity --es zc.session.host 192.168.1.1
+ * ```
+ * For a fake-ZR server on the development Mac, forward the PTP-IP port first:
+ * `adb reverse tcp:15740 tcp:15740`, then use host `127.0.0.1`.
+ */
+object SwiftCoreSessionProbe {
+    private const val TAG = "SwiftCoreCameraSession"
+
+    /** String intent extra carrying the camera host for the probe. */
+    const val EXTRA_SESSION_HOST = "zc.session.host"
+
+    /** Starts the probe when [intent] carries [EXTRA_SESSION_HOST]; no-op otherwise. */
+    fun maybeStart(intent: Intent) {
+        val host = intent.getStringExtra(EXTRA_SESSION_HOST) ?: return
+        if (!SwiftCore.isAvailable) {
+            Log.w(TAG, "libOpenZCineAndroid.so not bundled — run `just android-core` first")
+            return
+        }
+        CoroutineScope(Dispatchers.IO).launch { run(host) }
+    }
+
+    private suspend fun run(host: String) {
+        Log.i(TAG, "probe: connecting to $host")
+        val session =
+            SwiftCoreCameraSession(host) { phase, detail ->
+                Log.i(TAG, "phase: $phase${if (detail.isEmpty()) "" else " — $detail"}")
+            }
+        session.connect()
+
+        val state = session.state.value
+        if (state !is CameraSessionState.Connected) {
+            Log.w(TAG, "probe: connect failed — state=$state")
+            return
+        }
+        Log.i(
+            TAG,
+            "connected: ${state.identity.name} model=${state.identity.model} " +
+                "serial=${state.identity.serialNumber}",
+        )
+        val battery = session.readProperty(SwiftCore.PROP_BATTERY_LEVEL)
+        Log.i(TAG, "battery: ${battery ?: "<no answer>"}%")
+        val recording = session.readProperty(SwiftCore.PROP_MOVIE_REC_PROHIBITION)
+        Log.i(TAG, "recProhibition: ${recording ?: "<no answer>"} (0x0 = recordable)")
+
+        session.disconnect()
+        Log.i(TAG, "disconnected (graceful CloseSession)")
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCore.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCore.kt
@@ -47,4 +47,52 @@ object SwiftCore {
      * and live-view frames will use.
      */
     external fun startConnectionDemo(listener: ConnectionPhaseListener)
+
+    // ── Camera session (PTP-IP protocol/session layer in the Swift core) ──
+
+    /** Receives session lifecycle callbacks pushed from Swift (non-main thread). */
+    interface SessionListener {
+        /**
+         * Progress update. [phase] is a stable machine-readable name mirroring
+         * the core's `CameraConnectionPhase` (`handshaking`, `pairing`,
+         * `confirmOnCamera`, `connected`); [detail] carries the pairing PIN on
+         * `confirmOnCamera` and the display name on `connected`.
+         */
+        fun onPhase(phase: String, detail: String)
+
+        /** Terminal success: the PTP session is open and the camera identified. */
+        fun onConnected(name: String, model: String, serialNumber: String)
+
+        /** Terminal failure with an operator-facing message. */
+        fun onFailed(message: String)
+    }
+
+    /** MTP BatteryLevel (0x5001) — UINT8 percentage. */
+    const val PROP_BATTERY_LEVEL: Int = 0x5001
+
+    /** Nikon MovieRecProhibitionCondition (0xD0A4) — 0 means recording is allowed. */
+    const val PROP_MOVIE_REC_PROHIBITION: Int = 0xD0A4
+
+    /**
+     * Connects to the camera at [host] (numeric IPv4, port 15740): PTP-IP Init
+     * handshake on both channels, then the Nikon open/pair/identify sequence,
+     * all inside the Swift core's session layer. Returns immediately; progress
+     * and the terminal result arrive on [listener] from a background thread.
+     */
+    external fun sessionConnect(host: String, listener: SessionListener)
+
+    /**
+     * Reads one camera property through the active session, decoded by the
+     * Swift core (battery → percent string, others → raw hex). Null when no
+     * session is active or the camera rejected the read. Blocking — call from
+     * a background dispatcher.
+     */
+    external fun sessionReadProperty(code: Int): String?
+
+    /**
+     * Gracefully tears down the active session: best-effort `CloseSession` so
+     * the camera frees its connection slot, then both sockets. Blocking
+     * (bounded ~2 s) — call from a background dispatcher. Safe when idle.
+     */
+    external fun sessionDisconnect()
 }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSession.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSession.kt
@@ -1,0 +1,78 @@
+package com.opencapture.openzcine.bridge
+
+import com.opencapture.openzcine.core.CameraIdentity
+import com.opencapture.openzcine.core.CameraSession
+import com.opencapture.openzcine.core.CameraSessionState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+
+/**
+ * Production [CameraSession] backed by the shared Swift core's PTP-IP
+ * protocol/session layer over JNI: connect drives the Init handshake plus the
+ * Nikon open/pair/identify sequence inside the `.so`, and property reads are
+ * decoded by the core's codecs. This class is only state plumbing — no
+ * protocol logic lives on the Kotlin side.
+ *
+ * @property host Numeric IPv4 camera address (from NSD discovery, the fixed
+ *   camera-AP host, or a debug intent extra).
+ * @property phaseLogger Optional sink for progress phases (name + detail),
+ *   e.g. logcat in the debug probe. Called on a background thread.
+ */
+class SwiftCoreCameraSession(
+    private val host: String,
+    private val phaseLogger: (String, String) -> Unit = { _, _ -> },
+) : CameraSession {
+    private val _state = MutableStateFlow<CameraSessionState>(CameraSessionState.Disconnected)
+    override val state: StateFlow<CameraSessionState> = _state.asStateFlow()
+
+    /**
+     * Connects and suspends until the session is [CameraSessionState.Connected]
+     * or back at [CameraSessionState.Disconnected]. A missing native library
+     * (APK built without `just android-core`) stays disconnected without
+     * crashing.
+     */
+    override suspend fun connect() {
+        if (!SwiftCore.isAvailable) return
+        if (_state.value !is CameraSessionState.Disconnected) return
+        _state.value = CameraSessionState.Connecting
+        SwiftCore.sessionConnect(
+            host,
+            object : SwiftCore.SessionListener {
+                override fun onPhase(phase: String, detail: String) = phaseLogger(phase, detail)
+
+                override fun onConnected(name: String, model: String, serialNumber: String) {
+                    _state.value =
+                        CameraSessionState.Connected(CameraIdentity(name, model, serialNumber))
+                }
+
+                override fun onFailed(message: String) {
+                    phaseLogger("failed", message)
+                    _state.value = CameraSessionState.Disconnected
+                }
+            },
+        )
+        _state.first { it !is CameraSessionState.Connecting }
+    }
+
+    /**
+     * Reads one camera property (see `SwiftCore.PROP_*`), decoded by the Swift
+     * core. Null until connected or when the camera rejects the read.
+     */
+    suspend fun readProperty(code: Int): String? =
+        if (_state.value is CameraSessionState.Connected) {
+            withContext(Dispatchers.IO) { SwiftCore.sessionReadProperty(code) }
+        } else {
+            null
+        }
+
+    override suspend fun disconnect() {
+        if (SwiftCore.isAvailable) {
+            withContext(Dispatchers.IO) { SwiftCore.sessionDisconnect() }
+        }
+        _state.value = CameraSessionState.Disconnected
+    }
+}

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSessionTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSessionTest.kt
@@ -1,0 +1,46 @@
+package com.opencapture.openzcine.bridge
+
+import com.opencapture.openzcine.core.CameraSessionState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.test.runTest
+
+/**
+ * JVM-side behavior only: the native library is never present in unit tests
+ * (`SwiftCore.isAvailable` is false), so these cover the guard paths — the
+ * wire behavior itself is tested in Swift against the fake ZR
+ * (`Tests/OpenZCineAndroidFacadeTests`).
+ */
+class SwiftCoreCameraSessionTest {
+    @Test
+    fun `starts disconnected`() {
+        assertEquals(
+            CameraSessionState.Disconnected,
+            SwiftCoreCameraSession("192.168.1.1").state.value,
+        )
+    }
+
+    @Test
+    fun `connect without the native core stays disconnected and does not crash`() = runTest {
+        val session = SwiftCoreCameraSession("192.168.1.1")
+
+        session.connect()
+
+        assertEquals(CameraSessionState.Disconnected, session.state.value)
+    }
+
+    @Test
+    fun `readProperty is null while disconnected`() = runTest {
+        assertNull(SwiftCoreCameraSession("192.168.1.1").readProperty(SwiftCore.PROP_BATTERY_LEVEL))
+    }
+
+    @Test
+    fun `disconnect while disconnected is safe`() = runTest {
+        val session = SwiftCoreCameraSession("192.168.1.1")
+
+        session.disconnect()
+
+        assertEquals(CameraSessionState.Disconnected, session.state.value)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -39,5 +39,12 @@ let package = Package(
             name: "OpenZCineAndroidFacade",
             dependencies: ["OpenZCineCore", "CJNI"]
         ),
+        // Exercises the facade's PTP-IP session layer against a scripted fake
+        // camera server; runs on Darwin (and on Android via the cross-compile
+        // test path from the feasibility experiment).
+        .testTarget(
+            name: "OpenZCineAndroidFacadeTests",
+            dependencies: ["OpenZCineAndroidFacade", "OpenZCineCore"]
+        ),
     ]
 )

--- a/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
+++ b/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
@@ -1,0 +1,630 @@
+// PTP-IP protocol/session layer for the Android facade.
+//
+// Socket-ownership decision: the sockets live HERE, in Swift, inside the facade
+// target — not in Kotlin. AGENTS.md says platform adapters own sockets, and on
+// Android the facade *is* the platform adapter: routing every PTP-IP packet
+// Kotlin↔Swift over JNI would put several JNI round trips on each transaction
+// (and per live-view frame later), while the core deliberately exposes a
+// transaction-level `CameraTransport` boundary rather than a packet-pump engine.
+// This mirrors `ios/Runner/PTPIPTransport.swift` + `NativeCameraSession.swift`
+// (the iOS shell's twin of this file) with the same core codecs underneath;
+// the Kotlin side sees only coarse connect / read-property / disconnect calls.
+// See docs/investigations/android-core-feasibility.md ("Where sockets go").
+//
+// Everything below is adapter glue over `OpenZCineCore`: packet framing,
+// handshake payloads, transaction collection, property decoding, and pairing
+// policies all come from the core. This file compiles on Darwin too, so the
+// fake-camera tests in `Tests/OpenZCineAndroidFacadeTests` exercise the exact
+// bytes-on-the-wire behavior that ships in the Android `.so`.
+
+import Foundation
+import OpenZCineCore
+
+#if canImport(Android)
+    import Android
+#elseif canImport(Glibc)
+    import Glibc
+#elseif canImport(Darwin)
+    import Darwin
+#endif
+
+/// Errors surfaced by the facade's PTP-IP session layer.
+public enum PTPIPClientSessionError: Error, LocalizedError, Equatable {
+    case connectionFailed(String)
+    case connectionClosed
+    case timeout(String)
+    case unexpectedPacket(expected: String, actual: PTPIPPacketType)
+    case initFailed(PTPIPInitFailReason)
+    case operationRejected(PTPOperationCode, PTPResponseCode)
+    case invalidPacketLength(UInt32)
+    case pairingChallengeUnavailable
+    case appControlUnavailable
+    case unsupportedProperty(UInt32)
+
+    public var errorDescription: String? {
+        switch self {
+        case .connectionFailed(let message):
+            return message
+        case .connectionClosed:
+            return "The camera closed the connection."
+        case .timeout(let label):
+            return "\(label) timed out."
+        case .unexpectedPacket(let expected, let actual):
+            return "Expected \(expected), got PTP-IP packet \(actual.rawValue)."
+        case .initFailed(let reason):
+            return "The camera rejected the PTP-IP handshake: \(reason)."
+        case .operationRejected(let operation, let response):
+            return "Camera rejected \(operation) with response \(response)."
+        case .invalidPacketLength(let length):
+            return "Invalid PTP-IP packet length \(length)."
+        case .pairingChallengeUnavailable:
+            return
+                "The camera did not provide a pairing code. Restart Connect to Smart Device on the camera, then pair again."
+        case .appControlUnavailable:
+            return "The camera did not open app-control mode after pairing."
+        case .unsupportedProperty(let code):
+            return "Property 0x\(PTPIPClientSession.hexString(code)) is not known to the core."
+        }
+    }
+}
+
+/// Camera identity assembled from the Init handshake plus `GetDeviceInfo`.
+public struct PTPIPClientIdentity: Equatable, Sendable {
+    public let cameraName: String
+    public let manufacturer: String
+    public let model: String
+    public let deviceVersion: String
+    public let serialNumber: String
+
+    /// Operator-facing camera title, resolved by the core's shared naming policy.
+    public var displayName: String {
+        CameraDisplayNamePolicy.displayName(
+            cameraName: cameraName,
+            manufacturer: manufacturer,
+            model: model
+        )
+    }
+}
+
+/// A synchronous PTP-IP camera session: two TCP sockets (command + event) to
+/// port 15740, the CIPA DC-005 Init handshake, and the Nikon open/pair/identify
+/// sequence — the Android twin of `NativeCameraSession.establish`.
+///
+/// Blocking by design: JNI entry points arrive on JVM threads (Kotlin drives
+/// them from `Dispatchers.IO`), so the Dispatch/async machinery the iOS shell
+/// needs has no job here. All transactions are serialized on `transactionLock`.
+// SAFETY: `@unchecked Sendable` — `nextTransactionID` and socket I/O are only
+// touched inside transactions serialized by `transactionLock`.
+public final class PTPIPClientSession: @unchecked Sendable {
+    private let command: PosixTCPSocket
+    private let event: PosixTCPSocket
+    private let transactionLock = NSLock()
+    private var nextTransactionID: UInt32 = 1
+    private var isClosed = false
+
+    /// Camera identity resolved during `connect`. Written once by
+    /// `identify()` during establishment, before the session escapes to
+    /// callers, so reads never race the write.
+    public private(set) var identity: PTPIPClientIdentity
+
+    private init(command: PosixTCPSocket, event: PosixTCPSocket, identity: PTPIPClientIdentity) {
+        self.command = command
+        self.event = event
+        self.identity = identity
+    }
+
+    // MARK: - Connect
+
+    /// Connects, handshakes, and establishes an app-control PTP session.
+    ///
+    /// Mirrors the iOS shell's connection strategy: first a quiet saved-profile
+    /// attempt (OpenSession → ChangeApplicationMode); when the camera refuses
+    /// app control, the link is torn down gracefully and re-established with
+    /// the first-time pairing sequence (GetPairingInfo poll → ConfirmPairing).
+    /// Progress is pushed through `onPhase` (`.handshaking`, `.pairing`,
+    /// `.confirmOnCamera` with the PIN as detail, `.connected`).
+    public static func connect(
+        host: String,
+        port: UInt16 = UInt16(ptpIPPort),
+        guid: Data = PTPIPInitiator.appGUID,
+        friendlyName: String = PTPIPInitiator.friendlyName,
+        timeoutMilliseconds: Int32 = 10_000,
+        onPhase: (CameraConnectionPhase, String) -> Void = { _, _ in }
+    ) throws -> PTPIPClientSession {
+        onPhase(.handshaking, "")
+        let probe = try establishLink(
+            host: host, port: port, guid: guid, friendlyName: friendlyName,
+            timeoutMilliseconds: timeoutMilliseconds)
+        do {
+            try probe.openSession()
+            if try probe.enableAppControl() {
+                try probe.identify()
+                onPhase(.connected, probe.identity.displayName)
+                return probe
+            }
+        } catch {
+            probe.disconnect()
+            throw error
+        }
+        // Saved profile unavailable — release the slot gracefully and pair fresh,
+        // exactly like the iOS shell's savedProfile → firstTimePairing fallback.
+        probe.disconnect()
+
+        onPhase(.pairing, "")
+        let pairing = try establishLink(
+            host: host, port: port, guid: guid, friendlyName: friendlyName,
+            timeoutMilliseconds: timeoutMilliseconds)
+        do {
+            try pairing.openSession()
+            let challenge = try pairing.waitForPairingChallenge()
+            onPhase(.confirmOnCamera, challenge.pin ?? "")
+            try pairing.transactExpectingOK(
+                .confirmPairing, parameters: [PTPIPSessionScript.pairingConfirmValue])
+            guard try pairing.enableAppControl() else {
+                throw PTPIPClientSessionError.appControlUnavailable
+            }
+            try pairing.identify()
+            onPhase(.connected, pairing.identity.displayName)
+            return pairing
+        } catch {
+            pairing.disconnect()
+            throw error
+        }
+    }
+
+    /// Opens both TCP channels and runs the PTP-IP Init handshake; returns a
+    /// session whose identity carries only the handshake camera name so far.
+    private static func establishLink(
+        host: String,
+        port: UInt16,
+        guid: Data,
+        friendlyName: String,
+        timeoutMilliseconds: Int32
+    ) throws -> PTPIPClientSession {
+        let command = PosixTCPSocket(
+            host: host, port: port, label: "command", timeoutMilliseconds: timeoutMilliseconds)
+        let event = PosixTCPSocket(
+            host: host, port: port, label: "event", timeoutMilliseconds: timeoutMilliseconds)
+        do {
+            try command.open()
+            let initRequest = try PTPIPInitCommandRequest(guid: guid, friendlyName: friendlyName)
+            try command.send(
+                PTPIPPacket(type: .initCommandRequest, payload: Data(initRequest.payloadBytes)))
+            let initReply = try command.readPacket()
+            if initReply.type == .initFail {
+                let fail = try PTPIPInitFail(payloadBytes: Array(initReply.payload))
+                throw PTPIPClientSessionError.initFailed(fail.reason)
+            }
+            guard initReply.type == .initCommandAck else {
+                throw PTPIPClientSessionError.unexpectedPacket(
+                    expected: "Init_Command_Ack", actual: initReply.type)
+            }
+            let ack = try PTPIPInitCommandAck(payloadBytes: Array(initReply.payload))
+
+            try event.open()
+            try event.send(
+                PTPIPPacket(
+                    type: .initEventRequest,
+                    payload: Data(
+                        PTPIPInitEventRequest(connectionNumber: ack.connectionNumber).payloadBytes))
+            )
+            let eventReply = try event.readPacket()
+            guard eventReply.type == .initEventAck else {
+                throw PTPIPClientSessionError.unexpectedPacket(
+                    expected: "Init_Event_Ack", actual: eventReply.type)
+            }
+
+            let identity = PTPIPClientIdentity(
+                cameraName: ack.cameraName ?? "Nikon camera",
+                manufacturer: "", model: "", deviceVersion: "", serialNumber: "")
+            return PTPIPClientSession(command: command, event: event, identity: identity)
+        } catch {
+            command.close()
+            event.close()
+            throw error
+        }
+    }
+
+    // MARK: - Session sequence steps
+
+    private func openSession() throws {
+        let open = try executeTransaction(.openSession, transactionID: 0, parameters: [1])
+        let response = open.operationResponse.responseCode
+        guard response == .ok || response == .sessionAlreadyOpen else {
+            throw PTPIPClientSessionError.operationRejected(.openSession, response)
+        }
+    }
+
+    /// Nikon app-control gate. `true` when the camera accepted app control —
+    /// `false` routes the caller to first-time pairing (core probe policy).
+    private func enableAppControl() throws -> Bool {
+        let appMode = try executeTransaction(.changeApplicationMode, parameters: [1])
+        return PTPIPSavedProfileProbePolicy.resolve(
+            applicationModeResponse: appMode.operationResponse.responseCode) == .accepted
+    }
+
+    /// Polls `GetPairingInfo` until the camera produces a pairing challenge,
+    /// with the same cadence as the iOS shell (10 attempts, 250 ms apart).
+    private func waitForPairingChallenge() throws -> PTPIPPairingChallenge {
+        for _ in 1...10 {
+            if let pairInfo = try? executeTransaction(.getPairingInfo, dataPhase: .dataIn),
+                PTPIPPairingInfoPolicy.resolve(
+                    response: pairInfo.operationResponse.responseCode,
+                    byteCount: pairInfo.data.count) == .promptUser
+            {
+                return PTPIPPairingChallenge(data: pairInfo.data, cameraName: identity.cameraName)
+            }
+            Thread.sleep(forTimeInterval: 0.25)
+        }
+        throw PTPIPClientSessionError.pairingChallengeUnavailable
+    }
+
+    /// Runs `GetDeviceInfo` and fills in the full identity — in place, so the
+    /// session's transaction-ID sequence keeps counting (a fresh instance here
+    /// once restarted IDs mid-session, which a real body may reject).
+    private func identify() throws {
+        let info = try transactExpectingOK(.getDeviceInfo, dataPhase: .dataIn)
+        let deviceInfo = try PTPDeviceInfo(data: info.data)
+        identity = PTPIPClientIdentity(
+            cameraName: identity.cameraName.isEmpty ? deviceInfo.model : identity.cameraName,
+            manufacturer: deviceInfo.manufacturer,
+            model: deviceInfo.model,
+            deviceVersion: deviceInfo.deviceVersion,
+            serialNumber: deviceInfo.serialNumber)
+    }
+
+    // MARK: - Properties
+
+    /// Reads one camera property (`GetDevicePropValueEx`) and returns its raw bytes.
+    public func readProperty(_ property: PTPPropertyCode) throws -> Data {
+        try transactExpectingOK(
+            .getDevicePropValueEx, parameters: [property.rawValue], dataPhase: .dataIn
+        ).data
+    }
+
+    /// Reads a property and decodes it through the core: battery level comes
+    /// back as a percentage string (`"80"`), anything else as the raw
+    /// little-endian value in hex (`"0x0"`) until its decoder is wired up.
+    public func readPropertyDisplayValue(code: UInt32) throws -> String {
+        guard let property = PTPPropertyCode(rawValue: code) else {
+            throw PTPIPClientSessionError.unsupportedProperty(code)
+        }
+        let data = try readProperty(property)
+        let snapshot = PTPCameraPropertySnapshot().applying(property: property, data: data)
+        if property == .batteryLevel, let percent = snapshot.batteryPercent {
+            return "\(percent)"
+        }
+        // ponytail: generic hex fallback — per-property display decoding grows
+        // with the monitor UI slice; the raw value is what HW validation needs.
+        var value: UInt64 = 0
+        for byte in Array(data).prefix(8).reversed() {
+            value = value << 8 | UInt64(byte)
+        }
+        return "0x\(Self.hexString(value))"
+    }
+
+    // MARK: - Teardown
+
+    /// Graceful teardown: best-effort `CloseSession` so the camera releases its
+    /// session slot immediately, THEN drop both sockets — the same semantics as
+    /// the iOS reconnect-wedge fix (`NativeCameraSession.shutdown`). Bounded:
+    /// the read timeout is dropped to 2 s first, so a dead link cannot stall
+    /// teardown. Safe to call more than once.
+    public func disconnect() {
+        transactionLock.lock()
+        let alreadyClosed = isClosed
+        isClosed = true
+        transactionLock.unlock()
+        guard !alreadyClosed else { return }
+
+        command.timeoutMilliseconds = 2_000
+        _ = try? executeTransaction(.closeSession)
+        command.close()
+        event.close()
+    }
+
+    // MARK: - Transaction executor
+
+    @discardableResult
+    private func transactExpectingOK(
+        _ operationCode: PTPOperationCode,
+        parameters: [UInt32] = [],
+        dataPhase: PTPDataPhase = .noDataOrDataIn
+    ) throws -> PTPIPTransactionResult {
+        let result = try executeTransaction(
+            operationCode, parameters: parameters, dataPhase: dataPhase)
+        guard result.operationResponse.responseCode == .ok else {
+            throw PTPIPClientSessionError.operationRejected(
+                operationCode, result.operationResponse.responseCode)
+        }
+        return result
+    }
+
+    /// Executes one full PTP transaction on the command channel: request out,
+    /// then packets in until `Operation_Response`, collected by the core.
+    // ponytail: read-only slice — the host→camera data-out phase arrives with
+    // property writes; nothing in connect/read/disconnect needs it.
+    private func executeTransaction(
+        _ operationCode: PTPOperationCode,
+        transactionID explicitTransactionID: UInt32? = nil,
+        parameters: [UInt32] = [],
+        dataPhase: PTPDataPhase = .noDataOrDataIn
+    ) throws -> PTPIPTransactionResult {
+        transactionLock.lock()
+        defer { transactionLock.unlock() }
+
+        let transactionID = explicitTransactionID ?? nextTransactionID
+        if explicitTransactionID == nil {
+            nextTransactionID += 1
+        }
+        let request = PTPOperationRequest(
+            dataPhase: dataPhase,
+            operationCode: operationCode,
+            transactionID: transactionID,
+            parameters: parameters)
+        try command.send(
+            PTPIPPacket(type: .operationRequest, payload: Data(request.payloadBytes)))
+
+        var packets: [PTPIPPacket] = []
+        while true {
+            let packet = try command.readPacket()
+            packets.append(packet)
+            if packet.type == .operationResponse {
+                return try PTPIPTransactionCollector().collect(from: packets)
+            }
+            // Same desync guard as the iOS transport: a stream that never sends
+            // operationResponse must not grow `packets` forever.
+            guard packets.count <= 512 else {
+                throw PTPIPClientSessionError.connectionFailed(
+                    "PTP-IP transaction exceeded 512 packets without a response — stream desynchronized."
+                )
+            }
+        }
+    }
+
+    /// Uppercase hex without `String(format:)` (which drags umbrella Foundation
+    /// on Android — see the feasibility doc's ICU finding).
+    static func hexString<Value: BinaryInteger>(_ value: Value) -> String {
+        String(value, radix: 16, uppercase: true)
+    }
+}
+
+/// A blocking POSIX TCP socket with poll-bounded I/O — the facade twin of the
+/// iOS shell's `PTPIPSocket`, minus the Dispatch queue (callers here are plain
+/// JVM/test threads). Compiles against Darwin, Glibc, and bionic libc.
+// SAFETY: `@unchecked Sendable` — the descriptor is guarded by `descriptorLock`;
+// I/O is serialized by the owning session's transaction lock.
+final class PosixTCPSocket: @unchecked Sendable {
+    init(host: String, port: UInt16, label: String, timeoutMilliseconds: Int32) {
+        self.host = host
+        self.port = port
+        self.label = label
+        self.timeoutMilliseconds = timeoutMilliseconds
+    }
+
+    private let host: String
+    private let port: UInt16
+    private let label: String
+    /// Per-poll timeout; mutable so teardown can shorten it (see `disconnect`).
+    var timeoutMilliseconds: Int32
+    private let descriptorLock = NSLock()
+    private var descriptor: Int32 = -1
+    private var readBuffer = PTPIPReadBuffer()
+
+    func open() throws {
+        close()
+
+        var address = sockaddr_in()
+        #if canImport(Darwin)
+            address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        #endif
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = in_port_t(port).bigEndian
+        guard inet_pton(AF_INET, host, &address.sin_addr) == 1 else {
+            throw PTPIPClientSessionError.connectionFailed(
+                "Enter a numeric IPv4 camera address. Host names are not supported yet.")
+        }
+
+        let newDescriptor = socket(AF_INET, SOCK_STREAM, Int32(IPPROTO_TCP))
+        guard newDescriptor >= 0 else {
+            throw socketError(errno, context: "\(label) socket")
+        }
+        storeDescriptor(newDescriptor)
+
+        var noDelay: Int32 = 1
+        setsockopt(
+            newDescriptor, Int32(IPPROTO_TCP), TCP_NODELAY, &noDelay,
+            socklen_t(MemoryLayout<Int32>.size))
+        #if canImport(Darwin)
+            var noSigPipe: Int32 = 1
+            setsockopt(
+                newDescriptor, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe,
+                socklen_t(MemoryLayout<Int32>.size))
+        #endif
+        // ponytail: the iOS twin's keepalive timer tuning arrives with the
+        // Android reconnect machinery — connect/read/disconnect doesn't idle.
+
+        let flags = fcntl(newDescriptor, F_GETFL, 0)
+        if flags >= 0 {
+            _ = fcntl(newDescriptor, F_SETFL, flags | O_NONBLOCK)
+        }
+
+        let connectResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                connect(newDescriptor, socketAddress, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        if connectResult != 0 {
+            let code = errno
+            guard code == EINPROGRESS else {
+                close()
+                throw socketError(code, context: "\(label) connection")
+            }
+            try waitForDescriptor(
+                newDescriptor, events: Int16(POLLOUT), label: "\(label) connection")
+
+            var connectError: Int32 = 0
+            var connectErrorLength = socklen_t(MemoryLayout<Int32>.size)
+            guard
+                getsockopt(newDescriptor, SOL_SOCKET, SO_ERROR, &connectError, &connectErrorLength)
+                    == 0
+            else {
+                close()
+                throw socketError(errno, context: "\(label) connection")
+            }
+            guard connectError == 0 else {
+                close()
+                throw socketError(connectError, context: "\(label) connection")
+            }
+        }
+    }
+
+    func close() {
+        descriptorLock.lock()
+        let descriptorToClose = descriptor
+        descriptor = -1
+        descriptorLock.unlock()
+
+        if descriptorToClose >= 0 {
+            shutdown(descriptorToClose, Int32(SHUT_RDWR))
+            #if canImport(Android)
+                Android.close(descriptorToClose)
+            #elseif canImport(Glibc)
+                Glibc.close(descriptorToClose)
+            #else
+                Darwin.close(descriptorToClose)
+            #endif
+        }
+    }
+
+    func send(_ packet: PTPIPPacket) throws {
+        let data = Data(packet.serializedBytes)
+        let descriptor = try currentDescriptor()
+        #if canImport(Darwin)
+            let sendFlags: Int32 = 0
+        #else
+            let sendFlags = Int32(MSG_NOSIGNAL)
+        #endif
+        var offset = 0
+        try data.withUnsafeBytes { rawBuffer in
+            guard let base = rawBuffer.baseAddress else { return }
+            while offset < data.count {
+                try waitForDescriptor(descriptor, events: Int16(POLLOUT), label: "\(label) send")
+                let sent = platformSend(
+                    descriptor, base.advanced(by: offset), data.count - offset, sendFlags)
+                if sent > 0 {
+                    offset += sent
+                    continue
+                }
+                if sent == 0 {
+                    throw PTPIPClientSessionError.connectionClosed
+                }
+                let code = errno
+                if code == EINTR || code == EAGAIN || code == EWOULDBLOCK {
+                    continue
+                }
+                throw socketError(code, context: "\(label) send")
+            }
+        }
+    }
+
+    /// Reads one length-prefixed PTP-IP packet, with the same framing guards as
+    /// the iOS transport (8-byte header, 128 MiB payload ceiling).
+    func readPacket() throws -> PTPIPPacket {
+        let header = try readExact(byteCount: 8)
+        let headerBytes = Array(header)
+        let length = ByteCoding.readUInt32LE(headerBytes, at: 0)
+        guard length >= 8 && length <= 128 * 1024 * 1024 else {
+            throw PTPIPClientSessionError.invalidPacketLength(length)
+        }
+        let payloadLength = Int(length) - 8
+        let payload = payloadLength > 0 ? try readExact(byteCount: payloadLength) : Data()
+        return try PTPIPPacket(serializedBytes: headerBytes + Array(payload))
+    }
+
+    private func readExact(byteCount: Int) throws -> Data {
+        let descriptor = try currentDescriptor()
+        while readBuffer.availableCount < byteCount {
+            try waitForDescriptor(descriptor, events: Int16(POLLIN), label: "\(label) receive")
+            let remaining = byteCount - readBuffer.availableCount
+            let maximumLength = min(max(remaining, 4096), 256 * 1024)
+            var bytes = [UInt8](repeating: 0, count: maximumLength)
+            let received = bytes.withUnsafeMutableBytes { rawBuffer in
+                recv(descriptor, rawBuffer.baseAddress, maximumLength, 0)
+            }
+            if received > 0 {
+                readBuffer.append(Data(bytes.prefix(received)))
+                continue
+            }
+            if received == 0 {
+                throw PTPIPClientSessionError.connectionClosed
+            }
+            let code = errno
+            if code == EINTR || code == EAGAIN || code == EWOULDBLOCK {
+                continue
+            }
+            throw socketError(code, context: "\(label) receive")
+        }
+        // SAFETY: the loop guarantees availableCount >= byteCount, so `take` cannot return nil.
+        return readBuffer.take(byteCount)!
+    }
+
+    private func waitForDescriptor(_ descriptor: Int32, events: Int16, label: String) throws {
+        // Loop rather than recurse on EINTR / spurious wakeups (same rationale
+        // as the iOS twin: a signal storm must not grow the stack).
+        while true {
+            var pollDescriptor = pollfd(fd: descriptor, events: events, revents: 0)
+            let result = poll(&pollDescriptor, 1, min(timeoutMilliseconds, 30_000))
+            if result > 0 {
+                if (pollDescriptor.revents & events) != 0 {
+                    return
+                }
+                if (pollDescriptor.revents & Int16(POLLHUP | POLLERR | POLLNVAL)) != 0 {
+                    throw PTPIPClientSessionError.connectionClosed
+                }
+                continue
+            }
+            if result == 0 {
+                throw PTPIPClientSessionError.timeout(label)
+            }
+            if errno == EINTR {
+                continue
+            }
+            throw socketError(errno, context: label)
+        }
+    }
+
+    private func platformSend(
+        _ descriptor: Int32, _ base: UnsafeRawPointer, _ count: Int, _ flags: Int32
+    ) -> Int {
+        #if canImport(Android)
+            Android.send(descriptor, base, count, flags)
+        #elseif canImport(Glibc)
+            Glibc.send(descriptor, base, count, flags)
+        #else
+            Darwin.send(descriptor, base, count, flags)
+        #endif
+    }
+
+    private func storeDescriptor(_ descriptor: Int32) {
+        descriptorLock.lock()
+        self.descriptor = descriptor
+        descriptorLock.unlock()
+    }
+
+    private func currentDescriptor() throws -> Int32 {
+        descriptorLock.lock()
+        defer { descriptorLock.unlock() }
+        guard descriptor >= 0 else { throw PTPIPClientSessionError.connectionClosed }
+        return descriptor
+    }
+
+    private func socketError(_ code: Int32, context: String) -> PTPIPClientSessionError {
+        if code == ECONNREFUSED {
+            return .connectionFailed(
+                "No PTP-IP service answered at \(host):\(port). Confirm the camera is in PC/remote network mode."
+            )
+        }
+        return .connectionFailed("\(context) failed: \(String(cString: strerror(code)))")
+    }
+}

--- a/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
+++ b/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
@@ -122,6 +122,140 @@
         Thread.detachNewThread { pushDemoPhases(handle) }
     }
 
+    // MARK: - Camera session (PTP-IP)
+
+    /// Kotlin-side listener for `sessionConnect`, resolved to global refs +
+    /// method IDs so the connect thread can push into it.
+    ///
+    /// The raw pointers are a JNI global reference, process-wide `jmethodID`s,
+    /// and the process-wide `JavaVM*` — all valid across threads per the JNI
+    /// spec, hence `@unchecked Sendable`.
+    private struct SessionListenerHandle: @unchecked Sendable {
+        let vm: UnsafeMutablePointer<JavaVM?>
+        let listener: jobject
+        let onPhase: jmethodID
+        let onConnected: jmethodID
+        let onFailed: jmethodID
+    }
+
+    /// Process-wide active session slot behind the coarse JNI facade: one
+    /// camera at a time, matching the app's single-camera model.
+    private final class ActiveSessionSlot: @unchecked Sendable {
+        static let shared = ActiveSessionSlot()
+        private let lock = NSLock()
+        private var session: PTPIPClientSession?
+
+        /// Stores `new` and returns the displaced session (for teardown).
+        func replace(with new: PTPIPClientSession?) -> PTPIPClientSession? {
+            lock.lock()
+            defer { lock.unlock() }
+            let old = session
+            session = new
+            return old
+        }
+
+        func current() -> PTPIPClientSession? {
+            lock.lock()
+            defer { lock.unlock() }
+            return session
+        }
+    }
+
+    /// `SwiftCore.sessionConnect(host, listener)` — async connect: PTP-IP Init
+    /// handshake + Nikon open/pair/identify on a Swift background thread, with
+    /// phases pushed to the listener (`onPhase`), ending in `onConnected` or
+    /// `onFailed`. The established session parks in the process-wide slot for
+    /// `sessionReadProperty` / `sessionDisconnect`.
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_sessionConnect")
+    public func swiftCoreSessionConnect(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?, host: jstring?, listener: jobject?
+    ) {
+        let fns = table(env)
+        var vm: UnsafeMutablePointer<JavaVM?>?
+        guard fns.GetJavaVM!(env, &vm) == JNI_OK, let vm else { return }
+        guard let listener, let global = fns.NewGlobalRef!(env, listener) else { return }
+        guard let cls = fns.GetObjectClass!(env, global),
+            let onPhase = fns.GetMethodID!(
+                env, cls, "onPhase", "(Ljava/lang/String;Ljava/lang/String;)V"),
+            let onConnected = fns.GetMethodID!(
+                env, cls, "onConnected",
+                "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V"),
+            let onFailed = fns.GetMethodID!(env, cls, "onFailed", "(Ljava/lang/String;)V")
+        else {
+            fns.DeleteGlobalRef!(env, global)
+            return
+        }
+        let handle = SessionListenerHandle(
+            vm: vm, listener: global, onPhase: onPhase, onConnected: onConnected,
+            onFailed: onFailed)
+        let hostString = swiftString(env, host) ?? ""
+        Thread.detachNewThread { runSessionConnect(handle, host: hostString) }
+    }
+
+    /// Connect-thread body: attaches to the JVM, drives the blocking session
+    /// establishment, and pushes phases/terminal callbacks to the listener.
+    private func runSessionConnect(_ handle: SessionListenerHandle, host: String) {
+        // SAFETY: JavaVM handle and invoke table are JVM-provided and non-nil.
+        let invoke = handle.vm.pointee!.pointee
+        var envOut: UnsafeMutablePointer<JNIEnv?>?
+        guard invoke.AttachCurrentThread!(handle.vm, &envOut, nil) == JNI_OK,
+            let env = envOut
+        else { return }
+        defer { _ = invoke.DetachCurrentThread!(handle.vm) }
+        let fns = table(env)
+        defer { fns.DeleteGlobalRef!(env, handle.listener) }
+
+        func callStrings(_ method: jmethodID, _ values: [String]) {
+            let jValues = values.map { javaString(env, $0) }
+            var args = jValues.map { jvalue(l: $0) }
+            fns.CallVoidMethodA!(env, handle.listener, method, &args)
+            for value in jValues where value != nil {
+                fns.DeleteLocalRef!(env, value)
+            }
+        }
+
+        do {
+            let session = try PTPIPClientSession.connect(host: host) { phase, detail in
+                callStrings(handle.onPhase, [String(describing: phase), detail])
+            }
+            // A replaced session (reconnect without disconnect) is torn down
+            // gracefully so the camera's slot is released.
+            ActiveSessionSlot.shared.replace(with: session)?.disconnect()
+            callStrings(
+                handle.onConnected,
+                [
+                    session.identity.displayName, session.identity.model,
+                    session.identity.serialNumber,
+                ])
+        } catch {
+            callStrings(handle.onFailed, [error.localizedDescription])
+        }
+    }
+
+    /// `SwiftCore.sessionReadProperty(code): String?` — reads one camera
+    /// property through the active session, decoded by the core (battery →
+    /// percent, others → raw hex). Null when disconnected or rejected.
+    /// Blocking; Kotlin calls it from `Dispatchers.IO`.
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_sessionReadProperty")
+    public func swiftCoreSessionReadProperty(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?, code: jint
+    ) -> jstring? {
+        guard let session = ActiveSessionSlot.shared.current(),
+            let value = try? session.readPropertyDisplayValue(code: UInt32(bitPattern: code))
+        else { return nil }
+        return javaString(env, value)
+    }
+
+    /// `SwiftCore.sessionDisconnect()` — graceful teardown of the active
+    /// session: best-effort `CloseSession` then both sockets (the iOS
+    /// reconnect-wedge fix semantics). No-op when nothing is connected.
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_sessionDisconnect")
+    public func swiftCoreSessionDisconnect(
+        env _: UnsafeMutablePointer<JNIEnv?>, this _: jobject?
+    ) {
+        ActiveSessionSlot.shared.replace(with: nil)?.disconnect()
+    }
+
     /// Pushes `discovering → handshaking → connected` copy from the core to the
     /// registered listener, then releases it.
     private func pushDemoPhases(_ handle: ListenerHandle) {

--- a/Sources/OpenZCineCore/ByteCoding.swift
+++ b/Sources/OpenZCineCore/ByteCoding.swift
@@ -1,11 +1,14 @@
 import Foundation
 
-enum ByteCoding {
-    static func uint16LE(_ value: UInt16) -> [UInt8] {
+/// Little/big-endian scalar codecs shared by the PTP/PTP-IP packet builders and
+/// parsers — public so platform adapters (iOS shell, Android facade) frame
+/// packets with the same primitives the core uses.
+public enum ByteCoding {
+    public static func uint16LE(_ value: UInt16) -> [UInt8] {
         [UInt8(value & 0x00FF), UInt8((value >> 8) & 0x00FF)]
     }
 
-    static func uint32LE(_ value: UInt32) -> [UInt8] {
+    public static func uint32LE(_ value: UInt32) -> [UInt8] {
         [
             UInt8(value & 0x0000_00FF),
             UInt8((value >> 8) & 0x0000_00FF),
@@ -14,7 +17,7 @@ enum ByteCoding {
         ]
     }
 
-    static func uint64LE(_ value: UInt64) -> [UInt8] {
+    public static func uint64LE(_ value: UInt64) -> [UInt8] {
         [
             UInt8(value & 0x0000_0000_0000_00FF),
             UInt8((value >> 8) & 0x0000_0000_0000_00FF),
@@ -27,43 +30,43 @@ enum ByteCoding {
         ]
     }
 
-    static func int32LE(_ value: Int32) -> [UInt8] {
+    public static func int32LE(_ value: Int32) -> [UInt8] {
         uint32LE(UInt32(bitPattern: value))
     }
 
-    static func readUInt16LE(_ bytes: [UInt8], at offset: Int) -> UInt16 {
+    public static func readUInt16LE(_ bytes: [UInt8], at offset: Int) -> UInt16 {
         UInt16(bytes[offset]) | (UInt16(bytes[offset + 1]) << 8)
     }
 
     /// Big-endian uint16. The PTP containers are little-endian, but the Nikon LiveViewObject
     /// display-info header encodes its size/AF fields big-endian, so this pairs with `readUInt16BE`.
-    static func uint16BE(_ value: UInt16) -> [UInt8] {
+    public static func uint16BE(_ value: UInt16) -> [UInt8] {
         [UInt8((value >> 8) & 0x00FF), UInt8(value & 0x00FF)]
     }
 
-    static func readUInt16BE(_ bytes: [UInt8], at offset: Int) -> UInt16 {
+    public static func readUInt16BE(_ bytes: [UInt8], at offset: Int) -> UInt16 {
         (UInt16(bytes[offset]) << 8) | UInt16(bytes[offset + 1])
     }
 
-    static func readUInt32LE(_ bytes: [UInt8], at offset: Int) -> UInt32 {
+    public static func readUInt32LE(_ bytes: [UInt8], at offset: Int) -> UInt32 {
         UInt32(bytes[offset])
             | (UInt32(bytes[offset + 1]) << 8)
             | (UInt32(bytes[offset + 2]) << 16)
             | (UInt32(bytes[offset + 3]) << 24)
     }
 
-    static func readUInt32BE(_ bytes: [UInt8], at offset: Int) -> UInt32 {
+    public static func readUInt32BE(_ bytes: [UInt8], at offset: Int) -> UInt32 {
         (UInt32(bytes[offset]) << 24)
             | (UInt32(bytes[offset + 1]) << 16)
             | (UInt32(bytes[offset + 2]) << 8)
             | UInt32(bytes[offset + 3])
     }
 
-    static func readInt32LE(_ bytes: [UInt8], at offset: Int) -> Int32 {
+    public static func readInt32LE(_ bytes: [UInt8], at offset: Int) -> Int32 {
         Int32(bitPattern: readUInt32LE(bytes, at: offset))
     }
 
-    static func readUInt64LE(_ bytes: [UInt8], at offset: Int) -> UInt64 {
+    public static func readUInt64LE(_ bytes: [UInt8], at offset: Int) -> UInt64 {
         var value: UInt64 = 0
         for index in 0..<8 {
             value |= UInt64(bytes[offset + index]) << (index * 8)

--- a/Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift
@@ -1,0 +1,313 @@
+// Scripted fake Nikon ZR: a local PTP-IP TCP server answering the CIPA DC-005
+// Init handshake and the Nikon open/pair/identify + property-read sequence,
+// so `PTPIPClientSession` can be exercised end to end without hardware.
+//
+// The payload codecs themselves are covered by the core suites
+// (PTPIPHandshakeTests, PTPIPPacketTests, PTPIPTransactionTests); this server
+// exists for wire-level session sequencing, which nothing else tests.
+
+import Foundation
+import OpenZCineCore
+
+#if canImport(Android)
+    import Android
+#elseif canImport(Glibc)
+    import Glibc
+#elseif canImport(Darwin)
+    import Darwin
+#endif
+
+/// A scripted fake ZR listening on an ephemeral localhost port.
+// SAFETY: `@unchecked Sendable` — mutable state is guarded by `lock`; each
+// accepted connection runs on its own thread.
+final class FakeZRServer: @unchecked Sendable {
+    struct Options {
+        /// When false, `ChangeApplicationMode` is refused until the pairing
+        /// sequence (`GetPairingInfo` + `ConfirmPairing`) completes — the
+        /// first-time-pairing camera behavior.
+        var acceptsAppControlImmediately = true
+        /// Reply `Init_Fail` to every `Init_Command_Request`.
+        var refusesInit = false
+        var cameraName = "ZR_6001234"
+        var pairingPIN = "1234"
+        var batteryPercent: UInt8 = 80
+        var manufacturer = "Nikon Corporation"
+        var model = "ZR"
+        var deviceVersion = "01.00"
+        var serialNumber = "6001234"
+    }
+
+    let port: UInt16
+
+    private let options: Options
+    private let listenDescriptor: Int32
+    private let lock = NSLock()
+    private var operationLog: [PTPOperationCode] = []
+    private var transactionIDLog: [UInt32] = []
+    private var pairingConfirmed = false
+    private var stopped = false
+
+    init(options: Options = Options()) throws {
+        self.options = options
+
+        let descriptor = socket(AF_INET, SOCK_STREAM, Int32(IPPROTO_TCP))
+        guard descriptor >= 0 else { throw FakeZRServerError.socketFailed }
+        var reuse: Int32 = 1
+        setsockopt(
+            descriptor, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size))
+
+        var address = sockaddr_in()
+        #if canImport(Darwin)
+            address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        #endif
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = 0  // ephemeral
+        address.sin_addr.s_addr = UInt32(0x7F00_0001).bigEndian  // 127.0.0.1
+
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                bind(descriptor, socketAddress, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult == 0, listen(descriptor, 8) == 0 else {
+            close(descriptor)
+            throw FakeZRServerError.bindFailed
+        }
+
+        var bound = sockaddr_in()
+        var boundLength = socklen_t(MemoryLayout<sockaddr_in>.size)
+        withUnsafeMutablePointer(to: &bound) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                _ = getsockname(descriptor, socketAddress, &boundLength)
+            }
+        }
+        self.port = UInt16(bigEndian: bound.sin_port)
+        self.listenDescriptor = descriptor
+
+        Thread.detachNewThread { [weak self] in self?.acceptLoop() }
+    }
+
+    func stop() {
+        lock.lock()
+        stopped = true
+        lock.unlock()
+        shutdown(listenDescriptor, Int32(SHUT_RDWR))
+        close(listenDescriptor)
+    }
+
+    /// Every PTP operation received, in arrival order, across all connections.
+    func receivedOperations() -> [PTPOperationCode] {
+        lock.lock()
+        defer { lock.unlock() }
+        return operationLog
+    }
+
+    /// Transaction IDs in arrival order (parallel to `receivedOperations`).
+    func receivedTransactionIDs() -> [UInt32] {
+        lock.lock()
+        defer { lock.unlock() }
+        return transactionIDLog
+    }
+
+    // MARK: - Connection handling
+
+    private func acceptLoop() {
+        while true {
+            let connection = accept(listenDescriptor, nil, nil)
+            guard connection >= 0 else { return }
+            Thread.detachNewThread { [weak self] in self?.serve(connection) }
+        }
+    }
+
+    private func serve(_ connection: Int32) {
+        defer { close(connection) }
+        while let packet = try? readPacket(connection) {
+            switch packet.type {
+            case .initCommandRequest:
+                if options.refusesInit {
+                    send(
+                        connection,
+                        PTPIPPacket(
+                            type: .initFail, payload: Data(ByteCoding.uint32LE(1))))
+                    return
+                }
+                var payload = ByteCoding.uint32LE(1)  // connection number
+                payload += [UInt8](repeating: 0xAB, count: 16)  // responder GUID
+                payload += PTPIPFriendlyName.encode(options.cameraName)
+                send(connection, PTPIPPacket(type: .initCommandAck, payload: Data(payload)))
+            case .initEventRequest:
+                send(connection, PTPIPPacket(type: .initEventAck, payload: Data()))
+            case .operationRequest:
+                respond(connection, requestPayload: Array(packet.payload))
+            default:
+                return
+            }
+        }
+    }
+
+    private func respond(_ connection: Int32, requestPayload bytes: [UInt8]) {
+        guard bytes.count >= 10 else { return }
+        let rawOperation = ByteCoding.readUInt16LE(bytes, at: 4)
+        let transactionID = ByteCoding.readUInt32LE(bytes, at: 6)
+        guard let operation = PTPOperationCode(rawValue: rawOperation) else {
+            sendResponse(connection, code: 0x2005, transactionID: transactionID)
+            return
+        }
+        lock.lock()
+        operationLog.append(operation)
+        transactionIDLog.append(transactionID)
+        lock.unlock()
+
+        switch operation {
+        case .openSession, .closeSession:
+            sendResponse(connection, code: 0x2001, transactionID: transactionID)
+        case .changeApplicationMode:
+            lock.lock()
+            let accepted = options.acceptsAppControlImmediately || pairingConfirmed
+            lock.unlock()
+            sendResponse(
+                connection, code: accepted ? 0x2001 : 0x2002, transactionID: transactionID)
+        case .getPairingInfo:
+            sendDataIn(
+                connection, data: Data(options.pairingPIN.utf8), transactionID: transactionID)
+        case .confirmPairing:
+            lock.lock()
+            pairingConfirmed = true
+            lock.unlock()
+            sendResponse(connection, code: 0x2001, transactionID: transactionID)
+        case .getDeviceInfo:
+            sendDataIn(connection, data: deviceInfoDataset(), transactionID: transactionID)
+        case .getDevicePropValueEx:
+            let propertyCode = bytes.count >= 14 ? ByteCoding.readUInt32LE(bytes, at: 10) : 0
+            switch PTPPropertyCode(rawValue: propertyCode) {
+            case .batteryLevel:
+                sendDataIn(
+                    connection, data: Data([options.batteryPercent]),
+                    transactionID: transactionID)
+            case .movieRecProhibitionCondition:
+                // 0 = nothing prohibits recording.
+                sendDataIn(
+                    connection, data: Data(ByteCoding.uint32LE(0)), transactionID: transactionID)
+            default:
+                sendResponse(connection, code: 0x2002, transactionID: transactionID)
+            }
+        default:
+            sendResponse(connection, code: 0x2005, transactionID: transactionID)
+        }
+    }
+
+    // MARK: - Datasets
+
+    /// Minimal standard PTP `DeviceInfo` dataset carrying the identity strings.
+    private func deviceInfoDataset() -> Data {
+        var bytes: [UInt8] = []
+        bytes += ByteCoding.uint16LE(100)  // StandardVersion
+        bytes += ByteCoding.uint32LE(0)  // VendorExtensionID
+        bytes += ByteCoding.uint16LE(0)  // VendorExtensionVersion
+        bytes += ptpString("")  // VendorExtensionDesc
+        bytes += ByteCoding.uint16LE(0)  // FunctionalMode
+        for _ in 0..<5 {  // Operations/Events/Properties/CaptureFormats/ImageFormats
+            bytes += ByteCoding.uint32LE(0)
+        }
+        bytes += ptpString(options.manufacturer)
+        bytes += ptpString(options.model)
+        bytes += ptpString(options.deviceVersion)
+        bytes += ptpString(options.serialNumber)
+        return Data(bytes)
+    }
+
+    /// PTP string: UINT8 code-unit count (including trailing NUL) + UTF-16LE units.
+    private func ptpString(_ value: String) -> [UInt8] {
+        guard !value.isEmpty else { return [0] }
+        var units: [UInt8] = []
+        for codeUnit in value.utf16 {
+            units += ByteCoding.uint16LE(codeUnit)
+        }
+        units += [0, 0]
+        return [UInt8(units.count / 2)] + units
+    }
+
+    // MARK: - Framing
+
+    private func sendResponse(_ connection: Int32, code: UInt16, transactionID: UInt32) {
+        let payload = ByteCoding.uint16LE(code) + ByteCoding.uint32LE(transactionID)
+        send(connection, PTPIPPacket(type: .operationResponse, payload: Data(payload)))
+    }
+
+    private func sendDataIn(
+        _ connection: Int32, data: Data, transactionID: UInt32, code: UInt16 = 0x2001
+    ) {
+        send(
+            connection,
+            PTPIPPacket(
+                type: .startData,
+                payload: Data(
+                    PTPDataPayloads.startData(
+                        transactionID: transactionID, totalLength: UInt64(data.count)))))
+        send(
+            connection,
+            PTPIPPacket(
+                type: .endData,
+                payload: Data(PTPDataPayloads.endData(transactionID: transactionID, data: data))))
+        sendResponse(connection, code: code, transactionID: transactionID)
+    }
+
+    private func send(_ connection: Int32, _ packet: PTPIPPacket) {
+        let data = Data(packet.serializedBytes)
+        #if canImport(Darwin)
+            let flags: Int32 = 0
+        #else
+            let flags = Int32(MSG_NOSIGNAL)
+        #endif
+        data.withUnsafeBytes { rawBuffer in
+            guard let base = rawBuffer.baseAddress else { return }
+            var offset = 0
+            while offset < data.count {
+                let sent = platformSend(connection, base + offset, data.count - offset, flags)
+                guard sent > 0 else { return }
+                offset += sent
+            }
+        }
+    }
+
+    private func platformSend(
+        _ descriptor: Int32, _ base: UnsafeRawPointer, _ count: Int, _ flags: Int32
+    ) -> Int {
+        #if canImport(Android)
+            Android.send(descriptor, base, count, flags)
+        #elseif canImport(Glibc)
+            Glibc.send(descriptor, base, count, flags)
+        #else
+            Darwin.send(descriptor, base, count, flags)
+        #endif
+    }
+
+    private func readPacket(_ connection: Int32) throws -> PTPIPPacket {
+        let header = try readExact(connection, byteCount: 8)
+        let length = Int(ByteCoding.readUInt32LE(header, at: 0))
+        guard length >= 8, length <= 1024 * 1024 else { throw FakeZRServerError.badFrame }
+        let payload = try readExact(connection, byteCount: length - 8)
+        return try PTPIPPacket(serializedBytes: header + payload)
+    }
+
+    private func readExact(_ connection: Int32, byteCount: Int) throws -> [UInt8] {
+        var collected: [UInt8] = []
+        collected.reserveCapacity(byteCount)
+        while collected.count < byteCount {
+            var chunk = [UInt8](repeating: 0, count: byteCount - collected.count)
+            let received = chunk.withUnsafeMutableBytes { rawBuffer in
+                recv(connection, rawBuffer.baseAddress, rawBuffer.count, 0)
+            }
+            guard received > 0 else { throw FakeZRServerError.connectionClosed }
+            collected += chunk.prefix(received)
+        }
+        return collected
+    }
+}
+
+enum FakeZRServerError: Error {
+    case socketFailed
+    case bindFailed
+    case badFrame
+    case connectionClosed
+}

--- a/Tests/OpenZCineAndroidFacadeTests/PTPIPClientSessionTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/PTPIPClientSessionTests.swift
@@ -1,0 +1,143 @@
+// Wire-level tests for the Android facade's PTP-IP session layer against the
+// scripted fake ZR. Payload codecs are already covered by the core suites;
+// these tests cover what only a socket pair can: connection sequencing, the
+// saved-profile → first-time-pairing fallback, property reads through a live
+// transaction, and the graceful CloseSession teardown (the reconnect-wedge
+// fix semantics carried over from iOS).
+
+import Foundation
+import OpenZCineCore
+import Testing
+
+@testable import OpenZCineAndroidFacade
+
+struct PTPIPClientSessionTests {
+    private func connect(
+        to server: FakeZRServer,
+        onPhase: (CameraConnectionPhase, String) -> Void = { _, _ in }
+    ) throws -> PTPIPClientSession {
+        try PTPIPClientSession.connect(
+            host: "127.0.0.1",
+            port: server.port,
+            timeoutMilliseconds: 2_000,
+            onPhase: onPhase)
+    }
+
+    @Test func connectsWithSavedProfileAndIdentifies() throws {
+        let server = try FakeZRServer()
+        defer { server.stop() }
+
+        var phases: [CameraConnectionPhase] = []
+        let session = try connect(to: server) { phase, _ in phases.append(phase) }
+        defer { session.disconnect() }
+
+        #expect(phases == [.handshaking, .connected])
+        #expect(session.identity.cameraName == "ZR_6001234")
+        #expect(session.identity.manufacturer == "Nikon Corporation")
+        #expect(session.identity.model == "ZR")
+        #expect(session.identity.serialNumber == "6001234")
+        #expect(session.identity.displayName == "ZR_6001234")
+        // The quiet saved-profile path must not touch the pairing operations.
+        let operations = server.receivedOperations()
+        #expect(!operations.contains(.getPairingInfo))
+        #expect(!operations.contains(.confirmPairing))
+        #expect(operations.prefix(2) == [.openSession, .changeApplicationMode])
+    }
+
+    @Test func fallsBackToFirstTimePairingWhenAppControlIsRefused() throws {
+        var options = FakeZRServer.Options()
+        options.acceptsAppControlImmediately = false
+        let server = try FakeZRServer(options: options)
+        defer { server.stop() }
+
+        var phases: [(CameraConnectionPhase, String)] = []
+        let session = try connect(to: server) { phase, detail in phases.append((phase, detail)) }
+        defer { session.disconnect() }
+
+        #expect(phases.map(\.0) == [.handshaking, .pairing, .confirmOnCamera, .connected])
+        // The pairing PIN extracted by the core from the challenge bytes.
+        #expect(phases.first(where: { $0.0 == .confirmOnCamera })?.1 == "1234")
+        #expect(session.identity.model == "ZR")
+
+        let operations = server.receivedOperations()
+        // Probe attempt: open + refused app mode + graceful CloseSession…
+        #expect(operations.prefix(3) == [.openSession, .changeApplicationMode, .closeSession])
+        // …then the fresh pairing session in the iOS-verified order.
+        #expect(
+            operations.dropFirst(3).prefix(5)
+                == [
+                    .openSession, .getPairingInfo, .confirmPairing, .changeApplicationMode,
+                    .getDeviceInfo,
+                ])
+    }
+
+    @Test func readsBatteryAndRecordingStateProperties() throws {
+        let server = try FakeZRServer()
+        defer { server.stop() }
+        let session = try connect(to: server)
+        defer { session.disconnect() }
+
+        // Battery decodes through the core's snapshot (UINT8 percent).
+        let battery = try session.readPropertyDisplayValue(
+            code: PTPPropertyCode.batteryLevel.rawValue)
+        #expect(battery == "80")
+
+        // Recording state (MovieRecProhibitionCondition): raw value, 0 = recordable.
+        let recordingState = try session.readPropertyDisplayValue(
+            code: PTPPropertyCode.movieRecProhibitionCondition.rawValue)
+        #expect(recordingState == "0x0")
+
+        // Unknown codes are rejected core-side, not sent to the camera.
+        #expect(throws: PTPIPClientSessionError.unsupportedProperty(0xBEEF)) {
+            try session.readPropertyDisplayValue(code: 0xBEEF)
+        }
+
+        // Transaction IDs keep counting across establishment and the property
+        // reads — an ID sequence that restarts mid-session is a protocol bug.
+        let transactionIDs = server.receivedTransactionIDs()
+        #expect(transactionIDs == Array(0..<UInt32(transactionIDs.count)))
+    }
+
+    @Test func disconnectSendsGracefulCloseSession() throws {
+        let server = try FakeZRServer()
+        defer { server.stop() }
+        let session = try connect(to: server)
+
+        session.disconnect()
+        // Idempotent: a second disconnect must not send another CloseSession.
+        session.disconnect()
+
+        let closeCount = server.receivedOperations().filter { $0 == .closeSession }.count
+        #expect(closeCount == 1)
+        #expect(session.identity.model == "ZR")
+
+        // The link is gone after teardown.
+        #expect(throws: PTPIPClientSessionError.self) {
+            try session.readPropertyDisplayValue(code: PTPPropertyCode.batteryLevel.rawValue)
+        }
+    }
+
+    @Test func surfacesInitFail() throws {
+        var options = FakeZRServer.Options()
+        options.refusesInit = true
+        let server = try FakeZRServer(options: options)
+        defer { server.stop() }
+
+        #expect(throws: PTPIPClientSessionError.initFailed(.rejectedInitiator)) {
+            try connect(to: server)
+        }
+    }
+
+    @Test func failsCleanlyWhenNothingListens() throws {
+        let server = try FakeZRServer()
+        let port = server.port
+        server.stop()
+
+        // A refused connect surfaces as `.connectionClosed` (POLLHUP on the
+        // non-blocking connect) or `.connectionFailed` — never a hang.
+        #expect(throws: PTPIPClientSessionError.self) {
+            try PTPIPClientSession.connect(
+                host: "127.0.0.1", port: port, timeoutMilliseconds: 1_000)
+        }
+    }
+}

--- a/docs/investigations/android-core-feasibility.md
+++ b/docs/investigations/android-core-feasibility.md
@@ -373,3 +373,23 @@ a facade of a dozen coarse functions, hand-written `@_cdecl` shims
 (`Sources/OpenZCineAndroidFacade`, importing the NDK's `<jni.h>` through the header-only `CJNI`
 target) cost ~150 lines and zero new dependencies. Revisit jextract when its runtime jars reach
 Maven Central and the API stabilizes; the facade surface is deliberately small enough to migrate.
+
+**Session layer landed (2026-07-14):** the facade now carries the PTP-IP protocol/session slice
+(`Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift`), with sockets Swift-side per shape 2
+above — the facade is the Android platform adapter, so a blocking POSIX twin of the iOS
+`PTPIPSocket` lives inside it and the JNI surface stays coarse. Facade functions to date:
+
+- `coreVersion()`, `deriveAccessPointSSID(name)`, `resolveDisplayName(name)`,
+  `startConnectionDemo(listener)` (spike surface), and the session slice:
+- `sessionConnect(host, listener)` — Init handshake on both channels + the Nikon
+  open/pair/identify sequence (quiet saved-profile attempt, falling back to first-time pairing
+  with the PIN pushed via the listener), phases mirroring `CameraConnectionPhase`;
+- `sessionReadProperty(code)` — `GetDevicePropValueEx` decoded by the core
+  (battery → percent, others raw hex until their display decoders are wired);
+- `sessionDisconnect()` — best-effort `CloseSession` before dropping sockets (the iOS
+  reconnect-wedge fix semantics).
+
+The layer compiles on Darwin too, so `Tests/OpenZCineAndroidFacadeTests` exercises the same wire
+behavior against a scripted fake ZR (`FakeZRServer`) in `swift test` — sequencing, the pairing
+fallback, property decode, and graceful teardown; real-ZR validation of connect + property read
+is the remaining hardware step.


### PR DESCRIPTION
Adds the protocol/session slice of the Android session-management work: `sessionConnect` / `sessionReadProperty` / `sessionDisconnect` in the JNI facade, with the whole PTP-IP session — POSIX sockets, Init handshake on both channels, saved-profile → first-time-pairing fallback (PIN + confirm), core-decoded property reads, graceful CloseSession teardown (the reconnect-wedge semantics) — running inside the shared Swift core. No protocol logic in Kotlin; the facade is the Android platform adapter that owns sockets, mirroring the iOS layering.

- Kotlin gains `SwiftCoreCameraSession` behind the `CameraSession` seam plus a debug logcat probe (`--es zc.session.host <ip>`); MonitorShell/theme untouched.
- New Swift test target with a scripted fake-ZR TCP server (6 tests: both pairing paths, property decode, TID continuity, Init_Fail, graceful/idempotent teardown). The fake server caught and killed a real bug: transaction IDs restarted after identification; a regression test now pins monotonic TIDs.
- One core visibility change: `ByteCoding` is now `public` (SPM module boundary; iOS compiles core sources directly and never hit it).
- End-to-end device-verified (physical Android device, fake server over `adb reverse`): phases → connected ZR_6001234, battery 80%, recProhibition 0x0, graceful CloseSession on teardown.

**Review note:** the facade currently reuses the same initiator GUID + friendly name as the iOS app so an already-paired ZR takes the saved-profile path immediately (pragmatic for first hardware validation). Long-term the Android app likely wants its own initiator identity so a body can hold both pairings — flagged for a follow-up decision.

**Real-ZR validation steps** are in Apps/Android/README.md (install → phone on camera network → `zc.session.host` probe → verify battery/recording state + the immediate-reconnect wedge check).

Part of #69 · Kaneo: OPE-26

🤖 Generated with [Claude Code](https://claude.com/claude-code)
