### PR TITLE
feat(android): landscape monitor shell — 1:1 port of the iOS chrome

### DIFF
--- a/Apps/Android/README.md
+++ b/Apps/Android/README.md
@@ -1,7 +1,12 @@
 # OpenZCine Android
 
-Production Jetpack Compose shell — early scaffold. One placeholder monitor screen
-(black feed area, "No camera" state) wired through the camera-core seam.
+Production Jetpack Compose shell. The landscape monitor screen is a 1:1 port of the iOS
+shell's chrome, laid out by the shared core's zone map (`SwiftCore.monitorZoneMap` →
+`MonitorZoneLayout.map`) — no layout math lives in Kotlin. v1 covers the live feed, top
+info deck, capture readout strip, lock/battery band, and the record/DISP/media/settings
+rail with DISP 1↔2 cycling; assists, scopes, pickers, and portrait land later. Readouts
+are fake demo values until the session facade arrives. Without the staged Swift core the
+app falls back to the placeholder monitor ("No camera").
 
 - **Build:** `just android-build` from the repo root (or `just android-check` for build + tests + lint).
 - **Swift core:** the camera brain is the shared Swift core (`Sources/OpenZCineCore`), cross-compiled

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.opencapture.openzcine.core.CameraSession
 import com.opencapture.openzcine.core.CameraSessionState
+import com.opencapture.openzcine.bridge.SwiftCore
 import com.opencapture.openzcine.bridge.SwiftCoreSmoke
 import com.opencapture.openzcine.core.FakeCameraSession
 import com.opencapture.openzcine.core.LiveFrameSource
@@ -45,7 +46,14 @@ class MainActivity : ComponentActivity() {
                 ?: if (isNsdTransportRequested()) nsdTransportSession() else FakeCameraSession()
         setContent {
             OpenZCineTheme {
-                MonitorShell(session, frameSource = demo?.second)
+                if (SwiftCore.isAvailable) {
+                    // The real shell needs the shared core's zone map. An APK
+                    // built without `just android-core` (plain CI android-check)
+                    // has no native library, so it keeps the placeholder.
+                    MonitorScreen(session, frameSource = demo?.second)
+                } else {
+                    MonitorShell(session, frameSource = demo?.second)
+                }
             }
         }
     }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
@@ -1,8 +1,14 @@
 package com.opencapture.openzcine
 
 import android.content.pm.ApplicationInfo
+import android.graphics.Color
 import android.net.nsd.NsdManager
 import android.os.Bundle
+import android.view.WindowManager
+import androidx.activity.SystemBarStyle
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -35,7 +41,28 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (BuildConfig.DEBUG) SwiftCoreSmoke.run()
-        enableEdgeToEdge()
+        // Camera-monitor chrome owns the whole panel, like the iOS shell:
+        // sticky-immersive system bars (hidden; a swipe reveals them
+        // transiently and they re-hide), forced-dark transparent bar styling
+        // so the transient overlay is never an opaque white band, and
+        // shortEdges cutout mode so the feed draws under the punch-hole (the
+        // cutout arrives as a safe-area inset for the zone map).
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
+            navigationBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
+        )
+        window.isNavigationBarContrastEnforced = false
+        window.attributes.layoutInDisplayCutoutMode =
+            WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+        // BEHAVIOR_DEFAULT, not TRANSIENT_BARS_BY_SWIPE: the swipe reveal is
+        // equally transient on this device under both, but only DEFAULT emits
+        // the legacy system-UI visibility event MonitorScreen listens to for
+        // the rail shift (verified on the SM-A127F — transient mode emits no
+        // observable signal at all).
+        WindowCompat.getInsetsController(window, window.decorView).apply {
+            systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
+            hide(WindowInsetsCompat.Type.systemBars())
+        }
         // ponytail: fake backend by default until the real core lands behind
         // the seam; DI arrives with the first production implementation. Two
         // debug-only overrides: the demo harness (synthetic feed) wins, then

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorChrome.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorChrome.kt
@@ -40,6 +40,10 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.foundation.clickable
 import androidx.compose.material3.Text
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
 
 // Compose mirrors of the iOS monitor chrome primitives (ios/Runner/
 // MonitorControls.swift + MonitorExperience.swift). Layout frames come from the
@@ -151,21 +155,56 @@ fun FpsChip(signalBars: Int, fps: String) {
     }
 }
 
-/** One exposure readout: small label over a large mono value (iOS `CaptureSettingButton`). */
+/**
+ * One exposure readout: small label over a large mono value (iOS
+ * `CaptureSettingButton`). [widestValue] reserves the cell's width so the bar
+ * never shifts when a value changes — the iOS `widestValue` hidden-overlay trick.
+ */
 @Composable
-fun CaptureSettingCell(label: String, value: String) {
+fun CaptureSettingCell(label: String, value: String, widestValue: String = value) {
     Column(
         modifier = Modifier.padding(vertical = 5.dp, horizontal = 8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(3.dp),
     ) {
         Text(label, style = chromeStyle(9f, FontWeight.SemiBold), color = LiveDesign.faint)
-        Text(
-            value,
-            style = chromeStyle(19f, FontWeight.Medium, mono = true),
-            color = LiveDesign.text,
-            maxLines = 1,
-        )
+        Box(contentAlignment = Alignment.Center) {
+            Text(
+                widestValue,
+                style = chromeStyle(19f, FontWeight.Medium, mono = true),
+                color = Color.Transparent,
+                maxLines = 1,
+            )
+            Text(
+                value,
+                style = chromeStyle(19f, FontWeight.Medium, mono = true),
+                color = LiveDesign.text,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+/**
+ * Measures its single child unbounded and scales it down (top-start anchored)
+ * to fit [maxWidth] — the shell-level analog of iOS `minimumScaleFactor`, so
+ * chrome pills compress instead of wrapping when a band runs tight.
+ */
+@Composable
+fun FitScale(maxWidth: Dp, content: @Composable () -> Unit) {
+    Layout(content) { measurables, _ ->
+        val placeable = measurables.first().measure(Constraints())
+        val maxPx = maxWidth.roundToPx()
+        val scale = if (placeable.width > maxPx) maxPx / placeable.width.toFloat() else 1f
+        val width = (placeable.width * scale).toInt()
+        val height = (placeable.height * scale).toInt()
+        layout(width, height) {
+            placeable.placeWithLayer(0, 0) {
+                scaleX = scale
+                scaleY = scale
+                transformOrigin = TransformOrigin(0f, 0f)
+            }
+        }
     }
 }
 
@@ -191,7 +230,7 @@ fun LockButton(locked: Boolean, modifier: Modifier = Modifier, onClick: () -> Un
                 .chromeClickable(onClick),
         contentAlignment = Alignment.Center,
     ) {
-        PadlockGlyph(tint = tint, filled = locked, modifier = Modifier.size(16.dp))
+        PadlockGlyph(tint = tint, filled = locked, modifier = Modifier.size(13.dp, 17.dp))
     }
 }
 
@@ -514,35 +553,29 @@ fun SdCardGlyph(tint: Color, modifier: Modifier = Modifier.size(9.dp, 12.dp)) {
 @Composable
 fun PadlockGlyph(tint: Color, filled: Boolean, modifier: Modifier = Modifier) {
     Canvas(modifier) {
-        val stroke = 1.4.dp.toPx()
-        val bodyTop = size.height * 0.44f
-        val shackleWidth = size.width * 0.52f
+        val stroke = 1.6.dp.toPx()
+        // SF proportions: near-square body on the lower ~55%, a tall narrow
+        // shackle on top.
+        val bodyTop = size.height * 0.45f
+        val bodyInset = size.width * 0.08f
+        val shackleWidth = size.width * 0.48f
         drawArc(
             tint,
             startAngle = 180f,
             sweepAngle = 180f,
             useCenter = false,
-            topLeft = Offset((size.width - shackleWidth) / 2, size.height * 0.06f),
-            size = Size(shackleWidth, bodyTop * 1.6f),
+            topLeft = Offset((size.width - shackleWidth) / 2, stroke / 2),
+            size = Size(shackleWidth, (bodyTop - stroke / 2) * 2f),
             style = Stroke(stroke),
         )
-        val bodyRect = Rect(0f, bodyTop, size.width, size.height)
-        if (filled) {
-            drawRoundRect(
-                tint,
-                topLeft = bodyRect.topLeft,
-                size = bodyRect.size,
-                cornerRadius = CornerRadius(size.width * 0.18f),
-            )
-        } else {
-            drawRoundRect(
-                tint,
-                topLeft = bodyRect.topLeft,
-                size = bodyRect.size,
-                cornerRadius = CornerRadius(size.width * 0.18f),
-                style = Stroke(stroke),
-            )
-        }
+        val bodyRect = Rect(bodyInset, bodyTop, size.width - bodyInset, size.height)
+        drawRoundRect(
+            tint,
+            topLeft = bodyRect.topLeft,
+            size = bodyRect.size,
+            cornerRadius = CornerRadius(size.width * 0.16f),
+            style = if (filled) androidx.compose.ui.graphics.drawscope.Fill else Stroke(stroke),
+        )
     }
 }
 
@@ -550,53 +583,64 @@ fun PadlockGlyph(tint: Color, filled: Boolean, modifier: Modifier = Modifier) {
 @Composable
 fun GearGlyph(tint: Color, modifier: Modifier = Modifier) {
     Canvas(modifier) {
-        val stroke = 1.4.dp.toPx()
+        val stroke = 2.dp.toPx()
         val center = Offset(size.width / 2, size.height / 2)
-        val outer = size.minDimension / 2 - stroke
-        val ring = outer * 0.72f
+        val outer = size.minDimension / 2 - stroke / 2
+        val ring = outer * 0.68f
         drawCircle(tint, radius = ring, center = center, style = Stroke(stroke))
-        drawCircle(tint, radius = ring * 0.42f, center = center, style = Stroke(stroke))
+        drawCircle(tint, radius = ring * 0.4f, center = center, style = Stroke(stroke * 0.85f))
         repeat(8) { index ->
-            val angle = Math.toRadians(index * 45.0)
+            val angle = Math.toRadians(index * 45.0 + 22.5)
             val dir = Offset(kotlin.math.cos(angle).toFloat(), kotlin.math.sin(angle).toFloat())
             drawLine(
                 tint,
-                start = center + dir * ring,
+                start = center + dir * (ring - stroke / 2),
                 end = center + dir * outer,
-                strokeWidth = stroke * 1.4f,
+                strokeWidth = stroke * 1.6f,
                 cap = StrokeCap.Round,
             )
         }
     }
 }
 
-/** iOS `IconMedia` (rectangle.stack) stand-in. */
+/** iOS `IconMedia` (film-frame) stand-in: rounded frame + sprocket columns. */
 @Composable
 fun MediaStackGlyph(tint: Color, modifier: Modifier = Modifier) {
     Canvas(modifier) {
-        val stroke = 1.4.dp.toPx()
-        val cardHeight = size.height * 0.58f
-        val inset = size.width * 0.12f
+        val stroke = 1.8.dp.toPx()
         drawRoundRect(
             tint,
-            topLeft = Offset(inset, 0f),
-            size = Size(size.width - 2 * inset, size.height * 0.16f),
-            cornerRadius = CornerRadius(2.dp.toPx()),
-            style = Stroke(stroke * 0.9f),
-        )
-        drawRoundRect(
-            tint,
-            topLeft = Offset(inset / 2, size.height * 0.24f),
-            size = Size(size.width - inset, size.height * 0.14f),
-            cornerRadius = CornerRadius(2.dp.toPx()),
-            style = Stroke(stroke * 0.9f),
-        )
-        drawRoundRect(
-            tint,
-            topLeft = Offset(0f, size.height - cardHeight),
-            size = Size(size.width, cardHeight),
-            cornerRadius = CornerRadius(3.dp.toPx()),
+            topLeft = Offset(stroke / 2, stroke / 2),
+            size = Size(size.width - stroke, size.height - stroke),
+            cornerRadius = CornerRadius(size.height * 0.2f),
             style = Stroke(stroke),
+        )
+        // Sprocket columns: two filled holes down each side.
+        val holeW = size.width * 0.12f
+        val holeH = size.height * 0.16f
+        for (side in listOf(size.width * 0.16f, size.width * 0.84f - holeW)) {
+            for (row in listOf(size.height * 0.24f, size.height * 0.6f)) {
+                drawRoundRect(
+                    tint,
+                    topLeft = Offset(side, row),
+                    size = Size(holeW, holeH),
+                    cornerRadius = CornerRadius(holeW * 0.4f),
+                )
+            }
+        }
+        // Center pane divider lines framing the picture area.
+        val paneInset = size.width * 0.34f
+        drawLine(
+            tint,
+            Offset(paneInset, stroke),
+            Offset(paneInset, size.height - stroke),
+            stroke * 0.8f,
+        )
+        drawLine(
+            tint,
+            Offset(size.width - paneInset, stroke),
+            Offset(size.width - paneInset, size.height - stroke),
+            stroke * 0.8f,
         )
     }
 }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorChrome.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorChrome.kt
@@ -1,0 +1,602 @@
+package com.opencapture.openzcine
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.Text
+
+// Compose mirrors of the iOS monitor chrome primitives (ios/Runner/
+// MonitorControls.swift + MonitorExperience.swift). Layout frames come from the
+// shared core's zone map; these components only mirror the DRAWING — pill
+// shapes, type hierarchy, and LiveDesign colors. SF Symbols are approximated
+// with small Canvas glyphs; SF→Roboto type differences are accepted.
+
+/** Rounded chrome shape (iOS `LiveDesign.cornerRadius`). */
+val ChromeShape = RoundedCornerShape(LiveDesign.CORNER_RADIUS_DP.dp)
+
+/** iOS `liquidGlass` fallback treatment: glass fill + hairline stroke. */
+fun Modifier.glass(shape: Shape = ChromeShape): Modifier =
+    background(LiveDesign.glass, shape).border(1.dp, LiveDesign.hairline, shape)
+
+/** Click without the Material ripple (chrome buttons highlight by state, not ripple). */
+@Composable
+fun Modifier.chromeClickable(onClick: () -> Unit): Modifier =
+    clickable(
+        interactionSource = remember { MutableInteractionSource() },
+        indication = null,
+        onClick = onClick,
+    )
+
+/** Text style matching iOS `.system(size:weight:design:)` closely enough. */
+fun chromeStyle(size: Float, weight: FontWeight, mono: Boolean = false): TextStyle =
+    TextStyle(
+        fontSize = size.sp,
+        lineHeight = size.sp,
+        fontWeight = weight,
+        fontFamily = if (mono) FontFamily.Monospace else FontFamily.SansSerif,
+        platformStyle = PlatformTextStyle(includeFontPadding = false),
+    )
+
+/** `HH:MM:SS` in text with the `:FF` frame field tinted accent (iOS TimecodeReadout). */
+fun timecodeAnnotated(frameCount: Long, fps: Int): AnnotatedString {
+    val seconds = frameCount / fps
+    val main = "%02d:%02d:%02d".format(seconds / 3600, seconds / 60 % 60, seconds % 60)
+    val frames = ":%02d".format(frameCount % fps)
+    return buildAnnotatedString {
+        withStyle(SpanStyle(color = LiveDesign.text)) { append(main) }
+        withStyle(SpanStyle(color = LiveDesign.accent)) { append(frames) }
+    }
+}
+
+/** STBY/REC pill: state dot + label in a glass capsule (iOS `RecordChip`). */
+@Composable
+fun RecordChip(recording: Boolean) {
+    Row(
+        modifier = Modifier.glass(CircleShape).padding(horizontal = 12.dp, vertical = 7.dp),
+        horizontalArrangement = Arrangement.spacedBy(7.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            Modifier.size(9.dp)
+                .background(if (recording) LiveDesign.rec else LiveDesign.faint, CircleShape),
+        )
+        Text(
+            text = if (recording) "REC" else "STBY",
+            style = chromeStyle(11f, FontWeight.Bold, mono = true),
+            color = if (recording) LiveDesign.text else LiveDesign.muted,
+        )
+    }
+}
+
+/** Glyph + value in a glass capsule (iOS `inlineReadout`). */
+@Composable
+fun ReadoutPill(value: String, icon: @Composable () -> Unit) {
+    Row(
+        modifier = Modifier.glass(CircleShape).padding(horizontal = 10.dp, vertical = 6.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        icon()
+        Text(
+            text = value,
+            style = chromeStyle(15f, FontWeight.Medium, mono = true),
+            color = LiveDesign.text,
+            maxLines = 1,
+        )
+    }
+}
+
+/** Signal bars + FPS readout capsule (iOS `FPSChip`). */
+@Composable
+fun FpsChip(signalBars: Int, fps: String) {
+    val tint =
+        when {
+            signalBars >= 3 -> LiveDesign.good
+            signalBars == 2 -> LiveDesign.accent
+            signalBars == 1 -> LiveDesign.rec
+            else -> LiveDesign.faint
+        }
+    Row(
+        modifier = Modifier.glass(CircleShape).padding(horizontal = 11.dp, vertical = 7.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        SignalBarsGlyph(bars = signalBars, tint = tint)
+        Text(
+            "FPS",
+            style = chromeStyle(8f, FontWeight.Bold, mono = true),
+            color = LiveDesign.faint,
+        )
+        Text(
+            fps,
+            style = chromeStyle(12f, FontWeight.Medium, mono = true),
+            color = LiveDesign.text,
+        )
+    }
+}
+
+/** One exposure readout: small label over a large mono value (iOS `CaptureSettingButton`). */
+@Composable
+fun CaptureSettingCell(label: String, value: String) {
+    Column(
+        modifier = Modifier.padding(vertical = 5.dp, horizontal = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(3.dp),
+    ) {
+        Text(label, style = chromeStyle(9f, FontWeight.SemiBold), color = LiveDesign.faint)
+        Text(
+            value,
+            style = chromeStyle(19f, FontWeight.Medium, mono = true),
+            color = LiveDesign.text,
+            maxLines = 1,
+        )
+    }
+}
+
+/** Lock toggle: glass rounded square, gold when engaged (iOS `lockButton`). */
+@Composable
+fun LockButton(locked: Boolean, modifier: Modifier = Modifier, onClick: () -> Unit) {
+    val tint = if (locked) LiveDesign.accent else LiveDesign.text.copy(alpha = 0.86f)
+    Box(
+        modifier =
+            modifier
+                .glass(ChromeShape)
+                .then(
+                    if (locked) {
+                        Modifier.border(
+                            1.5.dp,
+                            LiveDesign.accent.copy(alpha = 0.75f),
+                            ChromeShape,
+                        )
+                    } else {
+                        Modifier
+                    },
+                )
+                .chromeClickable(onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        PadlockGlyph(tint = tint, filled = locked, modifier = Modifier.size(16.dp))
+    }
+}
+
+/** DISP pill: label over mode dashes, the active dash lit (iOS `displayButton`). */
+@Composable
+fun DispButton(
+    activeIndex: Int,
+    modeCount: Int,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    // iOS tints the whole control info-blue while the LIVE mode (index 0) is active.
+    val labelColor = if (activeIndex == 0) LiveDesign.info else LiveDesign.text
+    Column(
+        modifier = modifier.glass(ChromeShape).chromeClickable(onClick),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text("DISP", style = chromeStyle(12f, FontWeight.Bold), color = labelColor)
+        Row(
+            Modifier.padding(top = 3.dp),
+            horizontalArrangement = Arrangement.spacedBy(3.dp),
+        ) {
+            repeat(modeCount) { index ->
+                Box(
+                    Modifier.size(width = 14.dp, height = 3.dp)
+                        .background(
+                            if (index == activeIndex) LiveDesign.info
+                            else LiveDesign.hairlineStrong,
+                            CircleShape,
+                        ),
+                )
+            }
+        }
+    }
+}
+
+/** Round glass auxiliary button (iOS `AssetCircleButton`). */
+@Composable
+fun AuxCircleButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+    glyph: @Composable (Modifier, Color) -> Unit,
+) {
+    Box(
+        modifier = modifier.glass(CircleShape).chromeClickable(onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        // iOS sizes the asset glyph at 44% of the circle diameter.
+        glyph(Modifier.fillMaxSize(0.44f), LiveDesign.text.copy(alpha = 0.86f))
+    }
+}
+
+/** Record control: red gradient disc, white ring, disc→stop square (iOS `RecordButton`). */
+@Composable
+fun RecordButton(recording: Boolean, modifier: Modifier = Modifier, onClick: () -> Unit) {
+    Canvas(modifier.chromeClickable(onClick)) {
+        val d = size.minDimension
+        val center = Offset(size.width / 2, size.height / 2)
+        if (recording) {
+            // Approximation of the iOS recording glow shadow.
+            drawCircle(LiveDesign.rec.copy(alpha = 0.28f), radius = d * 0.56f, center = center)
+        }
+        drawCircle(
+            brush =
+                Brush.radialGradient(
+                    colors = listOf(Color(0.88f, 0.28f, 0.30f), LiveDesign.rec),
+                    center = Offset(center.x, center.y - d / 2),
+                    radius = d * (48f / 72f),
+                ),
+            radius = d / 2,
+            center = center,
+        )
+        drawCircle(
+            Color.White.copy(alpha = 0.17f),
+            radius = d / 2 - 1.5.dp.toPx(),
+            center = center,
+            style = Stroke(width = 3.dp.toPx()),
+        )
+        if (recording) {
+            val side = d * (25f / 72f)
+            drawRoundRect(
+                LiveDesign.rec,
+                topLeft = Offset(center.x - side / 2, center.y - side / 2),
+                size = Size(side, side),
+                cornerRadius = CornerRadius(8.dp.toPx()),
+            )
+        } else {
+            drawCircle(LiveDesign.rec, radius = d * (58f / 72f) / 2, center = center)
+        }
+    }
+}
+
+/** Battery glyph + percent + device glyph column (iOS `BatteryIndicator`, `.rail`). */
+@Composable
+fun BatteryIndicatorColumn(percent: Int, isCamera: Boolean, modifier: Modifier = Modifier) {
+    val low = if (isCamera) percent < 10 else percent <= 15
+    val tint =
+        when {
+            low -> Color.Red
+            isCamera -> LiveDesign.accent
+            else -> LiveDesign.text.copy(alpha = 0.85f)
+        }
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterVertically),
+    ) {
+        BatteryGlyph(percent = percent, tint = tint, modifier = Modifier.size(22.dp, 11.dp))
+        Text(
+            "$percent%",
+            style = chromeStyle(10.5f, FontWeight.Medium, mono = true),
+            color = LiveDesign.text.copy(alpha = 0.72f),
+        )
+        if (isCamera) {
+            CameraGlyph(tint = LiveDesign.muted, modifier = Modifier.size(15.dp, 12.dp))
+        } else {
+            PhoneGlyph(tint = LiveDesign.muted, modifier = Modifier.size(9.dp, 14.dp))
+        }
+    }
+}
+
+// MARK: - Canvas glyphs (SF Symbol approximations)
+
+/** SF `battery.NNpercent` (horizontal body, quarter-bucket fill). */
+@Composable
+fun BatteryGlyph(percent: Int, tint: Color, modifier: Modifier = Modifier) {
+    // iOS buckets the fill at 0/25/50/75/100%.
+    val fill =
+        when {
+            percent < 13 -> 0f
+            percent < 38 -> 0.25f
+            percent < 63 -> 0.5f
+            percent < 88 -> 0.75f
+            else -> 1f
+        }
+    Canvas(modifier) {
+        val bodyWidth = size.width * 0.86f
+        val stroke = 1.2.dp.toPx()
+        drawRoundRect(
+            tint.copy(alpha = 0.6f),
+            topLeft = Offset(0f, 0f),
+            size = Size(bodyWidth, size.height),
+            cornerRadius = CornerRadius(size.height * 0.3f),
+            style = Stroke(stroke),
+        )
+        // Terminal nub.
+        drawRoundRect(
+            tint.copy(alpha = 0.6f),
+            topLeft = Offset(bodyWidth + stroke, size.height * 0.3f),
+            size = Size(size.width - bodyWidth - stroke, size.height * 0.4f),
+            cornerRadius = CornerRadius(1.dp.toPx()),
+        )
+        if (fill > 0f) {
+            val inset = stroke * 1.8f
+            drawRoundRect(
+                tint,
+                topLeft = Offset(inset, inset),
+                size = Size((bodyWidth - 2 * inset) * fill, size.height - 2 * inset),
+                cornerRadius = CornerRadius(size.height * 0.18f),
+            )
+        }
+    }
+}
+
+/** SF `iphone` outline. */
+@Composable
+fun PhoneGlyph(tint: Color, modifier: Modifier = Modifier) {
+    Canvas(modifier) {
+        drawRoundRect(
+            tint,
+            topLeft = Offset.Zero,
+            size = size,
+            cornerRadius = CornerRadius(size.width * 0.25f),
+            style = Stroke(1.2.dp.toPx()),
+        )
+        drawLine(
+            tint,
+            start = Offset(size.width * 0.35f, size.height - 2.2.dp.toPx()),
+            end = Offset(size.width * 0.65f, size.height - 2.2.dp.toPx()),
+            strokeWidth = 1.dp.toPx(),
+            cap = StrokeCap.Round,
+        )
+    }
+}
+
+/** SF `camera` outline. */
+@Composable
+fun CameraGlyph(tint: Color, modifier: Modifier = Modifier) {
+    Canvas(modifier) {
+        val stroke = 1.2.dp.toPx()
+        val bodyTop = size.height * 0.22f
+        drawRoundRect(
+            tint,
+            topLeft = Offset(0f, bodyTop),
+            size = Size(size.width, size.height - bodyTop),
+            cornerRadius = CornerRadius(size.height * 0.18f),
+            style = Stroke(stroke),
+        )
+        // Viewfinder hump.
+        drawLine(
+            tint,
+            start = Offset(size.width * 0.32f, bodyTop),
+            end = Offset(size.width * 0.42f, 0.5f * stroke),
+            strokeWidth = stroke,
+        )
+        drawLine(
+            tint,
+            start = Offset(size.width * 0.42f, 0.5f * stroke),
+            end = Offset(size.width * 0.58f, 0.5f * stroke),
+            strokeWidth = stroke,
+        )
+        drawLine(
+            tint,
+            start = Offset(size.width * 0.58f, 0.5f * stroke),
+            end = Offset(size.width * 0.68f, bodyTop),
+            strokeWidth = stroke,
+        )
+        drawCircle(
+            tint,
+            radius = size.height * 0.22f,
+            center = Offset(size.width / 2, bodyTop + (size.height - bodyTop) / 2),
+            style = Stroke(stroke),
+        )
+    }
+}
+
+/** SF `cellularbars` with `variableValue` (filled bars vs dim bars). */
+@Composable
+fun SignalBarsGlyph(bars: Int, tint: Color, modifier: Modifier = Modifier.size(16.dp, 12.dp)) {
+    Canvas(modifier) {
+        val barWidth = size.width / 4f * 0.68f
+        val gap = size.width / 4f * 0.32f
+        for (index in 0 until 4) {
+            val height = size.height * (0.35f + 0.65f * index / 3f)
+            drawRoundRect(
+                if (index < bars) tint else tint.copy(alpha = 0.3f),
+                topLeft = Offset(index * (barWidth + gap), size.height - height),
+                size = Size(barWidth, height),
+                cornerRadius = CornerRadius(barWidth * 0.35f),
+            )
+        }
+    }
+}
+
+/** SF `video` (camera body + lens flag). */
+@Composable
+fun VideoGlyph(tint: Color, modifier: Modifier = Modifier.size(14.dp, 10.dp)) {
+    Canvas(modifier) {
+        val bodyWidth = size.width * 0.68f
+        drawRoundRect(
+            tint,
+            topLeft = Offset.Zero,
+            size = Size(bodyWidth, size.height),
+            cornerRadius = CornerRadius(size.height * 0.28f),
+        )
+        val path =
+            Path().apply {
+                moveTo(bodyWidth + size.width * 0.06f, size.height * 0.5f)
+                lineTo(size.width, size.height * 0.12f)
+                lineTo(size.width, size.height * 0.88f)
+                close()
+            }
+        drawPath(path, tint)
+    }
+}
+
+/** SF `film` (frame + sprocket columns). */
+@Composable
+fun FilmGlyph(tint: Color, modifier: Modifier = Modifier.size(12.dp, 11.dp)) {
+    Canvas(modifier) {
+        val stroke = 1.1.dp.toPx()
+        drawRoundRect(
+            tint,
+            topLeft = Offset.Zero,
+            size = size,
+            cornerRadius = CornerRadius(size.height * 0.14f),
+            style = Stroke(stroke),
+        )
+        val inset = size.width * 0.22f
+        drawLine(tint, Offset(inset, 0f), Offset(inset, size.height), stroke)
+        drawLine(
+            tint,
+            Offset(size.width - inset, 0f),
+            Offset(size.width - inset, size.height),
+            stroke,
+        )
+        drawLine(
+            tint,
+            Offset(inset, size.height / 2),
+            Offset(size.width - inset, size.height / 2),
+            stroke * 0.8f,
+        )
+    }
+}
+
+/** SF `sdcard` (card outline with a clipped corner). */
+@Composable
+fun SdCardGlyph(tint: Color, modifier: Modifier = Modifier.size(9.dp, 12.dp)) {
+    Canvas(modifier) {
+        val cut = size.width * 0.34f
+        val r = size.width * 0.18f
+        val path =
+            Path().apply {
+                moveTo(cut, 0f)
+                lineTo(size.width - r, 0f)
+                quadraticTo(size.width, 0f, size.width, r)
+                lineTo(size.width, size.height - r)
+                quadraticTo(size.width, size.height, size.width - r, size.height)
+                lineTo(r, size.height)
+                quadraticTo(0f, size.height, 0f, size.height - r)
+                lineTo(0f, cut)
+                close()
+            }
+        drawPath(path, tint, style = Stroke(1.1.dp.toPx()))
+    }
+}
+
+/** SF `lock` / `lock.fill` (shackle + body). */
+@Composable
+fun PadlockGlyph(tint: Color, filled: Boolean, modifier: Modifier = Modifier) {
+    Canvas(modifier) {
+        val stroke = 1.4.dp.toPx()
+        val bodyTop = size.height * 0.44f
+        val shackleWidth = size.width * 0.52f
+        drawArc(
+            tint,
+            startAngle = 180f,
+            sweepAngle = 180f,
+            useCenter = false,
+            topLeft = Offset((size.width - shackleWidth) / 2, size.height * 0.06f),
+            size = Size(shackleWidth, bodyTop * 1.6f),
+            style = Stroke(stroke),
+        )
+        val bodyRect = Rect(0f, bodyTop, size.width, size.height)
+        if (filled) {
+            drawRoundRect(
+                tint,
+                topLeft = bodyRect.topLeft,
+                size = bodyRect.size,
+                cornerRadius = CornerRadius(size.width * 0.18f),
+            )
+        } else {
+            drawRoundRect(
+                tint,
+                topLeft = bodyRect.topLeft,
+                size = bodyRect.size,
+                cornerRadius = CornerRadius(size.width * 0.18f),
+                style = Stroke(stroke),
+            )
+        }
+    }
+}
+
+/** iOS `IconSettings` (gearshape) stand-in. */
+@Composable
+fun GearGlyph(tint: Color, modifier: Modifier = Modifier) {
+    Canvas(modifier) {
+        val stroke = 1.4.dp.toPx()
+        val center = Offset(size.width / 2, size.height / 2)
+        val outer = size.minDimension / 2 - stroke
+        val ring = outer * 0.72f
+        drawCircle(tint, radius = ring, center = center, style = Stroke(stroke))
+        drawCircle(tint, radius = ring * 0.42f, center = center, style = Stroke(stroke))
+        repeat(8) { index ->
+            val angle = Math.toRadians(index * 45.0)
+            val dir = Offset(kotlin.math.cos(angle).toFloat(), kotlin.math.sin(angle).toFloat())
+            drawLine(
+                tint,
+                start = center + dir * ring,
+                end = center + dir * outer,
+                strokeWidth = stroke * 1.4f,
+                cap = StrokeCap.Round,
+            )
+        }
+    }
+}
+
+/** iOS `IconMedia` (rectangle.stack) stand-in. */
+@Composable
+fun MediaStackGlyph(tint: Color, modifier: Modifier = Modifier) {
+    Canvas(modifier) {
+        val stroke = 1.4.dp.toPx()
+        val cardHeight = size.height * 0.58f
+        val inset = size.width * 0.12f
+        drawRoundRect(
+            tint,
+            topLeft = Offset(inset, 0f),
+            size = Size(size.width - 2 * inset, size.height * 0.16f),
+            cornerRadius = CornerRadius(2.dp.toPx()),
+            style = Stroke(stroke * 0.9f),
+        )
+        drawRoundRect(
+            tint,
+            topLeft = Offset(inset / 2, size.height * 0.24f),
+            size = Size(size.width - inset, size.height * 0.14f),
+            cornerRadius = CornerRadius(2.dp.toPx()),
+            style = Stroke(stroke * 0.9f),
+        )
+        drawRoundRect(
+            tint,
+            topLeft = Offset(0f, size.height - cardHeight),
+            size = Size(size.width, cardHeight),
+            cornerRadius = CornerRadius(3.dp.toPx()),
+            style = Stroke(stroke),
+        )
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
@@ -80,6 +80,33 @@ private object DemoMonitorState {
 private fun Modifier.zone(frame: ZoneFrame): Modifier =
     offset(frame.x.dp, frame.y.dp).size(frame.width.dp, frame.height.dp)
 
+/**
+ * The iPhone Dynamic Island's landscape leading safe-area inset, in points/dp —
+ * the canonical iOS geometry throughout the core tests
+ * (`Tests/OpenZCineCoreTests/MonitorLayoutPolicyTests.swift`:
+ * `MonitorEdgeInsets(top: 0, leading: 59, bottom: 21, trailing: 44)`).
+ * `MonitorFeedLayout.leadingInset` turns it into a left chrome lane: the feed
+ * starts at x = 59 while the fixed-margin lock button and battery rail
+ * (chrome insets ignore the safe area; lock spans x 16–56) sit beside it.
+ */
+internal const val IOS_ISLAND_LANE_DP = 59f
+
+/**
+ * Leading inset handed to the zone map, in dp: the display cutout floored at
+ * [IOS_ISLAND_LANE_DP], plus any transient system-bar lane on this edge.
+ *
+ * Devices whose punch-hole resolves below the core's 50dp cutout threshold
+ * (SM-A127F: zero inset) would otherwise run the feed edge-to-edge, putting
+ * the lock button and battery rail ON the image. Flooring the cutout at the
+ * iPhone island lane synthesizes the iOS composition — feed right of the
+ * chrome — as a platform-adapter decision, keeping the shared core
+ * platform-blind. The floor is a MINIMUM under the physical cutout only; a
+ * transient bar on this edge (reverse-landscape nav bar) still ADDS its lane
+ * on top so the feed clears the overlay.
+ */
+internal fun monitorLeadingInsetDp(cutoutDp: Float, transientBarDp: Float): Float =
+    maxOf(cutoutDp, IOS_ISLAND_LANE_DP) + maxOf(0f, transientBarDp - cutoutDp)
+
 /** Unwraps the owning [android.app.Activity] (a ComposeView's context is a wrapper). */
 private tailrec fun android.content.Context.findActivity(): android.app.Activity? =
     when (this) {
@@ -212,8 +239,19 @@ fun MonitorScreen(session: CameraSession, frameSource: LiveFrameSource?) {
             edgeDp(cutout.getBottom(density), barInsets.bottom),
             label = "safeBottom",
         )
+        // Leading carries the synthesized iPhone island lane (see
+        // monitorLeadingInsetDp); trailing gets NO floor — in the landscape
+        // zone map the trailing inset only feeds the which-side-is-the-cutout
+        // comparison and moves no frame (iOS's 44pt trailing is < the 59pt
+        // leading, same branch), the rail centering in the letterbox lane on
+        // both platforms.
         val safeLeading by animateFloatAsState(
-            edgeDp(cutout.getLeft(density, direction), barInsets.left),
+            with(density) {
+                monitorLeadingInsetDp(
+                    cutoutDp = cutout.getLeft(this, direction).toDp().value,
+                    transientBarDp = barInsets.left.toDp().value,
+                )
+            },
             label = "safeLeading",
         )
         val safeTrailing =
@@ -270,18 +308,11 @@ fun MonitorScreen(session: CameraSession, frameSource: LiveFrameSource?) {
         }
 
         // Top info pill, centered in the deck band; compact in clean mode.
-        // The core anchors the deck to the feed, and iPhones always carry a
-        // landscape island inset that starts the feed right of the lock; this
-        // device's sub-50dp cutout resolves to no inset, so the raw band would
-        // run under the lock. Clamp the band's leading edge past the lock —
-        // on iPhone-style geometry (deck.x > lock.maxX) this is a no-op.
-        val pillBand =
-            zones.infoBar.let { deck ->
-                val leading = maxOf(deck.x, zones.lock.x + zones.lock.width + 8f)
-                ZoneFrame(leading, deck.y, deck.width - (leading - deck.x), deck.height)
-            }
-        Box(Modifier.zone(pillBand), contentAlignment = Alignment.Center) {
-            FitScale(pillBand.width.dp) {
+        // The deck is feed-anchored and the synthesized island lane (see
+        // monitorLeadingInsetDp) starts the feed right of the lock, so the
+        // band always clears it — same as iPhone geometry.
+        Box(Modifier.zone(zones.infoBar), contentAlignment = Alignment.Center) {
+            FitScale(zones.infoBar.width.dp) {
                 InfoPill(compact = isClean, recording = recording, frameCount = frameCount)
             }
         }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
@@ -1,18 +1,25 @@
 package com.opencapture.openzcine
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -27,12 +34,14 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.displayCutout
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.union
 import com.opencapture.openzcine.bridge.MonitorZones
 import com.opencapture.openzcine.bridge.SwiftCore
 import com.opencapture.openzcine.bridge.ZoneFrame
@@ -52,22 +61,32 @@ private object DemoMonitorState {
     const val MEDIA = "521 GB·47%"
     const val FPS = "25.00"
     const val FRAME_RATE = 25
-    const val SIGNAL_BARS = 0
+    const val SIGNAL_BARS = 4
     const val CAMERA_BATTERY = 80
     const val PHONE_BATTERY = 84
+
+    /** label / current value / widest value (fixes the cell width, iOS `widestValue`). */
     val VALUES =
         listOf(
-            "ISO" to "800",
-            "SHUTTER" to "180°",
-            "IRIS" to "f/2.8",
-            "WB" to "5600K",
-            "FOCUS" to "AF-C",
+            Triple("ISO", "800", "25600"),
+            Triple("SHUTTER", "180°", "1/16000"),
+            Triple("IRIS", "f/2.8", "f/2.8"),
+            Triple("WB", "5600K", "5600K"),
+            Triple("FOCUS", "AF-C", "Wide-L"),
         )
 }
 
 /** Places a composable at an absolute zone frame (full-viewport dp coordinates). */
 private fun Modifier.zone(frame: ZoneFrame): Modifier =
     offset(frame.x.dp, frame.y.dp).size(frame.width.dp, frame.height.dp)
+
+/** Unwraps the owning [android.app.Activity] (a ComposeView's context is a wrapper). */
+private tailrec fun android.content.Context.findActivity(): android.app.Activity? =
+    when (this) {
+        is android.app.Activity -> this
+        is android.content.ContextWrapper -> baseContext.findActivity()
+        else -> null
+    }
 
 /**
  * The landscape monitor shell — a 1:1 port of the iOS `MonitorShell`
@@ -99,15 +118,113 @@ fun MonitorScreen(session: CameraSession, frameSource: LiveFrameSource?) {
         }
     }
 
-    BoxWithConstraints(Modifier.fillMaxSize().background(Color.Black)) {
+    // Sticky-immersive bar cycle. The platform's own transient reveal is
+    // deliberately opaque to apps (measured on the SM-A127F: no WindowInsets
+    // change, no visibility event, and only an unreliable zero-inset
+    // animation dispatch), so chrome could never move off the overlaid bars.
+    // The app does still receive the edge swipe's pointer events, so the
+    // shell detects the gesture itself — observe-only, nothing consumed —
+    // and owns the cycle: show() the bars for real (dispatching genuine
+    // insets, so the rail glides inward), hold them for a grace period, then
+    // hide() (the rail reclaims the edge).
+    var barsShown by remember { mutableStateOf(false) }
+    // The bar lanes chrome must clear, published by the cycle below once the
+    // shown insets are actually applied (Compose's own WindowInsets never
+    // update after a programmatic show() on this device, so the applied
+    // values are read off rootWindowInsets and pushed through this state).
+    var barInsets by remember { mutableStateOf(androidx.core.graphics.Insets.NONE) }
+    val view = LocalView.current
+    LaunchedEffect(barsShown) {
+        if (!barsShown) return@LaunchedEffect
+        val window = view.context.findActivity()?.window ?: return@LaunchedEffect
+        val controller = WindowCompat.getInsetsController(window, view)
+        controller.show(WindowInsetsCompat.Type.systemBars())
+        // Wait (briefly) for the show to land, then publish the real lanes.
+        var attempts = 0
+        while (attempts < 20) {
+            delay(50)
+            attempts++
+            val applied =
+                view.rootWindowInsets?.let {
+                    WindowInsetsCompat.toWindowInsetsCompat(it, view)
+                        .getInsets(WindowInsetsCompat.Type.systemBars())
+                } ?: androidx.core.graphics.Insets.NONE
+            if (applied != androidx.core.graphics.Insets.NONE) {
+                barInsets = applied
+                break
+            }
+        }
+        delay(3_000)
+        controller.hide(WindowInsetsCompat.Type.systemBars())
+        barInsets = androidx.core.graphics.Insets.NONE
+        barsShown = false
+    }
+
+    BoxWithConstraints(
+        Modifier.fillMaxSize()
+            .background(Color.Black)
+            .pointerInput(Unit) {
+                awaitEachGesture {
+                    val down = awaitFirstDown(pass = PointerEventPass.Initial)
+                    val edge = 24.dp.toPx()
+                    val nearTop = down.position.y < edge
+                    val nearRight = down.position.x > size.width - edge
+                    if (!nearTop && !nearRight) return@awaitEachGesture
+                    var travelX = 0f
+                    var travelY = 0f
+                    while (true) {
+                        val event = awaitPointerEvent(PointerEventPass.Initial)
+                        val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                        if (!change.pressed) break
+                        val delta = change.positionChange()
+                        travelX += delta.x
+                        travelY += delta.y
+                        val inward = if (nearTop) travelY else -travelX
+                        if (inward > 40.dp.toPx()) {
+                            barsShown = true
+                            break
+                        }
+                    }
+                }
+            },
+    ) {
         val density = LocalDensity.current
         val direction = LocalLayoutDirection.current
-        val safe = WindowInsets.systemBars.union(WindowInsets.displayCutout)
-        val safeTop = with(density) { safe.getTop(this).toDp().value }
-        val safeBottom = with(density) { safe.getBottom(this).toDp().value }
-        val safeLeading = with(density) { safe.getLeft(this, direction).toDp().value }
-        val safeTrailing = with(density) { safe.getRight(this, direction).toDp().value }
-        val viewportWidth = maxWidth.value
+        // Live safe area: the punch-hole cutout plus the applied system-bar
+        // lanes published by the cycle above. Each edge animates so the
+        // chrome glides off the bars and back instead of jumping. The top
+        // and bottom lanes flow through the safe area (the zone map's chrome
+        // insets track them), but the RIGHT rail is centered in the letterbox
+        // lane between the feed and the viewport edge and ignores trailing
+        // insets by design — so the nav-bar lane shrinks the viewport width
+        // instead, which slides the whole lane (and rail) inward.
+        // ponytail: fixed-landscape means the nav bar can only sit on the
+        // right on this device class; a left-handed nav lane would need a
+        // leading offset too.
+        val cutout = WindowInsets.displayCutout
+        fun edgeDp(cutoutPx: Int, barPx: Int): Float =
+            with(density) { maxOf(cutoutPx, barPx).toDp().value }
+        val safeTop by animateFloatAsState(
+            edgeDp(cutout.getTop(density), barInsets.top),
+            label = "safeTop",
+        )
+        val safeBottom by animateFloatAsState(
+            edgeDp(cutout.getBottom(density), barInsets.bottom),
+            label = "safeBottom",
+        )
+        val safeLeading by animateFloatAsState(
+            edgeDp(cutout.getLeft(density, direction), barInsets.left),
+            label = "safeLeading",
+        )
+        val safeTrailing =
+            with(density) { cutout.getRight(this, direction).toDp().value }
+        val navLane by animateFloatAsState(
+            with(density) {
+                maxOf(0, barInsets.right - cutout.getRight(this, direction)).toDp().value
+            },
+            label = "navLane",
+        )
+        val viewportWidth = maxWidth.value - navLane
         val viewportHeight = maxHeight.value
 
         // Same core call the iOS shell makes once per layout pass. The
@@ -153,16 +270,33 @@ fun MonitorScreen(session: CameraSession, frameSource: LiveFrameSource?) {
         }
 
         // Top info pill, centered in the deck band; compact in clean mode.
-        Box(Modifier.zone(zones.infoBar), contentAlignment = Alignment.Center) {
-            InfoPill(compact = isClean, recording = recording, frameCount = frameCount)
+        // The core anchors the deck to the feed, and iPhones always carry a
+        // landscape island inset that starts the feed right of the lock; this
+        // device's sub-50dp cutout resolves to no inset, so the raw band would
+        // run under the lock. Clamp the band's leading edge past the lock —
+        // on iPhone-style geometry (deck.x > lock.maxX) this is a no-op.
+        val pillBand =
+            zones.infoBar.let { deck ->
+                val leading = maxOf(deck.x, zones.lock.x + zones.lock.width + 8f)
+                ZoneFrame(leading, deck.y, deck.width - (leading - deck.x), deck.height)
+            }
+        Box(Modifier.zone(pillBand), contentAlignment = Alignment.Center) {
+            FitScale(pillBand.width.dp) {
+                InfoPill(compact = isClean, recording = recording, frameCount = frameCount)
+            }
         }
 
-        // Bottom capture strip — live mode only, dimmed while locked. The
-        // assist toolbar zone to its left is deferred (v1 skips assists).
+        // Bottom capture strip — live mode only, dimmed while locked; the
+        // glass hugs its readouts against the band's trailing edge like the
+        // iOS content-hugging strip. The assist toolbar zone to its left is
+        // deferred (v1 skips assists).
         if (!isClean) {
             zones.captureStrip?.let { strip ->
-                Box(Modifier.zone(strip).alpha(if (locked) 0.4f else 1f)) {
-                    CaptureStrip()
+                Box(
+                    Modifier.zone(strip).alpha(if (locked) 0.4f else 1f),
+                    contentAlignment = Alignment.CenterEnd,
+                ) {
+                    FitScale(strip.width.dp) { CaptureStrip() }
                 }
             }
         }
@@ -236,12 +370,14 @@ private fun InfoPill(compact: Boolean, recording: Boolean, frameCount: Long) {
 private fun CaptureStrip() {
     Row(
         modifier =
-            Modifier.fillMaxSize()
+            Modifier.height(LiveDesign.CONTROL_HEIGHT_DP.dp)
                 .glass(ChromeShape)
                 .padding(horizontal = 12.dp, vertical = 4.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        DemoMonitorState.VALUES.forEach { (label, value) -> CaptureSettingCell(label, value) }
+        DemoMonitorState.VALUES.forEach { (label, value, widest) ->
+            CaptureSettingCell(label, value, widest)
+        }
     }
 }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
@@ -1,0 +1,247 @@
+package com.opencapture.openzcine
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
+import com.opencapture.openzcine.bridge.MonitorZones
+import com.opencapture.openzcine.bridge.SwiftCore
+import com.opencapture.openzcine.bridge.ZoneFrame
+import com.opencapture.openzcine.core.CameraSession
+import com.opencapture.openzcine.core.CameraSessionState
+import com.opencapture.openzcine.core.LiveFrameSource
+import kotlinx.coroutines.delay
+
+/**
+ * Fake monitor readouts behind the state seam — mirrors the iOS demo state
+ * (`CameraDisplayState.preview`) so side-by-side screenshots match. Real
+ * values arrive with the session facade later.
+ */
+private object DemoMonitorState {
+    const val RESOLUTION = "6K·25p"
+    const val CODEC = "R3D NE"
+    const val MEDIA = "521 GB·47%"
+    const val FPS = "25.00"
+    const val FRAME_RATE = 25
+    const val SIGNAL_BARS = 0
+    const val CAMERA_BATTERY = 80
+    const val PHONE_BATTERY = 84
+    val VALUES =
+        listOf(
+            "ISO" to "800",
+            "SHUTTER" to "180°",
+            "IRIS" to "f/2.8",
+            "WB" to "5600K",
+            "FOCUS" to "AF-C",
+        )
+}
+
+/** Places a composable at an absolute zone frame (full-viewport dp coordinates). */
+private fun Modifier.zone(frame: ZoneFrame): Modifier =
+    offset(frame.x.dp, frame.y.dp).size(frame.width.dp, frame.height.dp)
+
+/**
+ * The landscape monitor shell — a 1:1 port of the iOS `MonitorShell`
+ * (ios/Runner/MonitorUnified.swift) landscape branch, laid out by the SAME
+ * shared-core zone map via [SwiftCore.monitorZoneMap].
+ *
+ * v1 scope: feed, top info pill, lock/battery band, capture strip, record /
+ * DISP / media / settings rail, DISP 1↔2 cycling. Deferred: the assist
+ * toolbar zone (skipped — its capture-strip sibling renders at its own zone),
+ * scopes, pickers/panels, portrait.
+ */
+@Composable
+fun MonitorScreen(session: CameraSession, frameSource: LiveFrameSource?) {
+    val sessionState by session.state.collectAsState()
+    LaunchedEffect(session) { session.connect() }
+
+    // Shell state, iOS-model-equivalent: DISP index (0 live, 1 clean), the
+    // interface lock, the record toggle, and the fake-clock timecode tick.
+    var dispIndex by remember { mutableIntStateOf(0) }
+    var locked by remember { mutableStateOf(false) }
+    var recording by remember { mutableStateOf(false) }
+    var frameCount by remember { mutableLongStateOf(0L) }
+    LaunchedEffect(Unit) {
+        val startNanos = System.nanoTime()
+        while (true) {
+            delay(40)
+            frameCount =
+                (System.nanoTime() - startNanos) * DemoMonitorState.FRAME_RATE / 1_000_000_000L
+        }
+    }
+
+    BoxWithConstraints(Modifier.fillMaxSize().background(Color.Black)) {
+        val density = LocalDensity.current
+        val direction = LocalLayoutDirection.current
+        val safe = WindowInsets.systemBars.union(WindowInsets.displayCutout)
+        val safeTop = with(density) { safe.getTop(this).toDp().value }
+        val safeBottom = with(density) { safe.getBottom(this).toDp().value }
+        val safeLeading = with(density) { safe.getLeft(this, direction).toDp().value }
+        val safeTrailing = with(density) { safe.getRight(this, direction).toDp().value }
+        val viewportWidth = maxWidth.value
+        val viewportHeight = maxHeight.value
+
+        // Same core call the iOS shell makes once per layout pass. The
+        // landscape map is mode-invariant (iOS gates chrome shell-side), so
+        // the map is keyed on geometry only.
+        val zones =
+            remember(viewportWidth, viewportHeight, safeTop, safeLeading, safeBottom, safeTrailing) {
+                MonitorZones.parse(
+                    SwiftCore.monitorZoneMap(
+                        viewportWidth = viewportWidth,
+                        viewportHeight = viewportHeight,
+                        safeTop = safeTop,
+                        safeLeading = safeLeading,
+                        safeBottom = safeBottom,
+                        safeTrailing = safeTrailing,
+                        mode = dispIndex,
+                        isPortrait = false,
+                        aspectFill = false,
+                        scopeCount = 0,
+                        mirrored = false,
+                        bottomBarHeight = LiveDesign.CONTROL_HEIGHT_DP,
+                    ),
+                )
+            }
+        val isClean = dispIndex == 1
+
+        // Feed at the zone map's feed frame; LiveFeedView aspect-fits within it.
+        Box(Modifier.zone(zones.feed), contentAlignment = Alignment.Center) {
+            if (frameSource != null) {
+                LiveFeedView(frameSource, Modifier.fillMaxSize())
+            } else {
+                Text(
+                    text =
+                        when (val current = sessionState) {
+                            is CameraSessionState.Connected -> current.identity.name
+                            CameraSessionState.Connecting -> "Connecting…"
+                            CameraSessionState.Disconnected -> "No camera"
+                        },
+                    style = chromeStyle(15f, FontWeight.Medium),
+                    color = LiveDesign.muted,
+                )
+            }
+        }
+
+        // Top info pill, centered in the deck band; compact in clean mode.
+        Box(Modifier.zone(zones.infoBar), contentAlignment = Alignment.Center) {
+            InfoPill(compact = isClean, recording = recording, frameCount = frameCount)
+        }
+
+        // Bottom capture strip — live mode only, dimmed while locked. The
+        // assist toolbar zone to its left is deferred (v1 skips assists).
+        if (!isClean) {
+            zones.captureStrip?.let { strip ->
+                Box(Modifier.zone(strip).alpha(if (locked) 0.4f else 1f)) {
+                    CaptureStrip()
+                }
+            }
+        }
+
+        // Side rails: lock + battery indicators + record / DISP / media / settings.
+        LockButton(locked, Modifier.zone(zones.lock)) { locked = !locked }
+        zones.batteryPhone?.let {
+            BatteryIndicatorColumn(
+                percent = DemoMonitorState.PHONE_BATTERY,
+                isCamera = false,
+                modifier = Modifier.zone(it),
+            )
+        }
+        zones.batteryCamera?.let {
+            BatteryIndicatorColumn(
+                percent = DemoMonitorState.CAMERA_BATTERY,
+                isCamera = true,
+                modifier = Modifier.zone(it),
+            )
+        }
+        AuxCircleButton(Modifier.zone(zones.settings)) { glyphModifier, tint ->
+            GearGlyph(tint, glyphModifier)
+        }
+        AuxCircleButton(Modifier.zone(zones.media)) { glyphModifier, tint ->
+            MediaStackGlyph(tint, glyphModifier)
+        }
+        RecordButton(recording, Modifier.zone(zones.record)) { recording = !recording }
+        DispButton(
+            activeIndex = dispIndex,
+            modeCount = 3, // Live / Clean / Command dashes, matching iOS; Command lands later.
+            modifier = Modifier.zone(zones.disp),
+        ) {
+            dispIndex = (dispIndex + 1) % 2
+        }
+
+        // Recording tally border at the physical edge (iOS `RecordingBorderModule`).
+        if (recording) {
+            Box(
+                Modifier.fillMaxSize()
+                    .border(4.dp, LiveDesign.rec, RoundedCornerShape(24.dp)),
+            )
+        }
+    }
+}
+
+/** The landscape top deck (iOS `MonitorInfoBar` `.infoPill`). */
+@Composable
+private fun InfoPill(compact: Boolean, recording: Boolean, frameCount: Long) {
+    Row(
+        modifier = Modifier.glass(ChromeShape).padding(horizontal = 12.dp, vertical = 6.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RecordChip(recording)
+        Text(
+            timecodeAnnotated(frameCount, DemoMonitorState.FRAME_RATE),
+            style = chromeStyle(20f, FontWeight.Medium, mono = true),
+            maxLines = 1,
+        )
+        if (!compact) {
+            ReadoutPill(DemoMonitorState.RESOLUTION) { VideoGlyph(LiveDesign.muted) }
+            ReadoutPill(DemoMonitorState.CODEC) { FilmGlyph(LiveDesign.muted) }
+            ReadoutPill(DemoMonitorState.MEDIA) { SdCardGlyph(LiveDesign.muted) }
+        }
+        FpsChip(DemoMonitorState.SIGNAL_BARS, DemoMonitorState.FPS)
+    }
+}
+
+/** The ISO/SHUTTER/IRIS/WB/FOCUS readout bar (iOS `MonitorCaptureStrip`, landscape). */
+@Composable
+private fun CaptureStrip() {
+    Row(
+        modifier =
+            Modifier.fillMaxSize()
+                .glass(ChromeShape)
+                .padding(horizontal = 12.dp, vertical = 4.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        DemoMonitorState.VALUES.forEach { (label, value) -> CaptureSettingCell(label, value) }
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/Theme.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/Theme.kt
@@ -21,6 +21,34 @@ object BrandColors {
 }
 
 /**
+ * Live-monitor design tokens — a 1:1 mirror of the iOS shell's `LiveDesign`
+ * (ios/Runner/MonitorExperience.swift). Same float components, so the two
+ * shells render identical chrome colors. Keep the two lists in sync.
+ */
+object LiveDesign {
+    val background = Color(0.072f, 0.064f, 0.053f)
+    val surface = Color(0.145f, 0.128f, 0.102f)
+    val glass = Color(0.105f, 0.092f, 0.073f, 0.64f)
+    val glassBright = Color(0.178f, 0.155f, 0.122f, 0.68f)
+    val hairline = Color(0.968f, 0.937f, 0.882f, 0.14f)
+    val hairlineStrong = Color(0.968f, 0.937f, 0.882f, 0.22f)
+    val text = Color(0.958f, 0.935f, 0.885f)
+    val muted = Color(0.642f, 0.600f, 0.535f)
+    val faint = Color(0.455f, 0.420f, 0.365f)
+    val accent = Color(0.914f, 0.674f, 0.208f)
+    val accentDim = Color(0.914f, 0.674f, 0.208f, 0.16f)
+    val good = Color(0.18f, 0.78f, 0.42f)
+    val rec = Color(0.82f, 0.20f, 0.23f)
+    val info = Color(0.10f, 0.58f, 0.98f)
+
+    /** Corner radius for rounded chrome surfaces (iOS `DesignTokens.cornerRadius`). */
+    const val CORNER_RADIUS_DP = 16f
+
+    /** Height of the bottom control bars (iOS `LiveDesign.controlHeight`). */
+    const val CONTROL_HEIGHT_DP = 58f
+}
+
+/**
  * Dark-only Material 3 theme for the monitor shell. There is no light
  * variant on purpose: a camera monitor is always black-backed.
  */

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/MonitorZones.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/MonitorZones.kt
@@ -1,0 +1,81 @@
+package com.opencapture.openzcine.bridge
+
+/** One zone frame in full-physical-viewport dp coordinates. */
+data class ZoneFrame(val x: Float, val y: Float, val width: Float, val height: Float)
+
+/** Mirror of the core's `MonitorZoneStyle`; ordinals match `MonitorZoneMapWire`. */
+enum class ZoneStyle {
+    INFO_PILL,
+    INFO_BAR,
+    AXIS_HORIZONTAL,
+    AXIS_VERTICAL,
+    SCOPES_FLOATING,
+    SCOPES_STACKED,
+    BATTERY_RAIL,
+    BATTERY_INLINE,
+}
+
+/**
+ * Parsed monitor zone map — the Kotlin view of the core's `MonitorZoneMap`,
+ * decoded from the flat `[kind, style, x, y, width, height]` records produced
+ * by `SwiftCore.monitorZoneMap` / `MonitorZoneMapWire.flattened` (Swift).
+ *
+ * [batteryPhone]/[batteryCamera] are the per-indicator frames of the landscape
+ * battery rail (`MonitorBatteryRailLayout.fit`), present only when
+ * [batteryStyle] is [ZoneStyle.BATTERY_RAIL].
+ */
+data class MonitorZones(
+    val feed: ZoneFrame,
+    val infoBar: ZoneFrame,
+    val captureStrip: ZoneFrame?,
+    val assistStrip: ZoneFrame?,
+    val systemCluster: ZoneFrame,
+    val lock: ZoneFrame,
+    val disp: ZoneFrame,
+    val record: ZoneFrame,
+    val media: ZoneFrame,
+    val settings: ZoneFrame,
+    val batteryCluster: ZoneFrame?,
+    val batteryStyle: ZoneStyle?,
+    val batteryPhone: ZoneFrame?,
+    val batteryCamera: ZoneFrame?,
+    val scopes: ZoneFrame?,
+    val controlsGrid: ZoneFrame?,
+) {
+    companion object {
+        private const val STRIDE = 6
+
+        /** Decodes the wire array; throws when a required zone is missing. */
+        fun parse(flat: FloatArray): MonitorZones {
+            require(flat.size % STRIDE == 0) { "zone array length ${flat.size} not a multiple of $STRIDE" }
+            val frames = HashMap<Int, ZoneFrame>()
+            val styles = HashMap<Int, ZoneStyle>()
+            for (start in flat.indices step STRIDE) {
+                val kind = flat[start].toInt()
+                frames[kind] = ZoneFrame(flat[start + 2], flat[start + 3], flat[start + 4], flat[start + 5])
+                val style = flat[start + 1].toInt()
+                if (style >= 0) styles[kind] = ZoneStyle.entries[style]
+            }
+            fun required(kind: Int): ZoneFrame =
+                requireNotNull(frames[kind]) { "zone map missing required kind $kind" }
+            return MonitorZones(
+                feed = required(0),
+                infoBar = required(1),
+                captureStrip = frames[2],
+                assistStrip = frames[3],
+                systemCluster = required(4),
+                lock = required(5),
+                disp = required(6),
+                record = required(7),
+                media = required(8),
+                settings = required(9),
+                batteryCluster = frames[10],
+                batteryStyle = styles[10],
+                batteryPhone = frames[13],
+                batteryCamera = frames[14],
+                scopes = frames[11],
+                controlsGrid = frames[12],
+            )
+        }
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCore.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCore.kt
@@ -42,6 +42,31 @@ object SwiftCore {
     external fun resolveDisplayName(rawName: String): String
 
     /**
+     * Monitor zone map from the shared core's `MonitorZoneLayout.map` — the
+     * exact frames the iOS shell lays chrome out with. Flat records of
+     * `[kind, style, x, y, width, height]` (see [MonitorZones.parse] and the
+     * Swift mirror `MonitorZoneMapWire`). All dimensions are dp.
+     *
+     * @param mode DispMode ordinal: 0 live, 1 clean, 2 command.
+     * @param aspectFill portrait feed aspect; false = fit 16:9.
+     * @param mirrored true for the mirrored landscape-right chrome.
+     */
+    external fun monitorZoneMap(
+        viewportWidth: Float,
+        viewportHeight: Float,
+        safeTop: Float,
+        safeLeading: Float,
+        safeBottom: Float,
+        safeTrailing: Float,
+        mode: Int,
+        isPortrait: Boolean,
+        aspectFill: Boolean,
+        scopeCount: Int,
+        mirrored: Boolean,
+        bottomBarHeight: Float,
+    ): FloatArray
+
+    /**
      * Registers [listener] and has Swift push a canned connection-phase
      * sequence from a background thread — the callback shape session events
      * and live-view frames will use.

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/MonitorInsetsTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/MonitorInsetsTest.kt
@@ -1,0 +1,42 @@
+package com.opencapture.openzcine
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pure-JVM check of the zone-map leading-inset derivation: the display cutout
+ * floored at the synthesized iPhone island lane, plus any transient
+ * system-bar lane on the same edge.
+ */
+class MonitorInsetsTest {
+    @Test
+    fun zeroCutoutFloorsAtTheIslandLane() {
+        // SM-A127F: the punch-hole resolves to a zero inset — the floor alone
+        // must carve the iPhone-parity left lane.
+        assertEquals(IOS_ISLAND_LANE_DP, monitorLeadingInsetDp(0f, 0f))
+    }
+
+    @Test
+    fun cutoutWiderThanTheLaneWins() {
+        assertEquals(70f, monitorLeadingInsetDp(70f, 0f))
+    }
+
+    @Test
+    fun transientBarAddsItsLaneOnTopOfTheFloor() {
+        // Reverse-landscape nav bar on the leading edge: the bar lane stacks
+        // on the floored cutout so the feed clears the overlay.
+        assertEquals(IOS_ISLAND_LANE_DP + 48f, monitorLeadingInsetDp(0f, 48f))
+    }
+
+    @Test
+    fun transientBarOverlappingTheCutoutOnlyAddsTheExcess() {
+        // Bar (80) renders over the physical cutout (70): only the 10dp of
+        // bar beyond the cutout stacks — no double count.
+        assertEquals(80f, monitorLeadingInsetDp(70f, 80f))
+    }
+
+    @Test
+    fun transientBarNarrowerThanTheCutoutAddsNothing() {
+        assertEquals(70f, monitorLeadingInsetDp(70f, 40f))
+    }
+}

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/MonitorZonesTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/MonitorZonesTest.kt
@@ -1,0 +1,53 @@
+package com.opencapture.openzcine.bridge
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+/** Pure-JVM check of the wire decoding against a hand-built record array. */
+class MonitorZonesTest {
+    // [kind, style, x, y, width, height] — kinds 0..9 required, 10/13 optional.
+    private val flat =
+        floatArrayOf(
+            0f, -1f, 59f, 0f, 734f, 393f, // feed
+            1f, 0f, 100f, 8f, 500f, 46f, // infoBar, INFO_PILL
+            2f, 2f, 300f, 321f, 400f, 58f, // captureStrip, AXIS_HORIZONTAL
+            4f, 3f, 16f, 14f, 60f, 365f, // systemCluster, AXIS_VERTICAL
+            5f, -1f, 16f, 14f, 40f, 40f, // lock
+            6f, -1f, 780f, 300f, 44f, 34f, // disp
+            7f, -1f, 776f, 160f, 72f, 72f, // record
+            8f, -1f, 782f, 100f, 40f, 40f, // media
+            9f, -1f, 782f, 50f, 40f, 40f, // settings
+            10f, 6f, 16f, 80f, 38f, 233f, // batteryCluster, BATTERY_RAIL
+            13f, -1f, 16f, 90f, 38f, 70f, // batteryPhone
+            14f, -1f, 16f, 230f, 38f, 70f, // batteryCamera
+        )
+
+    @Test
+    fun parsesRequiredAndOptionalZones() {
+        val zones = MonitorZones.parse(flat)
+        assertEquals(ZoneFrame(59f, 0f, 734f, 393f), zones.feed)
+        assertEquals(ZoneFrame(776f, 160f, 72f, 72f), zones.record)
+        assertEquals(ZoneStyle.BATTERY_RAIL, zones.batteryStyle)
+        assertEquals(ZoneFrame(16f, 90f, 38f, 70f), zones.batteryPhone)
+        assertNull(zones.assistStrip)
+        assertNull(zones.scopes)
+        assertNull(zones.controlsGrid)
+    }
+
+    @Test
+    fun rejectsMissingRequiredZone() {
+        // Drop the feed record (first 6 floats).
+        assertFailsWith<IllegalArgumentException> {
+            MonitorZones.parse(flat.copyOfRange(6, flat.size))
+        }
+    }
+
+    @Test
+    fun rejectsTornArray() {
+        assertFailsWith<IllegalArgumentException> {
+            MonitorZones.parse(flat.copyOfRange(0, 7))
+        }
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -10,9 +10,9 @@ let package = Package(
     ],
     products: [
         .library(name: "OpenZCineCore", targets: ["OpenZCineCore"]),
-        // JNI facade consumed by the Android app (`just android-core`). The facade
-        // sources are fully `#if os(Android)`-gated, so on Darwin this product
-        // compiles to an empty module and iOS/macOS behavior is unchanged.
+        // JNI facade consumed by the Android app (`just android-core`). The JNI
+        // shims are `#if os(Android)`-gated; on Darwin only the platform-neutral
+        // wire helpers compile, so iOS/macOS behavior is unchanged.
         .library(
             name: "OpenZCineAndroid", type: .dynamic, targets: ["OpenZCineAndroidFacade"]),
     ],
@@ -39,9 +39,10 @@ let package = Package(
             name: "OpenZCineAndroidFacade",
             dependencies: ["OpenZCineCore", "CJNI"]
         ),
-        // Exercises the facade's PTP-IP session layer against a scripted fake
-        // camera server; runs on Darwin (and on Android via the cross-compile
-        // test path from the feasibility experiment).
+        // Runs on Darwin (and on Android via the cross-compile test path):
+        // the PTP-IP session layer against a scripted fake camera server, and
+        // the platform-independent zone-map wire format (MonitorZoneMapWire).
+        // The JNI shims themselves stay Android-only.
         .testTarget(
             name: "OpenZCineAndroidFacadeTests",
             dependencies: ["OpenZCineAndroidFacade", "OpenZCineCore"]

--- a/Sources/OpenZCineAndroidFacade/MonitorZoneMapWire.swift
+++ b/Sources/OpenZCineAndroidFacade/MonitorZoneMapWire.swift
@@ -1,0 +1,146 @@
+// Flat wire format for `MonitorZoneMap` crossing the JNI seam.
+//
+// Unlike the `@_cdecl` shims in SwiftCoreJNI.swift this file compiles on every
+// platform, so the flattening is exercised by `just native-check` on macOS
+// against the exact zone math the iOS shell consumes. The Kotlin mirror lives
+// in `Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/MonitorZones.kt`.
+
+import OpenZCineCore
+
+/// Flattens the core monitor zone map into a `[Float]` of fixed-stride records
+/// so the Compose shell consumes the SAME frames the iOS shell does — no layout
+/// math is re-derived in Kotlin.
+///
+/// Wire format: records of ``stride`` floats, `[kind, style, x, y, width, height]`,
+/// appended in ascending-kind order. Optional zones are simply absent. Frames are
+/// absolute full-physical-viewport coordinates in points (Android: dp).
+///
+/// Kind ordinals: 0 feed, 1 infoBar, 2 captureStrip, 3 assistStrip,
+/// 4 systemCluster, 5 lock, 6 disp, 7 record, 8 media, 9 settings,
+/// 10 batteryCluster, 11 scopes, 12 controlsGrid, 13 batteryPhone,
+/// 14 batteryCamera. Kinds 13/14 are the per-indicator frames of the landscape
+/// battery rail (`MonitorBatteryRailLayout.fit`), emitted only with a
+/// `.batteryRail`-styled cluster — the iOS shell computes these inside
+/// `BatteryRailModule`, which Compose cannot call.
+///
+/// Style ordinals mirror `MonitorZoneStyle` declaration order: 0 infoPill,
+/// 1 infoBar, 2 axisHorizontal, 3 axisVertical, 4 scopesFloating,
+/// 5 scopesStacked, 6 batteryRail, 7 batteryInline; `-1` for zones that carry
+/// no style (feed, system slots, battery indicators).
+public enum MonitorZoneMapWire {
+    /// Floats per record.
+    public static let stride = 6
+
+    /// Builds the zone map via `MonitorZoneLayout.map` and flattens it.
+    ///
+    /// - Parameters:
+    ///   - mode: `DispMode` ordinal — 0 live, 1 clean, 2 command.
+    ///   - aspectFill: portrait feed aspect — `false` = fit16x9, `true` = fill.
+    ///   - mirrored: `true` for the horizontally mirrored landscape-right chrome.
+    ///   - Remaining parameters mirror `MonitorZoneLayout.map` directly.
+    public static func flattened(
+        viewportWidth: Double,
+        viewportHeight: Double,
+        safeTop: Double,
+        safeLeading: Double,
+        safeBottom: Double,
+        safeTrailing: Double,
+        mode: Int,
+        isPortrait: Bool,
+        aspectFill: Bool,
+        scopeCount: Int,
+        mirrored: Bool,
+        bottomBarHeight: Double
+    ) -> [Float] {
+        let dispMode: DispMode =
+            switch mode {
+            case 1: .clean
+            case 2: .command
+            default: .live
+            }
+        let map = MonitorZoneLayout.map(
+            viewportWidth: viewportWidth,
+            viewportHeight: viewportHeight,
+            safeArea: MonitorEdgeInsets(
+                top: safeTop, leading: safeLeading, bottom: safeBottom, trailing: safeTrailing
+            ),
+            mode: dispMode,
+            isPortrait: isPortrait,
+            aspect: aspectFill ? .fill : .fit16x9,
+            scopeCount: scopeCount,
+            horizontalDirection: mirrored ? .mirrored : .standard,
+            bottomBarHeight: bottomBarHeight
+        )
+
+        var out: [Float] = []
+        func append(
+            kind: Int, style: MonitorZoneStyle?, x: Double, y: Double, width: Double,
+            height: Double
+        ) {
+            out.append(Float(kind))
+            out.append(style.map(styleOrdinal) ?? -1)
+            out.append(Float(x))
+            out.append(Float(y))
+            out.append(Float(width))
+            out.append(Float(height))
+        }
+        func append(kind: Int, zone: MonitorZone?) {
+            guard let zone else { return }
+            append(
+                kind: kind, style: zone.style, x: zone.frame.x, y: zone.frame.y,
+                width: zone.frame.width, height: zone.frame.height)
+        }
+        func append(kind: Int, slot: MonitorModuleFrame) {
+            append(
+                kind: kind, style: nil, x: slot.x, y: slot.y, width: slot.width,
+                height: slot.height)
+        }
+
+        append(
+            kind: 0, style: nil, x: map.feed.x, y: map.feed.y, width: map.feed.width,
+            height: map.feed.height)
+        append(kind: 1, zone: map.infoBar)
+        append(kind: 2, zone: map.captureStrip)
+        append(kind: 3, zone: map.assistStrip)
+        append(kind: 4, zone: map.systemCluster)
+        append(kind: 5, slot: map.systemSlots.lock)
+        append(kind: 6, slot: map.systemSlots.disp)
+        append(kind: 7, slot: map.systemSlots.record)
+        append(kind: 8, slot: map.systemSlots.media)
+        append(kind: 9, slot: map.systemSlots.settings)
+        append(kind: 10, zone: map.batteryCluster)
+        append(kind: 11, zone: map.scopes)
+        append(kind: 12, zone: map.controlsGrid)
+
+        // Battery-rail indicator frames (iOS: BatteryRailModule + MonitorBatteryRailLayout.fit).
+        if let battery = map.batteryCluster, battery.style == .batteryRail {
+            let rail = MonitorBatteryRailLayout.fit(railHeight: battery.frame.height)
+            let w = MonitorBatteryRailLayout.indicatorWidth
+            let h = MonitorBatteryRailLayout.indicatorHeight
+            append(
+                kind: 13, style: nil,
+                x: battery.frame.x + rail.phoneCenterX - w / 2,
+                y: battery.frame.y + rail.phoneCenterY - h / 2,
+                width: w, height: h)
+            append(
+                kind: 14, style: nil,
+                x: battery.frame.x + rail.cameraCenterX - w / 2,
+                y: battery.frame.y + rail.cameraCenterY - h / 2,
+                width: w, height: h)
+        }
+        return out
+    }
+
+    private static func styleOrdinal(_ style: MonitorZoneStyle) -> Float {
+        switch style {
+        case .infoPill: 0
+        case .infoBar: 1
+        case .axisHorizontal: 2
+        case .axisVertical: 3
+        case .scopesFloating: 4
+        case .scopesStacked: 5
+        case .batteryRail: 6
+        case .batteryInline: 7
+        }
+    }
+}

--- a/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
+++ b/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
@@ -85,6 +85,42 @@
         return javaString(env, display)
     }
 
+    // MARK: - Monitor layout
+
+    /// `SwiftCore.monitorZoneMap(...): FloatArray` — the shared core's
+    /// `MonitorZoneLayout.map` flattened per `MonitorZoneMapWire` (records of
+    /// `[kind, style, x, y, width, height]`). The Compose shell consumes the
+    /// same zone frames the iOS shell does; no layout math lives in Kotlin.
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_monitorZoneMap")
+    public func swiftCoreMonitorZoneMap(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?,
+        viewportWidth: jfloat, viewportHeight: jfloat,
+        safeTop: jfloat, safeLeading: jfloat, safeBottom: jfloat, safeTrailing: jfloat,
+        mode: jint, isPortrait: jboolean, aspectFill: jboolean,
+        scopeCount: jint, mirrored: jboolean, bottomBarHeight: jfloat
+    ) -> jfloatArray? {
+        let flat = MonitorZoneMapWire.flattened(
+            viewportWidth: Double(viewportWidth),
+            viewportHeight: Double(viewportHeight),
+            safeTop: Double(safeTop),
+            safeLeading: Double(safeLeading),
+            safeBottom: Double(safeBottom),
+            safeTrailing: Double(safeTrailing),
+            mode: Int(mode),
+            isPortrait: isPortrait != 0,
+            aspectFill: aspectFill != 0,
+            scopeCount: Int(scopeCount),
+            mirrored: mirrored != 0,
+            bottomBarHeight: Double(bottomBarHeight)
+        )
+        let fns = table(env)
+        guard let array = fns.NewFloatArray!(env, jsize(flat.count)) else { return nil }
+        flat.withUnsafeBufferPointer { buffer in
+            fns.SetFloatArrayRegion!(env, array, 0, jsize(flat.count), buffer.baseAddress)
+        }
+        return array
+    }
+
     // MARK: - Callback / streaming shape
 
     /// Listener state that crosses to the pushing thread.

--- a/Tests/OpenZCineAndroidFacadeTests/MonitorZoneMapWireTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/MonitorZoneMapWireTests.swift
@@ -1,0 +1,87 @@
+import OpenZCineCore
+import Testing
+
+@testable import OpenZCineAndroidFacade
+
+/// The wire format must carry `MonitorZoneLayout.map` frames byte-for-value —
+/// the Compose shell renders straight off these records.
+struct MonitorZoneMapWireTests {
+    // iPhone-class landscape viewport with a leading cutout, live mode.
+    private let flat = MonitorZoneMapWire.flattened(
+        viewportWidth: 852, viewportHeight: 393,
+        safeTop: 0, safeLeading: 59, safeBottom: 21, safeTrailing: 59,
+        mode: 0, isPortrait: false, aspectFill: false,
+        scopeCount: 0, mirrored: false, bottomBarHeight: 58
+    )
+
+    private let map = MonitorZoneLayout.map(
+        viewportWidth: 852, viewportHeight: 393,
+        safeArea: MonitorEdgeInsets(top: 0, leading: 59, bottom: 21, trailing: 59),
+        mode: .live, isPortrait: false, aspect: .fit16x9,
+        scopeCount: 0, horizontalDirection: .standard, bottomBarHeight: 58
+    )
+
+    /// Record for a kind: `[style, x, y, width, height]`, or nil when absent.
+    private func record(_ kind: Float) -> [Float]? {
+        for start in stride(from: 0, to: flat.count, by: MonitorZoneMapWire.stride)
+        where flat[start] == kind {
+            return Array(flat[(start + 1)..<(start + MonitorZoneMapWire.stride)])
+        }
+        return nil
+    }
+
+    @Test func recordsAreWellFormed() {
+        #expect(flat.count % MonitorZoneMapWire.stride == 0)
+        let allFinite = flat.allSatisfy { $0.isFinite }
+        #expect(allFinite)
+    }
+
+    @Test func feedFrameMatchesCore() throws {
+        let feed = try #require(record(0))
+        #expect(feed[0] == -1)
+        #expect(feed[1] == Float(map.feed.x))
+        #expect(feed[2] == Float(map.feed.y))
+        #expect(feed[3] == Float(map.feed.width))
+        #expect(feed[4] == Float(map.feed.height))
+    }
+
+    @Test func infoBarCarriesPillStyle() throws {
+        let info = try #require(record(1))
+        #expect(info[0] == 0)  // .infoPill
+        #expect(info[1] == Float(map.infoBar.frame.x))
+        #expect(info[3] == Float(map.infoBar.frame.width))
+    }
+
+    @Test func systemSlotsMatchCore() throws {
+        let lock = try #require(record(5))
+        #expect(lock[1] == Float(map.systemSlots.lock.x))
+        #expect(lock[2] == Float(map.systemSlots.lock.y))
+        let rec = try #require(record(7))
+        #expect(rec[1] == Float(map.systemSlots.record.x))
+        #expect(rec[3] == Float(map.systemSlots.record.width))
+    }
+
+    @Test func batteryRailEmitsIndicatorFrames() throws {
+        let cluster = try #require(map.batteryCluster)
+        #expect(cluster.style == .batteryRail)
+        let rail = MonitorBatteryRailLayout.fit(railHeight: cluster.frame.height)
+        let phone = try #require(record(13))
+        #expect(phone[0] == -1)
+        #expect(
+            phone[1]
+                == Float(
+                    cluster.frame.x + rail.phoneCenterX
+                        - MonitorBatteryRailLayout.indicatorWidth / 2))
+        let camera = try #require(record(14))
+        #expect(
+            camera[2]
+                == Float(
+                    cluster.frame.y + rail.cameraCenterY
+                        - MonitorBatteryRailLayout.indicatorHeight / 2))
+    }
+
+    @Test func landscapeOmitsPortraitOnlyZones() {
+        #expect(record(11) == nil)  // scopes float in landscape
+        #expect(record(12) == nil)  // controls grid is command/portrait-fit only
+    }
+}

--- a/ios/Runner/DemoHarness.swift
+++ b/ios/Runner/DemoHarness.swift
@@ -81,6 +81,17 @@ enum DemoHarness {
                     model.showPicker(
                         picker, mode: env["ZC_DEMO_PICKER_MODE"].flatMap(Int.init) ?? 0)
                 }
+                if let raw = env["ZC_DEMO_DISP"], let mode = DispMode(rawValue: raw) {
+                    // Demo/screenshot affordance: launch straight into a DISP mode (live/clean/
+                    // command) for headless mode-state captures.
+                    model.displayMode = mode
+                }
+                if env["ZC_DEMO_RECORDING"] == "1" {
+                    // Demo/screenshot affordance: stage the recording state (REC chip, tally
+                    // border, stop-square record button) without tapping the record control.
+                    model.isRecording = true
+                    model.cameraState = model.cameraState.updating(recordState: .recording)
+                }
                 if let raw = env["ZC_DEMO_LUT"] {
                     // Demo/screenshot affordance: seed a LUT and switch the tool on. `custom:<file>`
                     // selects a stored custom cube; otherwise the value names a built-in look.


### PR DESCRIPTION
Part of #72 (Kaneo OPE-29). The real Android monitor shell — a 1:1 port of the iOS landscape chrome, laid out by the shared core's zone map through a new JNI facade call so both platforms share one geometry engine.

- **`MonitorZoneMapWire`** (facade): flattens `MonitorZoneLayout.map` + battery-rail frames into a fixed-stride float array; compiles and is tested on Darwin (wire values asserted equal to the core map). Kotlin decodes it (`MonitorZones`, pure-JVM tested); no layout math re-derived in Kotlin.
- **Chrome**: LiveDesign tokens ported float-for-float — glass pills, top info deck (STBY/REC chip, ticking timecode, format/codec/storage pills, signal+FPS), lock toggle, battery rail at core-computed frames, capture strip with iOS width-reservation + fit-scale, record button (radial gradient / ring / stop-square + glow), DISP pill cycling DISP 1↔2, media/settings circles, recording tally border.
- **Immersive posture**: system bars sticky-hidden, forced-dark transparent styling. Samsung's transient bar reveal is provably invisible to apps (no insets/events — measured), so the shell owns the cycle: edge-swipe detected from pointer events → bars shown → rail glides inward off the nav bar → auto-rehide reclaims the edge. Feed stays stable.
- Fake demo readouts mirror `CameraDisplayState.preview` until the session facade wires in. v1 scope: landscape only; assist toolbar, scopes, pickers, portrait, DISP 3 deferred.

Verified: `just check` / `just native-check` (662 tests) / `just android-check` green; device-vs-simulator side-by-side montages for DISP 1, DISP 2, recording, and the bars cycle (in the PR conversation below).

Kaneo: OPE-29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
