### PR TITLE
docs: require Kaneo task assignment

### DIFF
--- a/docs/PROJECT-MANAGEMENT.md
+++ b/docs/PROJECT-MANAGEMENT.md
@@ -20,6 +20,11 @@ Agent access is via the Kaneo MCP tools (device-auth flow; the cached token live
 config — **never commit it**). Everything on the board, including task descriptions, is publicly
 visible through the read-only view: write descriptions accordingly.
 
+## Assignment
+
+Until project maintainers are added, every Kaneo task in project `OPE` must be assigned to Erik
+Sutton. Agents must assign Erik when creating a task and must not leave existing tasks unassigned.
+
 ## Statuses
 
 Valid task statuses: `to-do`, `in-progress`, `in-review`, `done`, `planned`, `archived`.


### PR DESCRIPTION
## What & why

Document the standing assignment rule requested for OpenZCine: until project maintainers are added, every Kaneo task in project OPE is assigned to Erik Sutton, including tasks created by agents.

Kaneo: OPE-46
Closes #112

## Checklist

- [x] `just check` passes.
- [x] Native production changes are not applicable; this is documentation-only.
- [x] Legacy prototype/reference changes are left local.
- [x] Commits follow Conventional Commits.
- [x] No proprietary assets (`vendor/`, `ref/`) are included.
- [x] Project-management documentation is updated.
- [x] iOS release versioning is not applicable.