### PR TITLE
feat(android): scopes v1 — waveform, parade, histogram, vectorscope from the core

### DIFF
--- a/Apps/Android/README.md
+++ b/Apps/Android/README.md
@@ -4,7 +4,7 @@ Production Jetpack Compose shell. The landscape monitor screen is a 1:1 port of 
 shell's chrome, laid out by the shared core's zone map (`SwiftCore.monitorZoneMap` →
 `MonitorZoneLayout.map`) — no layout math lives in Kotlin. v1 covers the live feed, top
 info deck, capture readout strip, lock/battery band, and the record/DISP/media/settings
-rail with DISP 1↔2 cycling; assists, scopes, pickers, and portrait land later. Readouts
+rail with DISP 1↔2 cycling; assists, pickers, and portrait land later. Readouts
 are fake demo values until the session facade arrives. Without the staged Swift core the
 app falls back to the placeholder monitor ("No camera").
 
@@ -34,4 +34,12 @@ app falls back to the placeholder monitor ("No camera").
   (logcat tag `SwiftCoreCameraSession`). For a fake-ZR server on the development Mac (scripted
   twin: `Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift`), forward the port with
   `adb reverse tcp:15740 tcp:15740` and use host `127.0.0.1`.
+- **Scopes v1:** waveform, RGB parade, histogram, and vectorscope render at ~10 Hz from the
+  live feed. All axis/curve math lives in the shared core behind the facade
+  (`Sources/OpenZCineAndroidFacade/ScopeFrameWire.swift` ↔ `bridge/ScopeWire.kt`): the 3-anchor
+  display axis (log-black floor → 5% crush line, fixed per-curve mid grey, clip warning → 95%
+  line) and the tone-mapped vectorscope come back as flat payloads; Kotlin only reduces the
+  JPEG (1/2ⁿ decode to ≤160 px wide) and draws (`ScopeView.kt`). Debug toggle until the scope
+  picker chrome lands:
+  `adb shell am start -n com.opencapture.openzcine/.MainActivity --ez zc.demo.feed true --es zc.scopes wave|parade|histo|vector`.
 - **Local SDK:** put `sdk.dir=<your Android SDK path>` in `Apps/Android/local.properties` (gitignored).

--- a/Apps/Android/app/src/debug/kotlin/com/opencapture/openzcine/DemoHarness.kt
+++ b/Apps/Android/app/src/debug/kotlin/com/opencapture/openzcine/DemoHarness.kt
@@ -22,6 +22,19 @@ object DemoHarness {
     /** Boolean intent extra that switches the synthetic demo feed on. */
     const val EXTRA_DEMO_FEED = "zc.demo.feed"
 
+    /** String intent extra selecting a scope: `wave|parade|histo|vector`. */
+    const val EXTRA_SCOPES = "zc.scopes"
+
+    /**
+     * The scope selected by the debug intent, or null. Activate with e.g.
+     * ```
+     * adb shell am start -n com.opencapture.openzcine/.MainActivity \
+     *   --ez zc.demo.feed true --es zc.scopes wave
+     * ```
+     */
+    fun scopeKind(intent: Intent): ScopeKind? =
+        ScopeKind.fromToken(intent.getStringExtra(EXTRA_SCOPES))
+
     /**
      * A demo session + synthetic 25 fps frame source when [intent] carries
      * [EXTRA_DEMO_FEED]; null in a normal launch. Also the debug intent entry

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
@@ -77,7 +77,11 @@ class MainActivity : ComponentActivity() {
                     // The real shell needs the shared core's zone map. An APK
                     // built without `just android-core` (plain CI android-check)
                     // has no native library, so it keeps the placeholder.
-                    MonitorScreen(session, frameSource = demo?.second)
+                    MonitorScreen(
+                        session,
+                        frameSource = demo?.second,
+                        scopeKind = DemoHarness.scopeKind(intent),
+                    )
                 } else {
                     MonitorShell(session, frameSource = demo?.second)
                 }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
@@ -126,7 +126,11 @@ private tailrec fun android.content.Context.findActivity(): android.app.Activity
  * scopes, pickers/panels, portrait.
  */
 @Composable
-fun MonitorScreen(session: CameraSession, frameSource: LiveFrameSource?) {
+fun MonitorScreen(
+    session: CameraSession,
+    frameSource: LiveFrameSource?,
+    scopeKind: ScopeKind? = null,
+) {
     val sessionState by session.state.collectAsState()
     LaunchedEffect(session) { session.connect() }
 
@@ -281,7 +285,7 @@ fun MonitorScreen(session: CameraSession, frameSource: LiveFrameSource?) {
                         mode = dispIndex,
                         isPortrait = false,
                         aspectFill = false,
-                        scopeCount = 0,
+                        scopeCount = if (scopeKind != null) 1 else 0,
                         mirrored = false,
                         bottomBarHeight = LiveDesign.CONTROL_HEIGHT_DP,
                     ),
@@ -361,6 +365,20 @@ fun MonitorScreen(session: CameraSession, frameSource: LiveFrameSource?) {
             modifier = Modifier.zone(zones.disp),
         ) {
             dispIndex = (dispIndex + 1) % 2
+        }
+
+        // Scopes v1: one debug-selected scope (`--es zc.scopes`), mounted at the
+        // zone map's scopes zone when the core emits one; the landscape map
+        // floats scopes over the feed (like iOS), so it falls back to the
+        // iOS-parity floating frame.
+        if (scopeKind != null && frameSource != null) {
+            ScopePanel(
+                scopeKind,
+                frameSource,
+                Modifier.zone(
+                    zones.scopes ?: floatingScopeFrame(scopeKind, zones.feed, zones.infoBar),
+                ),
+            )
         }
 
         // Recording tally border at the physical edge (iOS `RecordingBorderModule`).

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/ScopeView.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/ScopeView.kt
@@ -1,0 +1,701 @@
+package com.opencapture.openzcine
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.BlendMode
+import android.graphics.Paint
+import android.graphics.Typeface
+import android.util.Log
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import com.opencapture.openzcine.bridge.ScopeAnchors
+import com.opencapture.openzcine.bridge.ScopeTraces
+import com.opencapture.openzcine.bridge.SwiftCore
+import com.opencapture.openzcine.bridge.ZoneFrame
+import com.opencapture.openzcine.core.LiveFrame
+import java.nio.ByteBuffer
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.math.cos
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+import kotlin.math.sin
+import kotlin.math.sqrt
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private const val TAG = "ZCScope"
+
+/** Wire ordinal for RED Log3G10 — the ZR live-view default and iOS fallback curve. */
+private const val CURVE_LOG3G10 = 0
+
+/** Scope refresh period — ~10 Hz, timer-driven on an absolute schedule. */
+private const val SCOPE_PERIOD_NANOS = 100_000_000L
+
+/** Widest reduction frame handed to the core sampler (1280→160, 1024→128). */
+private const val REDUCTION_MAX_WIDTH = 160
+
+/**
+ * The four v1 scopes, selectable through the debug intent
+ * `--es zc.scopes wave|parade|histo|vector` (the real scope picker is chrome
+ * work, out of scope here).
+ */
+enum class ScopeKind(val token: String, val title: String, val chip: String) {
+    WAVEFORM("wave", "WAVE", "LUMA"),
+    PARADE("parade", "PARADE", "RGB"),
+    HISTOGRAM("histo", "HISTO", "RGBL"),
+    VECTORSCOPE("vector", "VECTOR", "MON · 1X"),
+    ;
+
+    companion object {
+        /** Parses an intent token; null for absent/unknown values. */
+        fun fromToken(value: String?): ScopeKind? = entries.firstOrNull { it.token == value }
+    }
+}
+
+/**
+ * Default frame for the floating scope panel, mirroring the iOS landscape
+ * `MovablePanel` sizes anchored inside the feed's top-leading corner, below
+ * the info deck (the landscape zone map carries no scopes zone — scopes float
+ * over the feed on both platforms).
+ */
+// ponytail: fixed top-leading anchor for the single debug scope; per-kind iOS
+// default corners + dragging arrive with the real scope-picker chrome.
+fun floatingScopeFrame(kind: ScopeKind, feed: ZoneFrame, infoBar: ZoneFrame): ZoneFrame {
+    val (width, height) =
+        when (kind) {
+            ScopeKind.WAVEFORM, ScopeKind.PARADE -> 250f to 153f
+            ScopeKind.HISTOGRAM -> 250f to 77f
+            ScopeKind.VECTORSCOPE -> 190f to 190f
+        }
+    return ZoneFrame(feed.x + 12f, infoBar.y + infoBar.height + 8f, width, height)
+}
+
+// ── Scope palette (iOS MonitorOverlays.swift `ScopePalette`, values 1:1) ──
+
+private fun rgba(r: Int, g: Int, b: Int, a: Float) = Color(r / 255f, g / 255f, b / 255f, a)
+
+private object ScopePalette {
+    val lumaGhost = rgba(182, 190, 186, 0.08f)
+    val luma = rgba(222, 230, 224, 1.0f)
+    val lumaHot = rgba(255, 255, 255, 1.0f)
+    val paradeRed = rgba(255, 86, 78, 1.0f)
+    val paradeGreen = rgba(102, 232, 132, 1.0f)
+    val paradeBlue = rgba(92, 156, 255, 1.0f)
+    val boundary = rgba(220, 235, 225, 0.8f)
+    val clip = rgba(255, 150, 142, 0.8f)
+    val middle = rgba(246, 241, 226, 0.8f)
+    val graticule = rgba(220, 235, 225, 0.55f)
+    val graticuleFaint = rgba(220, 235, 225, 0.30f)
+    val histogramRedFill = rgba(255, 48, 44, 0.17f)
+    val histogramGreenFill = rgba(0, 238, 70, 0.15f)
+    val histogramBlueFill = rgba(45, 76, 255, 0.19f)
+    val histogramRedStroke = rgba(255, 48, 44, 0.96f)
+    val histogramGreenStroke = rgba(0, 238, 70, 0.92f)
+    val histogramBlueStroke = rgba(45, 76, 255, 0.94f)
+    val histogramLumaStroke = rgba(245, 242, 232, 0.58f)
+    val panelBackground = Color(0.025f, 0.036f, 0.03f, 0.72f)
+
+    /** Phosphor persistence: the previous tick draws first at this opacity. */
+    const val TRAIL_DECAY = 0.35f
+}
+
+// ── Tick payload ──
+
+/** One presented scope tick: the current payload plus the previous one (trail). */
+private class ScopeDrawData(
+    val traces: ScopeTraces? = null,
+    val trailTraces: ScopeTraces? = null,
+    /** Blended + smoothed display bins per channel (histogram kind only). */
+    val histogram: HistogramDisplay? = null,
+    val vector: ImageBitmap? = null,
+    val vectorTrail: ImageBitmap? = null,
+)
+
+private class HistogramDisplay(
+    val luma: FloatArray,
+    val red: FloatArray,
+    val green: FloatArray,
+    val blue: FloatArray,
+    val peak: Float,
+)
+
+// ── Panel ──
+
+/**
+ * One scope panel — waveform, RGB parade, histogram, or vectorscope — fed by
+ * the live JPEG stream at ~10 Hz. All axis/curve math comes from the Swift
+ * core over the facade ([SwiftCore.scopeTraces] / [SwiftCore.scopeVector] /
+ * [SwiftCore.scopeAnchors]); this composable only reduces the frame and draws.
+ */
+@Composable
+fun ScopePanel(kind: ScopeKind, source: com.opencapture.openzcine.core.LiveFrameSource, modifier: Modifier = Modifier) {
+    val anchors = remember { ScopeAnchors.parse(SwiftCore.scopeAnchors(CURVE_LOG3G10)) }
+    val data = remember { mutableStateOf<ScopeDrawData?>(null) }
+
+    LaunchedEffect(source, kind) {
+        withContext(Dispatchers.Default) {
+            pumpScope(source.frames, kind) { data.value = it }
+        }
+    }
+
+    Box(
+        modifier
+            .background(ScopePalette.panelBackground, ChromeShape)
+            .border(1.dp, LiveDesign.hairline, ChromeShape),
+    ) {
+        Canvas(Modifier.fillMaxSize()) { drawScope(kind, anchors, data.value) }
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 8.dp).padding(top = 4.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                kind.title,
+                style = chromeStyle(10.5f, FontWeight.Bold, mono = true),
+                color = LiveDesign.text.copy(alpha = 0.66f),
+                maxLines = 1,
+            )
+            Text(
+                kind.chip,
+                style = chromeStyle(9.5f, FontWeight.Bold, mono = true),
+                color = LiveDesign.text.copy(alpha = 0.58f),
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+// ── Pump: absolute-schedule ~10 Hz reduction ──
+
+/**
+ * Decodes the live JPEG at 1/8-class resolution and drives one scope tick
+ * through the facade every [SCOPE_PERIOD_NANOS].
+ *
+ * Cadence is timer-driven against an absolute schedule (`start + n·period`) —
+ * NEVER an `elapsed >= interval` gate against the frame stream, which only
+ * ever locks onto integer divisions of the source rate (the repo's wall-clock
+ * aliasing scar, fixed 4ae1544 on iOS). A tick that finds no new frame skips
+ * the work and keeps the schedule.
+ */
+private suspend fun pumpScope(
+    frames: Flow<LiveFrame>,
+    kind: ScopeKind,
+    present: (ScopeDrawData) -> Unit,
+): Unit = coroutineScope {
+    val latest = AtomicReference<ByteArray?>(null)
+    launch { frames.collect { latest.set(it.jpegData) } }
+
+    val tap = ScopeFrameTap()
+    val stats = ScopeTickStats { if (BuildConfig.DEBUG) Log.d(TAG, it) }
+    val vectorBitmaps = VectorBitmapRing()
+    var lastProcessed: ByteArray? = null
+    var previousTraces: ScopeTraces? = null
+    var previousHistogram: ScopeTraces? = null
+    var previousVector: ImageBitmap? = null
+    val startNanos = System.nanoTime()
+    var tick = 0L
+    while (true) {
+        tick = max(tick + 1, (System.nanoTime() - startNanos) / SCOPE_PERIOD_NANOS)
+        val waitMillis = (startNanos + tick * SCOPE_PERIOD_NANOS - System.nanoTime()) / 1_000_000
+        if (waitMillis > 0) delay(waitMillis)
+
+        val jpeg = latest.get() ?: continue
+        if (jpeg === lastProcessed) continue // static feed — hold the trace
+        lastProcessed = jpeg
+
+        val tickStart = System.nanoTime()
+        val reduced = tap.reduce(jpeg) ?: continue
+        when (kind) {
+            ScopeKind.WAVEFORM, ScopeKind.PARADE -> {
+                val traces =
+                    ScopeTraces.parse(
+                        SwiftCore.scopeTraces(
+                            reduced.rgba, reduced.width, reduced.height,
+                            reduced.bytesPerRow, CURVE_LOG3G10,
+                        ),
+                    )
+                present(ScopeDrawData(traces = traces, trailTraces = previousTraces))
+                previousTraces = traces
+            }
+            ScopeKind.HISTOGRAM -> {
+                val traces =
+                    ScopeTraces.parse(
+                        SwiftCore.scopeTraces(
+                            reduced.rgba, reduced.width, reduced.height,
+                            reduced.bytesPerRow, CURVE_LOG3G10,
+                        ),
+                    )
+                present(ScopeDrawData(histogram = histogramDisplay(traces, previousHistogram)))
+                previousHistogram = traces
+            }
+            ScopeKind.VECTORSCOPE -> {
+                val pixels =
+                    SwiftCore.scopeVector(
+                        reduced.rgba, reduced.width, reduced.height,
+                        reduced.bytesPerRow, CURVE_LOG3G10,
+                    )
+                val image = vectorBitmaps.imageFrom(pixels)
+                present(ScopeDrawData(vector = image, vectorTrail = previousVector))
+                previousVector = image
+            }
+        }
+        stats.tickCompleted(System.nanoTime() - tickStart, System.nanoTime())
+    }
+}
+
+/** One reduced frame ready for the core sampler. */
+private class ReducedFrame(
+    val rgba: ByteArray,
+    val width: Int,
+    val height: Int,
+    val bytesPerRow: Int,
+)
+
+/**
+ * JPEG → small RGBA reduction, allocation-free in steady state: the JPEG is
+ * decoded straight at 1/2ⁿ scale (`inSampleSize` — the DCT-domain fast path,
+ * far cheaper than full decode + rescale, and independent of the feed
+ * renderer's bitmap ring, so a tick can never observe a torn frame) into one
+ * reused mutable bitmap, then copied into a reused RGBA byte array.
+ */
+private class ScopeFrameTap {
+    private val boundsOptions = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    private val options = BitmapFactory.Options().apply { inMutable = true }
+    private var bitmap: Bitmap? = null
+    private var rgba = ByteArray(0)
+
+    fun reduce(jpeg: ByteArray): ReducedFrame? {
+        BitmapFactory.decodeByteArray(jpeg, 0, jpeg.size, boundsOptions)
+        if (boundsOptions.outWidth <= 0) return null
+        var sample = 1
+        while (boundsOptions.outWidth / sample > REDUCTION_MAX_WIDTH) sample *= 2
+        options.inSampleSize = sample
+        options.inBitmap = bitmap
+        val decoded =
+            try {
+                BitmapFactory.decodeByteArray(jpeg, 0, jpeg.size, options)
+            } catch (_: IllegalArgumentException) {
+                // Pooled bitmap incompatible (feed size changed) — decode fresh.
+                options.inBitmap = null
+                BitmapFactory.decodeByteArray(jpeg, 0, jpeg.size, options)
+            } ?: return null
+        bitmap = decoded
+        val byteCount = decoded.rowBytes * decoded.height
+        if (rgba.size != byteCount) rgba = ByteArray(byteCount)
+        decoded.copyPixelsToBuffer(ByteBuffer.wrap(rgba))
+        return ReducedFrame(rgba, decoded.width, decoded.height, decoded.rowBytes)
+    }
+}
+
+/**
+ * Ring of reused 128×128 bitmaps for the vectorscope density image — 3 deep so
+ * the bitmap being written is never one the RenderThread may still read
+ * (current frame + trail), mirroring [JpegFrameDecoder]'s ring rationale.
+ */
+private class VectorBitmapRing {
+    private val pool = arrayOfNulls<Bitmap>(3)
+    private var next = 0
+
+    fun imageFrom(premultipliedRgba: ByteArray): ImageBitmap? {
+        if (premultipliedRgba.isEmpty()) return null
+        val side = sqrt(premultipliedRgba.size / 4.0).toInt()
+        var bitmap = pool[next]
+        if (bitmap == null || bitmap.width != side) {
+            bitmap = Bitmap.createBitmap(side, side, Bitmap.Config.ARGB_8888)
+            pool[next] = bitmap
+        }
+        bitmap.copyPixelsFromBuffer(ByteBuffer.wrap(premultipliedRgba))
+        next = (next + 1) % pool.size
+        return bitmap.asImageBitmap()
+    }
+}
+
+/** `0.65·current + 0.35·previous` display-bin blend, then a radius-2 box smooth (iOS parity). */
+private fun histogramDisplay(current: ScopeTraces, previous: ScopeTraces?): HistogramDisplay {
+    fun channel(now: FloatArray, before: FloatArray?): FloatArray {
+        val blended =
+            if (before == null || before.size != now.size) {
+                now
+            } else {
+                FloatArray(now.size) { now[it] * 0.65f + before[it] * 0.35f }
+            }
+        val smoothed = FloatArray(blended.size)
+        for (index in blended.indices) {
+            val lower = max(0, index - 2)
+            val upper = min(blended.size - 1, index + 2)
+            var sum = 0f
+            for (i in lower..upper) sum += blended[i]
+            smoothed[index] = sum / (upper - lower + 1)
+        }
+        return smoothed
+    }
+    val luma = channel(current.histogramLuma, previous?.histogramLuma)
+    val red = channel(current.histogramRed, previous?.histogramRed)
+    val green = channel(current.histogramGreen, previous?.histogramGreen)
+    val blue = channel(current.histogramBlue, previous?.histogramBlue)
+    val peak = max(max(luma.max(), red.max()), max(max(green.max(), blue.max()), 1f))
+    return HistogramDisplay(luma, red, green, blue, peak)
+}
+
+/** ~10 Hz cadence accounting: achieved rate plus per-tick cost every 5 s. */
+private class ScopeTickStats(private val log: (String) -> Unit) {
+    private var ticks = 0L
+    private var totalNanos = 0L
+    private var maxNanos = 0L
+    private var windowStart = 0L
+
+    fun tickCompleted(costNanos: Long, nowNanos: Long) {
+        if (windowStart == 0L) windowStart = nowNanos
+        ticks++
+        totalNanos += costNanos
+        maxNanos = max(maxNanos, costNanos)
+        val elapsed = nowNanos - windowStart
+        if (elapsed < 5_000_000_000L) return
+        log(
+            "scope pacing: %.1f Hz | tick avg %.1f ms max %.1f ms"
+                .format(ticks * 1e9 / elapsed, totalNanos / ticks / 1e6, maxNanos / 1e6),
+        )
+        ticks = 0
+        totalNanos = 0
+        maxNanos = 0
+        windowStart = nowNanos
+    }
+}
+
+// ── Drawing ──
+
+/** iOS `scopePlotRect`: 6pt side insets, 26pt title clearance, 8pt bottom. */
+private fun DrawScope.plotRect(): Rect =
+    Rect(
+        6.dp.toPx(),
+        26.dp.toPx(),
+        size.width - 6.dp.toPx(),
+        size.height - 8.dp.toPx(),
+    )
+
+/** iOS `scopeLevelY`: display level 0…1 to y, with the 4% top/bottom buffer. */
+private fun levelY(level: Float, plot: Rect): Float =
+    plot.bottom - (0.04f + level * 0.92f) * plot.height
+
+private fun DrawScope.drawScope(kind: ScopeKind, anchors: ScopeAnchors, data: ScopeDrawData?) {
+    val plot = plotRect()
+    when (kind) {
+        ScopeKind.WAVEFORM, ScopeKind.PARADE -> {
+            data?.trailTraces?.let { drawTrace(kind, it, plot, ScopePalette.TRAIL_DECAY) }
+            data?.traces?.let { drawTrace(kind, it, plot, 1f) }
+            drawAxisGuides(anchors, plot)
+        }
+        ScopeKind.HISTOGRAM -> {
+            data?.histogram?.let { drawHistogram(it, plot) }
+            drawHistogramGuides(anchors, plot)
+        }
+        ScopeKind.VECTORSCOPE -> {
+            val side = min(plot.width, plot.height)
+            val square =
+                Rect(
+                    plot.center.x - side / 2, plot.center.y - side / 2,
+                    plot.center.x + side / 2, plot.center.y + side / 2,
+                )
+            data?.vectorTrail?.let { drawVectorDensity(it, square, ScopePalette.TRAIL_DECAY) }
+            data?.vector?.let { drawVectorDensity(it, square, 1f) }
+            drawVectorGraticule(anchors, square)
+        }
+    }
+}
+
+// Waveform / parade points render through the native canvas: one batched
+// `drawPoints(FloatArray)` per pass over a reused scratch array — no per-point
+// object allocation (the Compose `drawPoints(List<Offset>)` overload boxes).
+private val pointScratch = ThreadLocal.withInitial { FloatArray(0) }
+
+private fun DrawScope.drawPointPass(
+    xy: FloatArray,
+    count: Int,
+    color: Color,
+    widthPx: Float,
+    opacity: Float,
+) {
+    if (count == 0) return
+    drawIntoCanvas { canvas ->
+        val paint = Paint()
+        paint.isAntiAlias = false
+        paint.strokeCap = Paint.Cap.SQUARE
+        paint.strokeWidth = widthPx
+        paint.blendMode = BlendMode.PLUS
+        paint.color =
+            android.graphics.Color.argb(
+                (color.alpha * opacity * 255).roundToInt(),
+                (color.red * 255).roundToInt(),
+                (color.green * 255).roundToInt(),
+                (color.blue * 255).roundToInt(),
+            )
+        canvas.nativeCanvas.drawPoints(xy, 0, count * 2, paint)
+    }
+}
+
+/** Fills the scratch array with plot-space positions for one channel. */
+private fun fillChannel(
+    traces: ScopeTraces,
+    channelOffset: Int,
+    plot: Rect,
+    laneOrigin: Float,
+    laneWidth: Float,
+    out: FloatArray,
+): Int {
+    val stride = ScopeTraces.POINT_STRIDE
+    for (index in 0 until traces.pointCount) {
+        val x = traces.points[index * stride]
+        val level = traces.points[index * stride + channelOffset]
+        out[index * 2] = laneOrigin + x * laneWidth
+        out[index * 2 + 1] = levelY(level, plot)
+    }
+    return traces.pointCount
+}
+
+private fun DrawScope.drawTrace(kind: ScopeKind, traces: ScopeTraces, plot: Rect, opacity: Float) {
+    if (traces.pointCount == 0) return
+    var scratch = pointScratch.get()
+    if (scratch.size < traces.pointCount * 2) {
+        scratch = FloatArray(traces.pointCount * 2)
+        pointScratch.set(scratch)
+    }
+    when (kind) {
+        ScopeKind.WAVEFORM -> {
+            // Luma trace: 2px additive ghost + 1px core, brighter every 4th dot.
+            val count = fillChannel(traces, 1, plot, plot.left, plot.width, scratch)
+            drawPointPass(scratch, count, ScopePalette.lumaGhost, 2.dp.toPx(), opacity)
+            drawPointPass(scratch, count, ScopePalette.luma, 1.dp.toPx(), opacity)
+            var hot = 0
+            for (index in 0 until count step 4) {
+                scratch[hot * 2] = scratch[index * 2]
+                scratch[hot * 2 + 1] = scratch[index * 2 + 1]
+                hot++
+            }
+            drawPointPass(scratch, hot, ScopePalette.lumaHot, 1.dp.toPx(), opacity)
+        }
+        ScopeKind.PARADE -> {
+            val laneWidth = plot.width / 3
+            val lanes =
+                listOf(
+                    Pair(2, ScopePalette.paradeRed),
+                    Pair(3, ScopePalette.paradeGreen),
+                    Pair(4, ScopePalette.paradeBlue),
+                )
+            for ((laneIndex, lane) in lanes.withIndex()) {
+                val origin = plot.left + laneIndex * laneWidth
+                val count = fillChannel(traces, lane.first, plot, origin, laneWidth - 1, scratch)
+                drawPointPass(scratch, count, lane.second, 1.dp.toPx(), opacity)
+            }
+        }
+        else -> Unit
+    }
+}
+
+/** Boundary lines (code 0/255) plus the three fixed anchor lines. */
+private fun DrawScope.drawAxisGuides(anchors: ScopeAnchors, plot: Rect) {
+    val dashed = PathEffect.dashPathEffect(floatArrayOf(4.dp.toPx(), 4.dp.toPx()))
+    fun line(level: Float, color: Color, width: Float, effect: PathEffect? = null) {
+        val y = levelY(level, plot)
+        drawLine(
+            color, Offset(plot.left, y), Offset(plot.right, y),
+            strokeWidth = width, pathEffect = effect,
+        )
+    }
+    line(0f, ScopePalette.boundary, 1.25.dp.toPx())
+    line(1f, ScopePalette.boundary, 1.25.dp.toPx())
+    line(anchors.clipLine, ScopePalette.clip, 1.dp.toPx(), dashed)
+    line(anchors.midGray, ScopePalette.middle, 1.dp.toPx())
+    line(anchors.crushLine, ScopePalette.clip, 1.dp.toPx(), dashed)
+}
+
+private fun DrawScope.drawHistogram(display: HistogramDisplay, plot: Rect) {
+    fun channel(bins: FloatArray, fill: Color, stroke: Color, strokeWidth: Float) {
+        val path = histogramPath(bins, plot, display.peak, closed = true)
+        drawPath(path, fill, alpha = 0.92f, blendMode = androidx.compose.ui.graphics.BlendMode.Plus)
+        val outline = histogramPath(bins, plot, display.peak, closed = false)
+        drawPath(
+            outline, stroke, alpha = 0.92f,
+            style = Stroke(strokeWidth, cap = androidx.compose.ui.graphics.StrokeCap.Round),
+            blendMode = androidx.compose.ui.graphics.BlendMode.Plus,
+        )
+    }
+    channel(display.red, ScopePalette.histogramRedFill, ScopePalette.histogramRedStroke, 1.8.dp.toPx())
+    channel(display.green, ScopePalette.histogramGreenFill, ScopePalette.histogramGreenStroke, 1.8.dp.toPx())
+    channel(display.blue, ScopePalette.histogramBlueFill, ScopePalette.histogramBlueStroke, 1.8.dp.toPx())
+    // Luma: dim outline only (a fill washed mid-tones white on iOS).
+    drawPath(
+        histogramPath(display.luma, plot, display.peak, closed = false),
+        ScopePalette.histogramLumaStroke,
+        alpha = 0.58f,
+        style = Stroke(1.4.dp.toPx(), cap = androidx.compose.ui.graphics.StrokeCap.Round),
+    )
+}
+
+/** Smoothed contour over the display bins (quadratic midpoints, iOS `histogramPaths`). */
+private fun histogramPath(bins: FloatArray, plot: Rect, peak: Float, closed: Boolean): Path {
+    val path = Path()
+    fun x(index: Int) = plot.left + index.toFloat() / (bins.size - 1) * plot.width
+    fun y(index: Int) = plot.bottom - bins[index] / peak * plot.height
+    if (closed) {
+        path.moveTo(plot.left, plot.bottom)
+        path.lineTo(x(0), y(0))
+    } else {
+        path.moveTo(x(0), y(0))
+    }
+    for (index in 1 until bins.size) {
+        val midX = (x(index - 1) + x(index)) / 2
+        val midY = (y(index - 1) + y(index)) / 2
+        path.quadraticTo(x(index - 1), y(index - 1), midX, midY)
+    }
+    path.quadraticTo(x(bins.size - 2), y(bins.size - 2), x(bins.size - 1), y(bins.size - 1))
+    if (closed) {
+        path.lineTo(plot.right, plot.bottom)
+        path.close()
+    }
+    return path
+}
+
+/** Quarter grid, 0/255 boundaries, and the three anchors as vertical lines. */
+private fun DrawScope.drawHistogramGuides(anchors: ScopeAnchors, plot: Rect) {
+    for (step in 1..3) {
+        val y = plot.top + plot.height * step / 4
+        drawLine(rgba(220, 235, 225, 0.06f), Offset(plot.left, y), Offset(plot.right, y), 1.dp.toPx())
+    }
+    fun vertical(fraction: Float, color: Color, width: Float, effect: PathEffect? = null) {
+        val x = plot.left + fraction * plot.width
+        drawLine(color, Offset(x, plot.top), Offset(x, plot.bottom), width, pathEffect = effect)
+    }
+    vertical(0f, ScopePalette.boundary, 1.25.dp.toPx())
+    vertical(1f, ScopePalette.boundary, 1.25.dp.toPx())
+    val dashed = PathEffect.dashPathEffect(floatArrayOf(4.dp.toPx(), 4.dp.toPx()))
+    vertical(anchors.crushLine, ScopePalette.clip, 1.dp.toPx(), dashed)
+    vertical(anchors.midGray, ScopePalette.middle, 1.dp.toPx())
+    vertical(anchors.clipLine, ScopePalette.clip, 1.dp.toPx(), dashed)
+}
+
+/**
+ * Blits the 128×128 density image into the square trace rect. The bilinear
+ * upscale melts bins into soft blobs (approximating the iOS Gaussian pass);
+ * a second crisp low-alpha draw keeps small saturated features locatable.
+ */
+private fun DrawScope.drawVectorDensity(image: ImageBitmap, square: Rect, opacity: Float) {
+    val dstOffset = IntOffset(square.left.roundToInt(), square.top.roundToInt())
+    val dstSize = IntSize(square.width.roundToInt(), square.height.roundToInt())
+    drawImage(
+        image,
+        srcOffset = IntOffset.Zero,
+        srcSize = IntSize(image.width, image.height),
+        dstOffset = dstOffset,
+        dstSize = dstSize,
+        alpha = opacity,
+        blendMode = androidx.compose.ui.graphics.BlendMode.Plus,
+    )
+    drawImage(
+        image,
+        srcOffset = IntOffset.Zero,
+        srcSize = IntSize(image.width, image.height),
+        dstOffset = dstOffset,
+        dstSize = dstSize,
+        alpha = 0.35f * opacity,
+        blendMode = androidx.compose.ui.graphics.BlendMode.Plus,
+    )
+}
+
+/**
+ * Vectorscope graticule: outer ring, centre crosshair, the dashed I-phase
+ * skin-tone line at 123°, and the six 75% targets at the core-supplied CbCr
+ * positions ([ScopeAnchors.vectorTargets] — trace and graticule can never
+ * disagree about the matrix).
+ */
+private fun DrawScope.drawVectorGraticule(anchors: ScopeAnchors, square: Rect) {
+    val centre = square.center
+    val radius = square.width / 2
+    drawCircle(ScopePalette.graticule, radius, centre, style = Stroke(1.25.dp.toPx()))
+    val cross = 8.dp.toPx()
+    drawLine(
+        ScopePalette.graticuleFaint,
+        Offset(centre.x - cross, centre.y), Offset(centre.x + cross, centre.y), 1.dp.toPx(),
+    )
+    drawLine(
+        ScopePalette.graticuleFaint,
+        Offset(centre.x, centre.y - cross), Offset(centre.x, centre.y + cross), 1.dp.toPx(),
+    )
+    val skinAngle = Math.toRadians(123.0)
+    drawLine(
+        ScopePalette.middle,
+        centre,
+        Offset(
+            centre.x + (cos(skinAngle) * radius * 0.92).toFloat(),
+            centre.y - (sin(skinAngle) * radius * 0.92).toFloat(),
+        ),
+        1.dp.toPx(),
+        pathEffect = PathEffect.dashPathEffect(floatArrayOf(4.dp.toPx(), 4.dp.toPx())),
+    )
+    val labels = listOf("R", "Mg", "B", "Cy", "G", "Yl")
+    val boxSide = 7.dp.toPx()
+    drawIntoCanvas { canvas ->
+        val textPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+        textPaint.typeface = Typeface.create(Typeface.MONOSPACE, Typeface.BOLD)
+        textPaint.textSize = 6.5.dp.toPx()
+        textPaint.textAlign = Paint.Align.CENTER
+        textPaint.color = android.graphics.Color.argb(140, 220, 235, 225)
+        for ((index, target) in anchors.vectorTargets.withIndex()) {
+            val point =
+                Offset(
+                    centre.x + target.first * square.width,
+                    centre.y - target.second * square.height,
+                )
+            drawRect(
+                ScopePalette.graticule.copy(alpha = 0.6f),
+                topLeft = Offset(point.x - boxSide / 2, point.y - boxSide / 2),
+                size = Size(boxSide, boxSide),
+                style = Stroke(1.dp.toPx()),
+            )
+            val dx = point.x - centre.x
+            val dy = point.y - centre.y
+            val length = max(1f, sqrt(dx * dx + dy * dy))
+            val push = 10.dp.toPx()
+            canvas.nativeCanvas.drawText(
+                labels[index],
+                point.x + dx / length * push,
+                point.y + dy / length * push + textPaint.textSize / 3,
+                textPaint,
+            )
+        }
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/ScopeWire.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/ScopeWire.kt
@@ -1,0 +1,76 @@
+package com.opencapture.openzcine.bridge
+
+/**
+ * Fixed scope-axis anchors decoded from [SwiftCore.scopeAnchors] — the Kotlin
+ * view of the Swift `ScopeFrameWire.anchors` payload. Levels are display
+ * fractions 0…1 from the plot bottom; the mid-grey anchor is per-curve and
+ * NEVER moves with ISO/exposure (the core pins it — Erik's hard rule).
+ */
+data class ScopeAnchors(
+    val crushLine: Float,
+    val midGray: Float,
+    val clipLine: Float,
+    /** Six 75% colour-bar targets as `(cb, cr)` pairs, each in −0.5…+0.5. */
+    val vectorTargets: List<Pair<Float, Float>>,
+) {
+    companion object {
+        private const val TARGET_COUNT = 6
+
+        /** Decodes the wire array; throws when malformed. */
+        fun parse(flat: FloatArray): ScopeAnchors {
+            require(flat.size == 3 + TARGET_COUNT * 2) { "anchor array length ${flat.size}" }
+            return ScopeAnchors(
+                crushLine = flat[0],
+                midGray = flat[1],
+                clipLine = flat[2],
+                vectorTargets = (0 until TARGET_COUNT).map { Pair(flat[3 + it * 2], flat[4 + it * 2]) },
+            )
+        }
+    }
+}
+
+/**
+ * One scope tick decoded from [SwiftCore.scopeTraces] — the Kotlin view of the
+ * Swift `ScopeFrameWire.traces` payload. Per-point levels and histogram
+ * buckets are already on the anchored display axis; drawing needs no curve
+ * math.
+ */
+class ScopeTraces(
+    val pointCount: Int,
+    /** `pointCount × 5` floats: `x, luma, red, green, blue` per point. */
+    val points: FloatArray,
+    val histogramLuma: FloatArray,
+    val histogramRed: FloatArray,
+    val histogramGreen: FloatArray,
+    val histogramBlue: FloatArray,
+) {
+    companion object {
+        /** Floats per point record — mirrors `ScopeFrameWire.pointStride`. */
+        const val POINT_STRIDE = 5
+
+        /** Display bins per histogram channel — mirrors `ScopeFrameWire.histogramBins`. */
+        const val HISTOGRAM_BINS = 256
+
+        /** Decodes the wire array; throws when malformed. */
+        fun parse(flat: FloatArray): ScopeTraces {
+            require(flat.isNotEmpty()) { "empty scope payload" }
+            val count = flat[0].toInt()
+            val pointsEnd = 1 + count * POINT_STRIDE
+            require(flat.size == pointsEnd + 4 * HISTOGRAM_BINS) {
+                "scope payload length ${flat.size} for $count points"
+            }
+            fun histogram(channel: Int): FloatArray {
+                val start = pointsEnd + channel * HISTOGRAM_BINS
+                return flat.copyOfRange(start, start + HISTOGRAM_BINS)
+            }
+            return ScopeTraces(
+                pointCount = count,
+                points = flat.copyOfRange(1, pointsEnd),
+                histogramLuma = histogram(0),
+                histogramRed = histogram(1),
+                histogramGreen = histogram(2),
+                histogramBlue = histogram(3),
+            )
+        }
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCore.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCore.kt
@@ -73,6 +73,47 @@ object SwiftCore {
      */
     external fun startConnectionDemo(listener: ConnectionPhaseListener)
 
+    // ── Scopes (anchored axis math + sampling in the Swift core) ──
+
+    /**
+     * Fixed scope-axis anchors and vectorscope graticule targets for a tone
+     * curve ([curve]: 0 = RED Log3G10, 1 = Nikon N-Log):
+     * `[crushLine, midGrayLevel, clipLine, (cb, cr) × 6 targets]` — see
+     * [ScopeAnchors.parse] and the Swift mirror `ScopeFrameWire.anchors`.
+     * Static per curve; call once.
+     */
+    external fun scopeAnchors(curve: Int): FloatArray
+
+    /**
+     * Samples one downsampled RGBA frame for the waveform / parade /
+     * histogram scopes: `[N, (x, luma, r, g, b) × N, 4 × 256 display bins]`
+     * with all levels already on the core's 3-anchor display axis — see
+     * [ScopeTraces.parse] and the Swift mirror `ScopeFrameWire.traces`.
+     * Blocking (one CPU sampling pass); call from a background dispatcher.
+     */
+    external fun scopeTraces(
+        rgba: ByteArray,
+        width: Int,
+        height: Int,
+        bytesPerRow: Int,
+        curve: Int,
+    ): FloatArray
+
+    /**
+     * Samples one downsampled RGBA frame for the vectorscope: a 128×128
+     * premultiplied-RGBA density image of the BT.709 chroma plane, computed
+     * from the clean points pushed through the core's built-in display tone
+     * map (`ScopeFrameWire.vectorPixels`). Empty when the frame yields no
+     * samples. Blocking; call from a background dispatcher.
+     */
+    external fun scopeVector(
+        rgba: ByteArray,
+        width: Int,
+        height: Int,
+        bytesPerRow: Int,
+        curve: Int,
+    ): ByteArray
+
     // ── Camera session (PTP-IP protocol/session layer in the Swift core) ──
 
     /** Receives session lifecycle callbacks pushed from Swift (non-main thread). */

--- a/Apps/Android/app/src/release/kotlin/com/opencapture/openzcine/DemoHarness.kt
+++ b/Apps/Android/app/src/release/kotlin/com/opencapture/openzcine/DemoHarness.kt
@@ -13,7 +13,14 @@ object DemoHarness {
     /** Never matched in release: the extra is read only by the debug harness. */
     const val EXTRA_DEMO_FEED = "zc.demo.feed"
 
+    /** Never matched in release: the extra is read only by the debug harness. */
+    const val EXTRA_SCOPES = "zc.scopes"
+
     /** Always null: release builds carry no demo frame source. */
     @Suppress("UNUSED_PARAMETER")
     fun demoLiveFeed(intent: Intent): Pair<CameraSession, LiveFrameSource>? = null
+
+    /** Always null: the debug scope toggle does not exist in release builds. */
+    @Suppress("UNUSED_PARAMETER")
+    fun scopeKind(intent: Intent): ScopeKind? = null
 }

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/ScopeWireTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/ScopeWireTest.kt
@@ -1,0 +1,50 @@
+package com.opencapture.openzcine.bridge
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/** Pure-JVM check of the scope wire decoding against hand-built payloads. */
+class ScopeWireTest {
+    @Test
+    fun parsesAnchors() {
+        val flat =
+            floatArrayOf(0.05f, 0.47f, 0.95f) +
+                FloatArray(12) { (it - 6) / 24f } // 6 (cb, cr) pairs
+        val anchors = ScopeAnchors.parse(flat)
+        assertEquals(0.05f, anchors.crushLine)
+        assertEquals(0.47f, anchors.midGray)
+        assertEquals(0.95f, anchors.clipLine)
+        assertEquals(6, anchors.vectorTargets.size)
+        assertEquals(Pair(-6 / 24f, -5 / 24f), anchors.vectorTargets[0])
+    }
+
+    @Test
+    fun rejectsTornAnchors() {
+        assertFailsWith<IllegalArgumentException> { ScopeAnchors.parse(FloatArray(4)) }
+    }
+
+    @Test
+    fun parsesTraces() {
+        // Two points, then 4 × 256 histogram bins tagged by channel.
+        val points =
+            floatArrayOf(
+                0.0f, 0.1f, 0.2f, 0.3f, 0.4f,
+                1.0f, 0.5f, 0.6f, 0.7f, 0.8f,
+            )
+        val histograms = FloatArray(4 * 256) { (it / 256).toFloat() }
+        val traces = ScopeTraces.parse(floatArrayOf(2f) + points + histograms)
+        assertEquals(2, traces.pointCount)
+        assertEquals(0.5f, traces.points[1 * ScopeTraces.POINT_STRIDE + 1]) // point 1 luma
+        assertEquals(0f, traces.histogramLuma[0])
+        assertEquals(1f, traces.histogramRed[0])
+        assertEquals(2f, traces.histogramGreen[255])
+        assertEquals(3f, traces.histogramBlue[128])
+    }
+
+    @Test
+    fun rejectsTornTraces() {
+        assertFailsWith<IllegalArgumentException> { ScopeTraces.parse(floatArrayOf(3f, 0f)) }
+        assertFailsWith<IllegalArgumentException> { ScopeTraces.parse(FloatArray(0)) }
+    }
+}

--- a/Sources/OpenZCineAndroidFacade/ScopeFrameWire.swift
+++ b/Sources/OpenZCineAndroidFacade/ScopeFrameWire.swift
@@ -1,0 +1,162 @@
+// Flat wire format for one scope tick crossing the JNI seam.
+//
+// Like `MonitorZoneMapWire`, this file compiles on every platform so the
+// payloads are exercised by `just native-check` on macOS against the exact
+// core scope math the iOS shell consumes (`ScopeSampler`, `ScopeDisplayScale`,
+// `VectorscopeSampler`). The Kotlin mirror lives in
+// `Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/ScopeWire.kt`.
+
+import Foundation
+import OpenZCineCore
+
+/// Core-driven scope payloads for the Compose shell: the MATH (anchor axis
+/// placement, curve mapping, chroma binning, tone-mapped vectorscope) runs in
+/// the shared Swift core; Kotlin only draws the returned records.
+///
+/// All display levels use the 3-anchor axis (`ScopeDisplayScale.waveformLevel`):
+/// the curve's log-black floor lands on the crush line 5% up, mid grey sits at
+/// its FIXED per-curve level (never moved by ISO/exposure), and the ISO
+/// clip-warning code lands on the clip line 5% down from the top.
+public enum ScopeFrameWire {
+    /// Floats per point record in ``traces``: `x, luma, red, green, blue`
+    /// (x is 0…1 across the frame; the rest are anchored display levels 0…1).
+    public static let pointStride = 5
+
+    /// Bins per remapped histogram channel (display-axis buckets).
+    public static let histogramBins = 256
+
+    /// Vectorscope density grid axis (matches the iOS panels).
+    public static let vectorBinCount = 128
+
+    /// Sampling step in pixels — the iOS live tap's `ScopeAssistSampling.pointStride`.
+    public static let sampleStride = 2
+
+    /// `ExposureToneCurve` for a wire ordinal: 0 = RED Log3G10 (the ZR live-view
+    /// default and the iOS fallback), 1 = Nikon N-Log.
+    static func curve(ordinal: Int) -> ExposureToneCurve {
+        ordinal == 1 ? .nikonNLog : .redLog3G10
+    }
+
+    /// Fixed axis anchors and graticule constants for one curve:
+    /// `[crushLine, middleGrayLevel, clipLine]` followed by six `(cb, cr)`
+    /// pairs — the 75% R/Mg/B/Cy/G/Yl vectorscope targets from the core's
+    /// BT.709 chroma matrix, each component in −0.5…+0.5.
+    ///
+    /// Mid grey is per-curve and deliberately independent of ISO/exposure:
+    /// `ScopeDisplayScale.middleGrayLevel(curve:)` pins it where 18% grey sits
+    /// at the curve's published base-ISO clip. Only the highlight segment
+    /// re-stretches when the camera's clip warning moves.
+    public static func anchors(curveOrdinal: Int) -> [Float] {
+        let curve = curve(ordinal: curveOrdinal)
+        var out: [Float] = [
+            Float(ScopeDisplayScale.crushLineLevel),
+            Float(ScopeDisplayScale.middleGrayLevel(curve: curve)),
+            Float(ScopeDisplayScale.clipLineLevel),
+        ]
+        // 75% colour-bar targets (191 = 0.75 × 255) — same values the iOS
+        // graticule feeds through `VectorscopeSampler.chroma`.
+        let targets: [(red: UInt8, green: UInt8, blue: UInt8)] = [
+            (191, 0, 0), (191, 0, 191), (0, 0, 191),
+            (0, 191, 191), (0, 191, 0), (191, 191, 0),
+        ]
+        for target in targets {
+            let (cb, cr) = VectorscopeSampler.chroma(
+                red: target.red, green: target.green, blue: target.blue)
+            out.append(Float(cb))
+            out.append(Float(cr))
+        }
+        return out
+    }
+
+    /// Samples one downsampled RGBA frame for the waveform / parade / histogram
+    /// scopes and returns the flattened payload:
+    ///
+    /// `[N, (x, luma, red, green, blue) × N, 256 luma bins, 256 red, 256 green, 256 blue]`
+    ///
+    /// Point levels and histogram buckets are already on the anchored display
+    /// axis, so the shell places pixels without re-deriving any curve math.
+    /// Invalid buffer geometry yields `[0]` plus four empty histograms.
+    public static func traces(
+        rgba: [UInt8], width: Int, height: Int, bytesPerRow: Int, curveOrdinal: Int
+    ) -> [Float] {
+        let mapping = ExposureSignalMapping(curve: curve(ordinal: curveOrdinal))
+        let samples = ScopeSampler.sample(
+            rgba: rgba, width: width, height: height, bytesPerRow: bytesPerRow,
+            stride: sampleStride)
+        var out = [Float]()
+        out.reserveCapacity(1 + samples.points.count * pointStride + 4 * histogramBins)
+        out.append(Float(samples.points.count))
+        func level(_ native: UInt8) -> Float {
+            Float(
+                ScopeDisplayScale.waveformLevel(
+                    signalNative: Double(native), mapping: mapping))
+        }
+        for point in samples.points {
+            out.append(Float(point.xRatio))
+            out.append(level(point.luma))
+            out.append(level(point.red))
+            out.append(level(point.green))
+            out.append(level(point.blue))
+        }
+        let histograms = [
+            samples.histogramLuma, samples.histogramRed,
+            samples.histogramGreen, samples.histogramBlue,
+        ]
+        for histogram in histograms {
+            let remapped = ScopeDisplayScale.remapHistogram(histogram, mapping: mapping)
+            for bin in remapped {
+                out.append(Float(bin))
+            }
+        }
+        return out
+    }
+
+    /// Built-in monitor looks for the vectorscope's tone-mapped domain, built
+    /// once — the same `MonitorLUT` cubes the iOS shell falls back to when no
+    /// operator LUT is active.
+    private static let log3G10MonitorCube = MonitorLUT.log3G10Rec709.cube()
+    private static let nLogMonitorCube = MonitorLUT.nLogRec709.cube()
+
+    /// Samples one downsampled RGBA frame for the vectorscope and returns the
+    /// 128×128 premultiplied-RGBA density image (row 0 at +Cr, ready to blit).
+    ///
+    /// The clean log points are pushed through the built-in display tone map
+    /// (`MonitorLUT` — v1 has no operator LUTs on Android, matching the iOS
+    /// no-LUT fallback), binned by BT.709 CbCr, then rasterized with the same
+    /// log-density ramp and trace tint as the iOS shell's
+    /// `VectorscopeDensityRasterizer` at default brightness. Empty when the
+    /// frame yields no samples.
+    public static func vectorPixels(
+        rgba: [UInt8], width: Int, height: Int, bytesPerRow: Int, curveOrdinal: Int
+    ) -> [UInt8] {
+        let samples = ScopeSampler.sample(
+            rgba: rgba, width: width, height: height, bytesPerRow: bytesPerRow,
+            stride: sampleStride)
+        let cube = curveOrdinal == 1 ? nLogMonitorCube : log3G10MonitorCube
+        let monitorPoints = VectorscopeSampler.monitorPoints(samples.points, through: cube)
+        let bins = VectorscopeSampler.accumulate(
+            points: monitorPoints, binCount: vectorBinCount, gain: 1)
+        let n = bins.binCount
+        guard n > 0, bins.peak > 0 else { return [] }
+        let peak = Double(bins.peak)
+        var pixels = [UInt8](repeating: 0, count: n * n * 4)
+        for index in 0..<bins.counts.count {
+            let count = bins.counts[index]
+            guard count > 0 else { continue }
+            // Logarithmic density ramp (phosphor-style) — keeps single-pixel
+            // chroma readable while dense regions still glow.
+            let density = log(1 + Double(count)) / log(1 + peak)
+            let alpha = min(1, max(0, 0.4 + 0.6 * density))
+            let tint = bins.averageColor(at: index).traceTint
+            // Flip rows so +Cr renders upward (bins store row 0 at −Cr).
+            let row = n - 1 - index / n
+            let column = index % n
+            let offset = (row * n + column) * 4
+            pixels[offset] = UInt8(255 * tint.red * alpha)
+            pixels[offset + 1] = UInt8(255 * tint.green * alpha)
+            pixels[offset + 2] = UInt8(255 * tint.blue * alpha)
+            pixels[offset + 3] = UInt8(255 * alpha)
+        }
+        return pixels
+    }
+}

--- a/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
+++ b/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
@@ -42,6 +42,49 @@
         return String(cString: chars)
     }
 
+    /// Copies a `jbyteArray` into a Swift `[UInt8]`.
+    private func swiftBytes(
+        _ env: UnsafeMutablePointer<JNIEnv?>, _ value: jbyteArray?
+    ) -> [UInt8]? {
+        guard let value else { return nil }
+        let fns = table(env)
+        let length = Int(fns.GetArrayLength!(env, value))
+        guard length > 0 else { return [] }
+        var out = [UInt8](repeating: 0, count: length)
+        out.withUnsafeMutableBytes { raw in
+            fns.GetByteArrayRegion!(
+                env, value, 0, jsize(length),
+                raw.baseAddress?.assumingMemoryBound(to: jbyte.self))
+        }
+        return out
+    }
+
+    /// Copies a Swift `[Float]` into a new JVM-owned `jfloatArray`.
+    private func javaFloatArray(
+        _ env: UnsafeMutablePointer<JNIEnv?>, _ values: [Float]
+    ) -> jfloatArray? {
+        let fns = table(env)
+        guard let array = fns.NewFloatArray!(env, jsize(values.count)) else { return nil }
+        values.withUnsafeBufferPointer { buffer in
+            fns.SetFloatArrayRegion!(env, array, 0, jsize(values.count), buffer.baseAddress)
+        }
+        return array
+    }
+
+    /// Copies a Swift `[UInt8]` into a new JVM-owned `jbyteArray`.
+    private func javaByteArray(
+        _ env: UnsafeMutablePointer<JNIEnv?>, _ values: [UInt8]
+    ) -> jbyteArray? {
+        let fns = table(env)
+        guard let array = fns.NewByteArray!(env, jsize(values.count)) else { return nil }
+        values.withUnsafeBufferPointer { buffer in
+            buffer.baseAddress?.withMemoryRebound(to: jbyte.self, capacity: values.count) {
+                fns.SetByteArrayRegion!(env, array, 0, jsize(values.count), $0)
+            }
+        }
+        return array
+    }
+
     // MARK: - Info
 
     /// `SwiftCore.coreVersion(): String` — proves the Swift core is alive in-process.
@@ -119,6 +162,49 @@
             fns.SetFloatArrayRegion!(env, array, 0, jsize(flat.count), buffer.baseAddress)
         }
         return array
+    }
+
+    // MARK: - Scopes
+
+    /// `SwiftCore.scopeAnchors(curve): FloatArray` — fixed axis anchors and
+    /// vectorscope graticule targets per `ScopeFrameWire.anchors`.
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_scopeAnchors")
+    public func swiftCoreScopeAnchors(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?, curve: jint
+    ) -> jfloatArray? {
+        javaFloatArray(env, ScopeFrameWire.anchors(curveOrdinal: Int(curve)))
+    }
+
+    /// `SwiftCore.scopeTraces(rgba, width, height, bytesPerRow, curve): FloatArray`
+    /// — one scope tick's waveform/parade/histogram payload per
+    /// `ScopeFrameWire.traces`. Blocking; Kotlin calls it off the main thread.
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_scopeTraces")
+    public func swiftCoreScopeTraces(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?, rgba: jbyteArray?,
+        width: jint, height: jint, bytesPerRow: jint, curve: jint
+    ) -> jfloatArray? {
+        guard let buffer = swiftBytes(env, rgba) else { return nil }
+        return javaFloatArray(
+            env,
+            ScopeFrameWire.traces(
+                rgba: buffer, width: Int(width), height: Int(height),
+                bytesPerRow: Int(bytesPerRow), curveOrdinal: Int(curve)))
+    }
+
+    /// `SwiftCore.scopeVector(rgba, width, height, bytesPerRow, curve): ByteArray`
+    /// — one scope tick's 128×128 premultiplied-RGBA vectorscope density image
+    /// per `ScopeFrameWire.vectorPixels`. Empty for a frame with no samples.
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_scopeVector")
+    public func swiftCoreScopeVector(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?, rgba: jbyteArray?,
+        width: jint, height: jint, bytesPerRow: jint, curve: jint
+    ) -> jbyteArray? {
+        guard let buffer = swiftBytes(env, rgba) else { return nil }
+        return javaByteArray(
+            env,
+            ScopeFrameWire.vectorPixels(
+                rgba: buffer, width: Int(width), height: Int(height),
+                bytesPerRow: Int(bytesPerRow), curveOrdinal: Int(curve)))
     }
 
     // MARK: - Callback / streaming shape

--- a/Tests/OpenZCineAndroidFacadeTests/ScopeFrameWireTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/ScopeFrameWireTests.swift
@@ -1,0 +1,150 @@
+import OpenZCineCore
+import Testing
+
+@testable import OpenZCineAndroidFacade
+
+/// The scope wire must carry the core's anchored axis math value-for-value —
+/// the Compose shell draws straight off these payloads with no curve math of
+/// its own.
+struct ScopeFrameWireTests {
+    // MARK: - Anchors
+
+    @Test func anchorsCarryFixedSafeBorderLines() {
+        for ordinal in [0, 1] {
+            let anchors = ScopeFrameWire.anchors(curveOrdinal: ordinal)
+            #expect(anchors.count == 3 + 6 * 2)
+            #expect(anchors[0] == Float(ScopeDisplayScale.crushLineLevel))
+            #expect(anchors[2] == Float(ScopeDisplayScale.clipLineLevel))
+            #expect(anchors[0] < anchors[1] && anchors[1] < anchors[2])
+        }
+    }
+
+    @Test func midGrayAnchorMatchesCoreAndIgnoresISO() {
+        let anchors = ScopeFrameWire.anchors(curveOrdinal: 0)
+        // The wire's mid-grey anchor is the per-curve fixed level — the same
+        // value regardless of any ISO-driven clip shift, by construction: it
+        // derives from the curve's PUBLISHED default clip, never the live one.
+        #expect(anchors[1] == Float(ScopeDisplayScale.middleGrayLevel(curve: .redLog3G10)))
+        let shiftedISO = ExposureSignalMapping(curve: .redLog3G10, clipNative: 215)
+        #expect(
+            Float(ScopeDisplayScale.middleGrayLevel(mapping: shiftedISO)) == anchors[1])
+    }
+
+    @Test func vectorTargetsMatchCoreChromaMatrix() {
+        let anchors = ScopeFrameWire.anchors(curveOrdinal: 0)
+        // First target is 75% red: positive Cr, negative Cb, inside ±0.5.
+        let (cb, cr) = VectorscopeSampler.chroma(red: 191, green: 0, blue: 0)
+        #expect(anchors[3] == Float(cb))
+        #expect(anchors[4] == Float(cr))
+        for value in anchors[3...] {
+            #expect(value >= -0.5 && value <= 0.5)
+        }
+    }
+
+    // MARK: - Traces
+
+    /// A 2×8 buffer whose stride-2 sweep samples exactly one pixel per value
+    /// band: black, mid grey (Log3G10 18% grey code), clip warning, white.
+    private func syntheticBuffer() -> ([UInt8], Int, Int) {
+        let mid = UInt8(ExposureToneCurve.redLog3G10.middleGrayNativeCode.rounded())
+        let clip = UInt8(ExposureToneCurve.redLog3G10.defaultClipNative.rounded())
+        var rgba = [UInt8]()
+        for value in [UInt8(0), mid, clip, 255] {
+            // Two rows per band, two pixels per row — stride 2 hits row 0, col 0.
+            for _ in 0..<4 {
+                rgba.append(contentsOf: [value, value, value, 255])
+            }
+        }
+        return (rgba, 2, 8)
+    }
+
+    @Test func tracesPayloadIsWellFormed() {
+        let (rgba, width, height) = syntheticBuffer()
+        let flat = ScopeFrameWire.traces(
+            rgba: rgba, width: width, height: height, bytesPerRow: width * 4,
+            curveOrdinal: 0)
+        let count = Int(flat[0])
+        // stride-2 sweep over 4×4 → 2×2 points.
+        #expect(count == 4)
+        #expect(
+            flat.count
+                == 1 + count * ScopeFrameWire.pointStride + 4 * ScopeFrameWire.histogramBins)
+        let allFinite = flat.allSatisfy { $0.isFinite }
+        #expect(allFinite)
+    }
+
+    @Test func pointLevelsSitOnTheAnchoredAxis() {
+        let (rgba, width, height) = syntheticBuffer()
+        let flat = ScopeFrameWire.traces(
+            rgba: rgba, width: width, height: height, bytesPerRow: width * 4,
+            curveOrdinal: 0)
+        let count = Int(flat[0])
+        let anchors = ScopeFrameWire.anchors(curveOrdinal: 0)
+        var levels = [Float]()
+        for index in 0..<count {
+            levels.append(flat[1 + index * ScopeFrameWire.pointStride + 1])  // luma level
+        }
+        levels.sort()
+        // Black row (native 0) sits below the crush line; the mid-grey row sits
+        // exactly on the fixed mid-grey anchor; the clip-warning row lands on
+        // the clip line (±1 code of quantisation).
+        #expect(levels[0] < anchors[0])
+        #expect(abs(levels[1] - anchors[1]) < 0.01)
+        #expect(abs(levels[2] - anchors[2]) < 0.01)
+        #expect(levels[3] > anchors[2])
+    }
+
+    @Test func histogramsCarryEverySampledPixel() {
+        let (rgba, width, height) = syntheticBuffer()
+        let flat = ScopeFrameWire.traces(
+            rgba: rgba, width: width, height: height, bytesPerRow: width * 4,
+            curveOrdinal: 0)
+        let count = Int(flat[0])
+        let start = 1 + count * ScopeFrameWire.pointStride
+        for channel in 0..<4 {
+            let bins = flat[
+                (start + channel * ScopeFrameWire.histogramBins)..<(start + (channel + 1)
+                    * ScopeFrameWire.histogramBins)
+            ]
+            #expect(Int(bins.reduce(0, +).rounded()) == count)
+        }
+    }
+
+    @Test func invalidBufferYieldsEmptyPayload() {
+        let flat = ScopeFrameWire.traces(
+            rgba: [0, 0, 0], width: 4, height: 4, bytesPerRow: 16, curveOrdinal: 0)
+        #expect(flat[0] == 0)
+        #expect(flat.count == 1 + 4 * ScopeFrameWire.histogramBins)
+    }
+
+    // MARK: - Vectorscope
+
+    @Test func vectorPixelsArePremultipliedRGBA() {
+        // A saturated two-colour frame so the tone-mapped chroma spreads into
+        // more than one bin.
+        var rgba = [UInt8]()
+        for index in 0..<16 {
+            rgba.append(contentsOf: index % 2 == 0 ? [200, 40, 40, 255] : [40, 40, 200, 255])
+        }
+        let pixels = ScopeFrameWire.vectorPixels(
+            rgba: rgba, width: 4, height: 4, bytesPerRow: 16, curveOrdinal: 0)
+        let n = ScopeFrameWire.vectorBinCount
+        #expect(pixels.count == n * n * 4)
+        var occupied = 0
+        for offset in Swift.stride(from: 0, to: pixels.count, by: 4) {
+            let alpha = pixels[offset + 3]
+            if alpha > 0 { occupied += 1 }
+            // Premultiplied: no channel may exceed its alpha.
+            #expect(pixels[offset] <= alpha)
+            #expect(pixels[offset + 1] <= alpha)
+            #expect(pixels[offset + 2] <= alpha)
+        }
+        #expect(occupied > 0)
+    }
+
+    @Test func emptyFrameYieldsEmptyVectorImage() {
+        let pixels = ScopeFrameWire.vectorPixels(
+            rgba: [], width: 0, height: 0, bytesPerRow: 0, curveOrdinal: 0)
+        #expect(pixels.isEmpty)
+    }
+}


### PR DESCRIPTION
Part of #73 (Kaneo OPE-30, scopes half). One scope panel renders over the live feed at ~10 Hz, selected by the debug intent `--es zc.scopes wave|parade|histo|vector` (scope-picker chrome tracked separately).

**The math is Swift, the drawing is Kotlin**: a new Darwin-tested facade wire (`ScopeFrameWire`) carries the fixed 3-anchor axis — log-black floor → 5% crush line, **mid grey pinned per curve (never moved by ISO/exposure — enforced by construction and by a test asserting identity under an ISO-shifted clip mapping)**, clip warning → 95% line — plus pre-mapped trace/histogram payloads and the tone-mapped 128×128 vectorscope density image (Log3G10→Rec709 fallback cube, iOS log-density ramp). Kotlin reduces the raw live-view JPEG (1/2ⁿ decode to ≤160px, reused buffers, zero steady-state allocation) on an absolute-schedule timer and draws with the iOS panels' exact palette and phosphor-trail language.

**Measured on the SM-A127F**: feed holds 25.0 fps / 0 drops with a scope active, present rate at 100.9% of baseline, scope ticks 5.6–7.3 ms at a steady 10 Hz (~7% of one core) — the GPU reduction path is documented as unnecessary rather than half-built.

Deferred: scope-picker chrome, RGB-overlay waveform modes (payload already carries channels), Gaussian blob blur (API 31 RenderEffect upgrade), operator-LUT vector domain.

9 new Darwin facade tests + JVM parse tests; `just check` / `just native-check` (671 tests) / `just android-check` / `just android-core` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
