### PR TITLE
feat(android): pairing UX — camera-AP join and phone-hotspot paths

### DIFF
--- a/Apps/Android/README.md
+++ b/Apps/Android/README.md
@@ -9,6 +9,16 @@ are fake demo values until the session facade arrives. Without the staged Swift 
 app falls back to the placeholder monitor ("No camera").
 
 - **Build:** `just android-build` from the repo root (or `just android-check` for build + tests + lint).
+- **Pairing (`app/.../pairing/`):** the app opens on the first-pair wizard, a port of the iOS
+  startup flow (`ios/Runner/StartupDesign.swift`) in its design language: permissions → choose
+  path → prepare → network (→ find and pair). Two hard-separated paths: **camera-AP** (the phone
+  joins the camera's `NIKON_ZR_…` network via `WifiNetworkSpecifier` + `bindProcessToNetwork`,
+  key entered once and remembered in a Keystore-encrypted store) and **phone-hotspot** (the
+  CAMERA joins the phone's hotspot — the phone hosts, never scans or joins; NSD discovery waits
+  for the camera). A connected session hands off to the monitor. Every wizard state is
+  scriptable for screenshots: `adb shell am start -n com.opencapture.openzcine/.MainActivity
+  --es zc.demo.pairing permissions|choose|prepare|network|discover|connecting
+  --es zc.demo.pairingPath ap|hotspot` (debug builds only).
 - **Swift core:** the camera brain is the shared Swift core (`Sources/OpenZCineCore`), cross-compiled
   to `libOpenZCineAndroid.so` and bound via JNI (`bridge/SwiftCore.kt` ↔
   `Sources/OpenZCineAndroidFacade`). Run **`just android-core` before installing** — it stages the

--- a/Apps/Android/app/src/debug/kotlin/com/opencapture/openzcine/DemoHarness.kt
+++ b/Apps/Android/app/src/debug/kotlin/com/opencapture/openzcine/DemoHarness.kt
@@ -4,8 +4,22 @@ import android.content.Intent
 import com.opencapture.openzcine.bridge.SwiftCoreSessionProbe
 import com.opencapture.openzcine.core.CameraIdentity
 import com.opencapture.openzcine.core.CameraSession
+import com.opencapture.openzcine.core.CameraSessionState
 import com.opencapture.openzcine.core.FakeCameraSession
 import com.opencapture.openzcine.core.LiveFrameSource
+import com.opencapture.openzcine.pairing.PairingCredentials
+import com.opencapture.openzcine.pairing.PairingEnvironment
+import com.opencapture.openzcine.pairing.PairingFlowState
+import com.opencapture.openzcine.pairing.PairingPath
+import com.opencapture.openzcine.pairing.PairingScript
+import com.opencapture.openzcine.pairing.PairingStep
+import com.opencapture.openzcine.transport.CameraDiscovery
+import com.opencapture.openzcine.transport.DiscoveredCamera
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flow
 
 /**
  * Debug-only demo hooks, mirroring `ios/Runner/DemoHarness.swift`: this real
@@ -17,10 +31,23 @@ import com.opencapture.openzcine.core.LiveFrameSource
  * ```
  * adb shell am start -n com.opencapture.openzcine/.MainActivity --ez zc.demo.feed true
  * ```
+ *
+ * Drive the pairing wizard to any state (screenshot verification):
+ * ```
+ * adb shell am start -n com.opencapture.openzcine/.MainActivity \
+ *   --es zc.demo.pairing permissions|choose|prepare|network|discover|connecting \
+ *   --es zc.demo.pairingPath ap|hotspot
+ * ```
  */
 object DemoHarness {
     /** Boolean intent extra that switches the synthetic demo feed on. */
     const val EXTRA_DEMO_FEED = "zc.demo.feed"
+
+    /** String intent extra selecting the pairing wizard state to script. */
+    const val EXTRA_PAIRING_STEP = "zc.demo.pairing"
+
+    /** String intent extra selecting the scripted pairing path (`ap` or `hotspot`). */
+    const val EXTRA_PAIRING_PATH = "zc.demo.pairingPath"
 
     /**
      * A demo session + synthetic 25 fps frame source when [intent] carries
@@ -37,5 +64,96 @@ object DemoHarness {
                 CameraIdentity(name = "Demo Feed", model = "OpenZCine Demo", serialNumber = "DEMO"),
             )
         return session to DemoFrameSource()
+    }
+
+    /**
+     * A scripted pairing-wizard state + fake backend when [intent] carries
+     * [EXTRA_PAIRING_STEP]; null in a normal launch. Joins always succeed
+     * after a beat, discovery finds a fake ZR after a few seconds, and the
+     * session connects slowly enough to screenshot the connecting state.
+     */
+    fun pairingScript(intent: Intent): PairingScript? {
+        val raw = intent.getStringExtra(EXTRA_PAIRING_STEP) ?: return null
+        val requestedHotspot = intent.getStringExtra(EXTRA_PAIRING_PATH) == "hotspot"
+        val step =
+            when (raw) {
+                "permissions" -> PairingStep.PERMISSIONS
+                "choose" -> PairingStep.CHOOSE_PATH
+                "prepare" -> PairingStep.PREPARE
+                "network", "connecting" -> PairingStep.NETWORK
+                "discover" -> PairingStep.DISCOVER
+                else -> PairingStep.CHOOSE_PATH
+            }
+        val path =
+            if (requestedHotspot || step == PairingStep.DISCOVER) {
+                PairingPath.PHONE_HOTSPOT
+            } else {
+                PairingPath.CAMERA_ACCESS_POINT
+            }
+        return PairingScript(
+            start = PairingFlowState(step = step, path = path),
+            environment = scriptedEnvironment(),
+            autoConnect = raw == "connecting",
+        )
+    }
+
+    private fun scriptedEnvironment(): PairingEnvironment {
+        val credentials =
+            object : PairingCredentials {
+                override var lastSsid: String? = null
+                private val saved = mutableMapOf<String, String>()
+
+                override fun passphrase(ssid: String): String? = saved[ssid]
+
+                override fun save(ssid: String, passphrase: String) {
+                    saved[ssid] = passphrase
+                }
+            }
+        return PairingEnvironment(
+            joinCameraAp = { _, _ ->
+                delay(1_500)
+                true
+            },
+            releaseCameraAp = {},
+            hotspotCameras =
+                flow {
+                    emit(emptyList())
+                    delay(4_000)
+                    emit(
+                        listOf(
+                            DiscoveredCamera(
+                                name = "ZR_6001234",
+                                host = "172.20.10.9",
+                                port = CameraDiscovery.PTP_IP_PORT,
+                            )
+                        )
+                    )
+                },
+            createSession = { ScriptedPairingSession() },
+            credentials = credentials,
+        )
+    }
+
+    /** Connects slowly (8 s) so the connecting state can be screenshotted. */
+    private class ScriptedPairingSession : CameraSession {
+        private val mutableState =
+            MutableStateFlow<CameraSessionState>(CameraSessionState.Disconnected)
+
+        override val state: StateFlow<CameraSessionState> = mutableState.asStateFlow()
+
+        override suspend fun connect() {
+            // Idempotent: the monitor shell re-connects the handed-off session.
+            if (mutableState.value is CameraSessionState.Connected) return
+            mutableState.value = CameraSessionState.Connecting
+            delay(8_000)
+            mutableState.value =
+                CameraSessionState.Connected(
+                    CameraIdentity(name = "Nikon ZR", model = "NIKON ZR", serialNumber = "6001234")
+                )
+        }
+
+        override suspend fun disconnect() {
+            mutableState.value = CameraSessionState.Disconnected
+        }
     }
 }

--- a/Apps/Android/app/src/main/AndroidManifest.xml
+++ b/Apps/Android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,21 @@
 
     <!-- PTP-IP camera sockets (local network only; there is no server backend). -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Camera-AP join: WifiNetworkSpecifier requestNetwork + bindProcessToNetwork. -->
+    <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <!-- NSD/Wi-Fi camera discovery: NEARBY_WIFI_DEVICES on 13+ (never used
+        for location — the app only finds its own camera), location below. -->
+    <uses-permission
+        android:name="android.permission.NEARBY_WIFI_DEVICES"
+        android:usesPermissionFlags="neverForLocation" />
+    <uses-permission
+        android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="32" />
+    <!-- Android 12 requires COARSE alongside FINE; approximate is enough for NSD. -->
+    <uses-permission
+        android:name="android.permission.ACCESS_COARSE_LOCATION"
+        android:maxSdkVersion="32" />
 
     <application
         android:label="OpenZCine"

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
@@ -21,21 +21,26 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.opencapture.openzcine.core.CameraSession
 import com.opencapture.openzcine.core.CameraSessionState
 import com.opencapture.openzcine.bridge.SwiftCore
 import com.opencapture.openzcine.bridge.SwiftCoreSmoke
-import com.opencapture.openzcine.core.FakeCameraSession
 import com.opencapture.openzcine.core.LiveFrameSource
+import com.opencapture.openzcine.pairing.PairingExperience
+import com.opencapture.openzcine.pairing.realPairingEnvironment
 import com.opencapture.openzcine.transport.AndroidNsdBrowser
 import com.opencapture.openzcine.transport.NsdCameraSessionFactory
 
 /**
- * App entry point: a full-screen placeholder monitor shell fed by the
- * [CameraSession] seam. Real chrome (controls, scopes, panels) comes later;
- * this only proves the shell-to-core boundary end to end.
+ * App entry point: the pairing wizard first (camera-AP and phone-hotspot
+ * paths), handing a connected [CameraSession] to the monitor shell. Debug
+ * hooks (demo feed, NSD transport probe) bypass pairing straight to the
+ * monitor, preserving the existing capture workflows.
  */
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -54,6 +59,40 @@ class MainActivity : ComponentActivity() {
         window.isNavigationBarContrastEnforced = false
         window.attributes.layoutInDisplayCutoutMode =
             WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+        val demo = DemoHarness.demoLiveFeed(intent)
+        val debugSession: CameraSession? =
+            demo?.first ?: if (isNsdTransportRequested()) nsdTransportSession() else null
+        val pairingScript = DemoHarness.pairingScript(intent)
+        setContent {
+            OpenZCineTheme {
+                var monitorSession by remember { mutableStateOf(debugSession) }
+                // The monitor is immersive; the pairing screens keep the
+                // (transparent, dark-styled) system bars, like the iOS
+                // startup screens keep the status bar.
+                val immersive = monitorSession != null
+                LaunchedEffect(immersive) { setSystemBarsHidden(immersive) }
+                val active = monitorSession
+                if (active == null) {
+                    PairingExperience(
+                        environment = pairingScript?.environment
+                            ?: realPairingEnvironment(this@MainActivity),
+                        script = pairingScript,
+                        onPaired = { monitorSession = it },
+                    )
+                } else if (SwiftCore.isAvailable) {
+                    // The real shell needs the shared core's zone map. An APK
+                    // built without `just android-core` (plain CI android-check)
+                    // has no native library, so it keeps the placeholder.
+                    MonitorScreen(active, frameSource = demo?.second)
+                } else {
+                    MonitorShell(active, frameSource = demo?.second)
+                }
+            }
+        }
+    }
+
+    /** Hides (monitor) or shows (pairing) the system bars; styling stays transparent-dark. */
+    private fun setSystemBarsHidden(hidden: Boolean) {
         // BEHAVIOR_DEFAULT, not TRANSIENT_BARS_BY_SWIPE: the swipe reveal is
         // equally transient on this device under both, but only DEFAULT emits
         // the legacy system-UI visibility event MonitorScreen listens to for
@@ -61,26 +100,10 @@ class MainActivity : ComponentActivity() {
         // observable signal at all).
         WindowCompat.getInsetsController(window, window.decorView).apply {
             systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
-            hide(WindowInsetsCompat.Type.systemBars())
-        }
-        // ponytail: fake backend by default until the real core lands behind
-        // the seam; DI arrives with the first production implementation. Two
-        // debug-only overrides: the demo harness (synthetic feed) wins, then
-        // the NSD discovery + socket transport path.
-        val demo = DemoHarness.demoLiveFeed(intent)
-        val session: CameraSession =
-            demo?.first
-                ?: if (isNsdTransportRequested()) nsdTransportSession() else FakeCameraSession()
-        setContent {
-            OpenZCineTheme {
-                if (SwiftCore.isAvailable) {
-                    // The real shell needs the shared core's zone map. An APK
-                    // built without `just android-core` (plain CI android-check)
-                    // has no native library, so it keeps the placeholder.
-                    MonitorScreen(session, frameSource = demo?.second)
-                } else {
-                    MonitorShell(session, frameSource = demo?.second)
-                }
+            if (hidden) {
+                hide(WindowInsetsCompat.Type.systemBars())
+            } else {
+                show(WindowInsetsCompat.Type.systemBars())
             }
         }
     }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/CameraApJoiner.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/CameraApJoiner.kt
@@ -1,0 +1,88 @@
+package com.opencapture.openzcine.pairing
+
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.net.wifi.WifiNetworkSpecifier
+import kotlin.coroutines.resume
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+/**
+ * CAMERA-AP-ONLY Wi-Fi join machinery: the phone joins the camera's own
+ * network (`NIKON_ZR_xxxxx`) via [WifiNetworkSpecifier] +
+ * [ConnectivityManager.requestNetwork] — a peer-to-peer request with no
+ * internet expectation (API 29+, the app's minSdk floor).
+ *
+ * This class is the entire camera-AP network surface. The phone-hotspot path
+ * must NEVER touch it: there the camera joins the phone, the phone hosts and
+ * neither scans nor joins anything (the iOS shells learned this separation
+ * the hard way — see `hotspot-path-not-camera-ap` history).
+ *
+ * On join, the process is bound to the camera network with
+ * [ConnectivityManager.bindProcessToNetwork] so the PTP-IP sockets route over
+ * it (the specifier network carries no internet, and unbound sockets would
+ * otherwise prefer the default network). The [android.net.ConnectivityManager.NetworkCallback]
+ * stays registered while the session lives — unregistering tears the
+ * peer-to-peer network down — so callers must [release] on teardown.
+ */
+public class CameraApJoiner(private val connectivity: ConnectivityManager) {
+    private var callback: ConnectivityManager.NetworkCallback? = null
+
+    /**
+     * Requests the camera's network and suspends until Android connects
+     * (`true`) or declines/times out (`false`). Android shows its own consent
+     * dialog for the specifier request; a user cancel surfaces as
+     * `onUnavailable` → `false`. Cancelling the coroutine releases the request.
+     *
+     * @param ssid Exact camera SSID from the camera's Direct-connection screen.
+     * @param passphrase WPA2 key, or null/empty for an open camera network.
+     * @param timeoutMillis How long Android keeps looking before giving up.
+     */
+    public suspend fun join(
+        ssid: String,
+        passphrase: String?,
+        timeoutMillis: Int = 45_000,
+    ): Boolean {
+        release()
+        val specifier =
+            WifiNetworkSpecifier.Builder()
+                .setSsid(ssid)
+                .apply { if (!passphrase.isNullOrEmpty()) setWpa2Passphrase(passphrase) }
+                .build()
+        val request =
+            NetworkRequest.Builder()
+                .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                .removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                .setNetworkSpecifier(specifier)
+                .build()
+        return suspendCancellableCoroutine { continuation ->
+            val networkCallback =
+                object : ConnectivityManager.NetworkCallback() {
+                    override fun onAvailable(network: Network) {
+                        connectivity.bindProcessToNetwork(network)
+                        if (continuation.isActive) continuation.resume(true)
+                    }
+
+                    override fun onUnavailable() {
+                        if (continuation.isActive) continuation.resume(false)
+                    }
+                }
+            callback = networkCallback
+            connectivity.requestNetwork(request, networkCallback, timeoutMillis)
+            continuation.invokeOnCancellation { release() }
+        }
+    }
+
+    /**
+     * Drops the camera network: unbinds the process and unregisters the
+     * callback (which releases the peer-to-peer network). Safe to call twice.
+     */
+    public fun release() {
+        val current = callback ?: return
+        callback = null
+        connectivity.bindProcessToNetwork(null)
+        // Racing a self-releasing request (e.g. timeout) throws if already gone.
+        runCatching { connectivity.unregisterNetworkCallback(current) }
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/CameraWifiCredentialStore.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/CameraWifiCredentialStore.kt
@@ -1,0 +1,91 @@
+package com.opencapture.openzcine.pairing
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+/**
+ * Encrypted-at-rest storage for camera Wi-Fi keys, the Android counterpart of
+ * the iOS Keychain-backed `CameraWiFiCredentialStore`
+ * (ios/Runner/CameraWiFiCredentialStore.swift): the camera-AP key is entered
+ * once and remembered per SSID.
+ *
+ * Values are AES/GCM-encrypted with a non-exportable Android Keystore key and
+ * persisted in app-private [SharedPreferences]. Jetpack Security's
+ * `EncryptedSharedPreferences` is deprecated (the library was abandoned in
+ * 2024); direct Keystore encryption is the current supported route.
+ *
+ * The plaintext key must never be logged or included in errors.
+ */
+public class CameraWifiCredentialStore(context: Context) : PairingCredentials {
+    private val preferences: SharedPreferences =
+        context.getSharedPreferences("openzcine.camera-wifi", Context.MODE_PRIVATE)
+
+    override var lastSsid: String?
+        get() = preferences.getString(LAST_SSID_PREFERENCE, null)
+        set(value) {
+            preferences.edit().putString(LAST_SSID_PREFERENCE, value?.trim()).apply()
+        }
+
+    /** The remembered Wi-Fi key for [ssid], or null when none is stored (or undecryptable). */
+    override fun passphrase(ssid: String): String? {
+        val stored = preferences.getString(entryName(ssid), null) ?: return null
+        val parts = stored.split(SEPARATOR, limit = 2)
+        if (parts.size != 2) return null
+        return runCatching {
+                val cipher = Cipher.getInstance(TRANSFORMATION)
+                val iv = Base64.decode(parts[0], Base64.NO_WRAP)
+                cipher.init(Cipher.DECRYPT_MODE, keystoreEntry(), GCMParameterSpec(128, iv))
+                String(cipher.doFinal(Base64.decode(parts[1], Base64.NO_WRAP)), Charsets.UTF_8)
+            }
+            .getOrNull()
+    }
+
+    /** Remembers [passphrase] for [ssid], replacing any previous value. */
+    override fun save(ssid: String, passphrase: String) {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
+        cipher.init(Cipher.ENCRYPT_MODE, keystoreEntry())
+        val sealed = cipher.doFinal(passphrase.toByteArray(Charsets.UTF_8))
+        val value =
+            Base64.encodeToString(cipher.iv, Base64.NO_WRAP) +
+                SEPARATOR +
+                Base64.encodeToString(sealed, Base64.NO_WRAP)
+        preferences.edit().putString(entryName(ssid), value).apply()
+    }
+
+    private fun entryName(ssid: String): String = "ssid:" + ssid.trim()
+
+    /** The non-exportable AES key, generated inside the Keystore on first use. */
+    private fun keystoreEntry(): SecretKey {
+        val keystore = KeyStore.getInstance(KEYSTORE).apply { load(null) }
+        (keystore.getKey(ALIAS, null) as? SecretKey)?.let {
+            return it
+        }
+        val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE)
+        generator.init(
+            KeyGenParameterSpec.Builder(
+                    ALIAS,
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+                )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .build()
+        )
+        return generator.generateKey()
+    }
+
+    private companion object {
+        const val KEYSTORE = "AndroidKeyStore"
+        const val ALIAS = "openzcine.camera-wifi"
+        const val TRANSFORMATION = "AES/GCM/NoPadding"
+        const val SEPARATOR = ":"
+        const val LAST_SSID_PREFERENCE = "last-ssid"
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/PairingExperience.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/PairingExperience.kt
@@ -1,0 +1,1070 @@
+package com.opencapture.openzcine.pairing
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.ConnectivityManager
+import android.net.Uri
+import android.net.nsd.NsdManager
+import android.os.Build
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.opencapture.openzcine.bridge.SwiftCoreCameraSession
+import com.opencapture.openzcine.core.CameraSession
+import com.opencapture.openzcine.core.CameraSessionState
+import com.opencapture.openzcine.transport.AndroidNsdBrowser
+import com.opencapture.openzcine.transport.CameraDiscovery
+import com.opencapture.openzcine.transport.DiscoveredCamera
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+
+/** Saved camera-AP credential surface the wizard needs (real: [CameraWifiCredentialStore]). */
+public interface PairingCredentials {
+    /** Last camera SSID the operator joined — prefills the wizard's SSID field. */
+    public var lastSsid: String?
+
+    /** The remembered Wi-Fi key for [ssid], or null when none is stored. */
+    public fun passphrase(ssid: String): String?
+
+    /** Remembers [passphrase] for [ssid]. */
+    public fun save(ssid: String, passphrase: String)
+}
+
+/**
+ * Side-effect seams behind the pairing wizard, so the debug demo harness can
+ * script every state for screenshots (mirroring `ios/Runner/DemoHarness.swift`).
+ *
+ * The hard AP/hotspot separation is visible here: [joinCameraAp] is invoked
+ * ONLY from the camera-AP path's network step, and [hotspotCameras] is
+ * collected ONLY on the phone-hotspot path's discover step — the two paths
+ * share no join/scan machinery.
+ */
+public class PairingEnvironment(
+    /** Joins the camera's own Wi-Fi network (camera-AP path only). */
+    public val joinCameraAp: suspend (ssid: String, passphrase: String?) -> Boolean,
+    /** Releases the camera-AP network binding (camera-AP path only). */
+    public val releaseCameraAp: () -> Unit,
+    /** NSD camera discovery on the hotspot subnet (phone-hotspot path only). */
+    public val hotspotCameras: Flow<List<DiscoveredCamera>>,
+    /** Builds the control session once a camera host is known. */
+    public val createSession: (host: String) -> CameraSession,
+    /** Remembered camera-AP credentials. */
+    public val credentials: PairingCredentials,
+)
+
+/** Production [PairingEnvironment] over the real platform services. */
+public fun realPairingEnvironment(context: Context): PairingEnvironment {
+    val joiner = CameraApJoiner(context.getSystemService(ConnectivityManager::class.java))
+    val discovery =
+        CameraDiscovery(AndroidNsdBrowser(context.getSystemService(NsdManager::class.java)))
+    return PairingEnvironment(
+        joinCameraAp = { ssid, passphrase -> joiner.join(ssid, passphrase) },
+        releaseCameraAp = joiner::release,
+        hotspotCameras = discovery.cameras(),
+        createSession = { host -> SwiftCoreCameraSession(host) },
+        credentials = CameraWifiCredentialStore(context),
+    )
+}
+
+/**
+ * Debug-only wizard script: a forced starting state plus a fake environment,
+ * so every wizard state can be driven for screenshot verification. Built
+ * exclusively by the debug `DemoHarness`; release builds always pass null.
+ */
+public data class PairingScript(
+    val start: PairingFlowState,
+    val environment: PairingEnvironment,
+    /** Jump straight into the connecting phase (for the connecting screenshot). */
+    val autoConnect: Boolean = false,
+)
+
+/** The runtime permission NSD/Wi-Fi discovery needs on this OS version. */
+public fun requiredPairingPermission(): String =
+    if (Build.VERSION.SDK_INT >= 33) {
+        Manifest.permission.NEARBY_WIFI_DEVICES
+    } else {
+        Manifest.permission.ACCESS_FINE_LOCATION
+    }
+
+/** Whether the pairing permission is already granted. */
+public fun isPairingPermissionGranted(context: Context): Boolean =
+    context.checkSelfPermission(requiredPairingPermission()) == PackageManager.PERMISSION_GRANTED
+
+// MARK: - Copy
+
+/**
+ * Wizard copy, ported from iOS `StartupWizardContent` / `NativeAppRoot`
+ * (body-agnostic "your camera" per the Z-lineup pass; "iPhone" → "phone").
+ */
+internal object PairingCopy {
+    fun stepTitle(step: PairingStep): String =
+        when (step) {
+            PairingStep.PERMISSIONS -> "Allow permissions"
+            PairingStep.CHOOSE_PATH -> "Choose how to connect"
+            PairingStep.PREPARE -> "Prepare your camera"
+            PairingStep.NETWORK -> "Set up the network"
+            PairingStep.DISCOVER -> "Find and pair"
+        }
+
+    fun introFooter(step: PairingStep): String =
+        when (step) {
+            PairingStep.PERMISSIONS ->
+                "Only what pairing needs — change anytime in Android Settings."
+            PairingStep.CHOOSE_PATH ->
+                "Each trades battery, quality, and convenience — pick what fits the shoot."
+            PairingStep.PREPARE ->
+                "Menu names match the Nikon ZR; they may vary by model and firmware version."
+            PairingStep.NETWORK ->
+                "Get both devices onto the same network — we'll find the camera automatically."
+            PairingStep.DISCOVER -> "Keep the camera powered on and nearby while we find it."
+        }
+
+    fun pathTitle(path: PairingPath): String =
+        when (path) {
+            PairingPath.CAMERA_ACCESS_POINT -> "Camera's Access Point"
+            PairingPath.PHONE_HOTSPOT -> "Phone's Hotspot"
+        }
+
+    fun pathBadge(path: PairingPath): String =
+        when (path) {
+            PairingPath.CAMERA_ACCESS_POINT -> "Simplest"
+            PairingPath.PHONE_HOTSPOT -> "Best wireless"
+        }
+
+    fun pathPros(path: PairingPath): List<String> =
+        when (path) {
+            PairingPath.CAMERA_ACCESS_POINT ->
+                listOf("Lightest battery use", "No phone setup needed")
+            PairingPath.PHONE_HOTSPOT -> listOf("Best wireless quality", "Stable at high settings")
+        }
+
+    fun pathCon(path: PairingPath): String =
+        when (path) {
+            PairingPath.CAMERA_ACCESS_POINT -> "Softer link, lower quality"
+            PairingPath.PHONE_HOTSPOT -> "Heavier battery drain"
+        }
+
+    // [VERIFY-ON-HW] Confirm the ZR's exact menu wording for each path on hardware.
+    fun prepareSteps(path: PairingPath): List<String> =
+        when (path) {
+            PairingPath.CAMERA_ACCESS_POINT ->
+                listOf(
+                    "On the camera: Network menu → Connect to computer → Network settings.",
+                    "Choose Create Profile and give the profile a name.",
+                    "Select Direct connection to computer — the camera shows its SSID and key.",
+                )
+            PairingPath.PHONE_HOTSPOT ->
+                listOf(
+                    "Turn on your phone's Wi‑Fi hotspot (Settings → Hotspot & tethering).",
+                    "Note the hotspot name and password — the camera needs them to join.",
+                    "On the camera: Network menu → Connect to computer.",
+                    "We'll walk through joining your hotspot in the next step.",
+                )
+        }
+
+    fun networkSubtitle(path: PairingPath, keyRemembered: Boolean): String =
+        when (path) {
+            PairingPath.CAMERA_ACCESS_POINT ->
+                if (keyRemembered) {
+                    "The key for this camera is remembered — check the SSID and tap Join."
+                } else {
+                    "The camera now shows its Wi‑Fi SSID and key. Enter them below — " +
+                        "Android will confirm the connection, and we remember the key " +
+                        "for next time."
+                }
+            PairingPath.PHONE_HOTSPOT -> "Keep your phone's Wi‑Fi hotspot on. Then on the camera:"
+        }
+
+    /** Camera-side instruction card lines for the hotspot network step. */
+    val hotspotCameraSteps: List<String> =
+        listOf(
+            "Connect to computer → Network settings",
+            "Create Profile → name your profile",
+            "Search for Wi‑Fi network → join this phone's hotspot",
+            "IP address → Obtain automatically",
+        )
+
+    val permissionTitle: String =
+        if (Build.VERSION.SDK_INT >= 33) "Nearby devices" else "Location"
+
+    val permissionDetail: String =
+        if (Build.VERSION.SDK_INT >= 33) {
+            "Find and stream from your camera over Wi‑Fi."
+        } else {
+            "Android uses Location access to find cameras on Wi‑Fi. " +
+                "Your location is never tracked or stored."
+        }
+}
+
+// MARK: - Wizard
+
+/** What the wizard is busy doing besides showing a step. */
+private sealed interface PairingPhase {
+    data object Idle : PairingPhase
+
+    data object Joining : PairingPhase
+
+    data object Connecting : PairingPhase
+
+    data class Error(val message: String) : PairingPhase
+}
+
+/**
+ * The first-pair wizard — Android port of the iOS `StartupFirstPairWizardView`
+ * (ios/Runner/StartupDesign.swift): a two-column landscape layout with the
+ * goal/progress intro card on the left and the current step card on the
+ * right. Ends by handing a connected [CameraSession] to [onPaired].
+ */
+@Composable
+public fun PairingExperience(
+    environment: PairingEnvironment,
+    script: PairingScript? = null,
+    onPaired: (CameraSession) -> Unit,
+) {
+    val context = LocalContext.current
+    var permissionGranted by remember { mutableStateOf(isPairingPermissionGranted(context)) }
+    var permissionDenied by remember { mutableStateOf(false) }
+    var flow by remember {
+        mutableStateOf(
+            script?.start ?: PairingFlowState.initial(isPairingPermissionGranted(context))
+        )
+    }
+    var phase by remember { mutableStateOf<PairingPhase>(PairingPhase.Idle) }
+    var ssidField by remember {
+        mutableStateOf(
+            environment.credentials.lastSsid ?: CameraDiscovery.NIKON_ZR_SSID_PREFIX
+        )
+    }
+    var keyField by remember {
+        mutableStateOf(
+            environment.credentials.lastSsid?.let(environment.credentials::passphrase) ?: ""
+        )
+    }
+    val keyWasRemembered = remember { keyField.isNotEmpty() }
+    var cameras by remember { mutableStateOf(emptyList<DiscoveredCamera>()) }
+    val scope = rememberCoroutineScope()
+    var work by remember { mutableStateOf<Job?>(null) }
+
+    fun connect(host: String) {
+        phase = PairingPhase.Connecting
+        work =
+            scope.launch {
+                val session = environment.createSession(host)
+                session.connect()
+                if (session.state.value is CameraSessionState.Connected) {
+                    onPaired(session)
+                } else {
+                    phase =
+                        PairingPhase.Error(
+                            "Couldn't reach the camera. Check Wi‑Fi and try again."
+                        )
+                }
+            }
+    }
+
+    fun joinCameraAp() {
+        val ssid = ssidField.trim()
+        if (ssid.isEmpty()) return
+        phase = PairingPhase.Joining
+        work =
+            scope.launch {
+                val joined = environment.joinCameraAp(ssid, keyField.ifEmpty { null })
+                if (joined) {
+                    if (keyField.isNotEmpty()) environment.credentials.save(ssid, keyField)
+                    environment.credentials.lastSsid = ssid
+                    // Camera-AP mode: the ZR always answers on the fixed AP host.
+                    connect(CameraDiscovery.NIKON_ZR_ACCESS_POINT_HOST)
+                } else {
+                    phase =
+                        PairingPhase.Error(
+                            "Couldn't join the camera's Wi‑Fi. Check the key and try again."
+                        )
+                }
+            }
+    }
+
+    fun cancelWork() {
+        work?.cancel()
+        work = null
+        if (flow.path == PairingPath.CAMERA_ACCESS_POINT) environment.releaseCameraAp()
+        phase = PairingPhase.Idle
+    }
+
+    // Permission launcher + re-check on return from Settings.
+    val permissionLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            permissionGranted = granted
+            permissionDenied = !granted
+        }
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                permissionGranted = isPairingPermissionGranted(context)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    // Hotspot path ONLY: watch for the camera to join the phone's hotspot.
+    // The phone hosts — it never scans or joins networks on this path.
+    if (flow.step == PairingStep.DISCOVER) {
+        LaunchedEffect(environment) {
+            environment.hotspotCameras.collect { cameras = it }
+        }
+    }
+
+    if (script?.autoConnect == true) {
+        LaunchedEffect(script) { connect(CameraDiscovery.NIKON_ZR_ACCESS_POINT_HOST) }
+    }
+
+    val busy = phase == PairingPhase.Joining || phase == PairingPhase.Connecting
+    val statusTitle =
+        when {
+            phase == PairingPhase.Joining -> "Joining"
+            phase == PairingPhase.Connecting -> "Connecting"
+            flow.step == PairingStep.DISCOVER -> "Looking"
+            else -> "Ready"
+        }
+
+    Box(Modifier.fillMaxSize().startupBackdrop()) {
+        Column(
+            Modifier.fillMaxSize()
+                .windowInsetsPadding(WindowInsets.safeDrawing)
+                .padding(horizontal = 24.dp, vertical = 12.dp)
+        ) {
+            StartupHeader(
+                title = "Connection setup",
+                statusTitle = statusTitle,
+                isBusy = busy || flow.step == PairingStep.DISCOVER,
+            )
+            Spacer(Modifier.height(12.dp))
+            BoxWithConstraints(Modifier.weight(1f)) {
+                val twoColumn = maxWidth >= 640.dp
+                val introWidth = maxOf(236.dp, maxWidth * 0.28f)
+                if (twoColumn) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                        IntroCard(
+                            flow = flow,
+                            modifier = Modifier.width(introWidth).fillMaxSize(),
+                        )
+                        StepCard(
+                            flow = flow,
+                            phase = phase,
+                            permissionGranted = permissionGranted,
+                            permissionDenied = permissionDenied,
+                            ssidField = ssidField,
+                            onSsidChange = { ssidField = it },
+                            keyField = keyField,
+                            onKeyChange = { keyField = it },
+                            keyWasRemembered = keyWasRemembered,
+                            cameras = cameras,
+                            onRequestPermission = {
+                                if (permissionDenied) {
+                                    context.startActivity(
+                                        Intent(
+                                            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                                            Uri.fromParts("package", context.packageName, null),
+                                        )
+                                    )
+                                } else {
+                                    permissionLauncher.launch(requiredPairingPermission())
+                                }
+                            },
+                            onChoose = { flow = flow.choose(it) },
+                            onAdvance = { flow = flow.advance() },
+                            onRetreat = {
+                                phase = PairingPhase.Idle
+                                flow = flow.retreat()
+                            },
+                            onJoin = ::joinCameraAp,
+                            onConnectCamera = { connect(it.host) },
+                            onCancel = ::cancelWork,
+                            modifier = Modifier.weight(1f).fillMaxSize(),
+                        )
+                    }
+                } else {
+                    // ponytail: the app is landscape-locked; the stacked layout
+                    // is a narrow-viewport fallback, not a designed portrait mode.
+                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        StartupWizardProgress(
+                            currentStep = flow.displayStepNumber,
+                            totalSteps = flow.stepCount,
+                        )
+                        StepCard(
+                            flow = flow,
+                            phase = phase,
+                            permissionGranted = permissionGranted,
+                            permissionDenied = permissionDenied,
+                            ssidField = ssidField,
+                            onSsidChange = { ssidField = it },
+                            keyField = keyField,
+                            onKeyChange = { keyField = it },
+                            keyWasRemembered = keyWasRemembered,
+                            cameras = cameras,
+                            onRequestPermission = {
+                                permissionLauncher.launch(requiredPairingPermission())
+                            },
+                            onChoose = { flow = flow.choose(it) },
+                            onAdvance = { flow = flow.advance() },
+                            onRetreat = {
+                                phase = PairingPhase.Idle
+                                flow = flow.retreat()
+                            },
+                            onJoin = ::joinCameraAp,
+                            onConnectCamera = { connect(it.host) },
+                            onCancel = ::cancelWork,
+                            modifier = Modifier.weight(1f).fillMaxWidth(),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Left column
+
+@Composable
+private fun IntroCard(flow: PairingFlowState, modifier: Modifier = Modifier) {
+    // Vertical budget is tight in the ~360dp-tall landscape band — sizes are
+    // trimmed from the iOS 32pt title so the footer never clips the card edge.
+    Column(modifier.startupCard().padding(horizontal = 20.dp, vertical = 16.dp)) {
+        Text(
+            "FIRST RUN",
+            color = StartupColors.muted,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+            letterSpacing = 1.4.sp,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            "Pair your camera.",
+            color = StartupColors.ink,
+            fontSize = 24.sp,
+            fontWeight = FontWeight.Bold,
+            lineHeight = 27.sp,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            "We'll walk you through it — your camera is connected in about a minute.",
+            color = StartupColors.muted,
+            fontSize = 12.sp,
+            lineHeight = 16.sp,
+        )
+        Spacer(Modifier.weight(1f))
+        StartupWizardProgress(currentStep = flow.displayStepNumber, totalSteps = flow.stepCount)
+        Spacer(Modifier.height(8.dp))
+        Text(
+            PairingCopy.introFooter(flow.step),
+            color = StartupColors.dim,
+            fontSize = 11.sp,
+            lineHeight = 15.sp,
+        )
+    }
+}
+
+// MARK: - Right column
+
+@Composable
+private fun StepCard(
+    flow: PairingFlowState,
+    phase: PairingPhase,
+    permissionGranted: Boolean,
+    permissionDenied: Boolean,
+    ssidField: String,
+    onSsidChange: (String) -> Unit,
+    keyField: String,
+    onKeyChange: (String) -> Unit,
+    keyWasRemembered: Boolean,
+    cameras: List<DiscoveredCamera>,
+    onRequestPermission: () -> Unit,
+    onChoose: (PairingPath) -> Unit,
+    onAdvance: () -> Unit,
+    onRetreat: () -> Unit,
+    onJoin: () -> Unit,
+    onConnectCamera: (DiscoveredCamera) -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier.startupCard().padding(20.dp)) {
+        Text(
+            "STEP ${flow.displayStepNumber} OF ${flow.stepCount}",
+            color = StartupColors.muted,
+            fontSize = 11.sp,
+            fontWeight = FontWeight.SemiBold,
+            letterSpacing = 1.4.sp,
+        )
+        Spacer(Modifier.height(6.dp))
+        Text(
+            PairingCopy.stepTitle(flow.step),
+            color = StartupColors.ink,
+            fontSize = 21.sp,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(Modifier.height(10.dp))
+
+        val busy = phase == PairingPhase.Joining || phase == PairingPhase.Connecting
+        Column(Modifier.weight(1f).verticalScroll(rememberScrollState())) {
+            if (busy) {
+                BusyBody(phase)
+            } else {
+                when (flow.step) {
+                    PairingStep.PERMISSIONS ->
+                        PermissionsBody(permissionGranted, permissionDenied, onRequestPermission)
+                    PairingStep.CHOOSE_PATH -> ChoosePathBody(onChoose)
+                    PairingStep.PREPARE -> NumberedCards(PairingCopy.prepareSteps(flow.path))
+                    PairingStep.NETWORK ->
+                        NetworkBody(
+                            path = flow.path,
+                            ssidField = ssidField,
+                            onSsidChange = onSsidChange,
+                            keyField = keyField,
+                            onKeyChange = onKeyChange,
+                            keyWasRemembered = keyWasRemembered,
+                        )
+                    PairingStep.DISCOVER -> DiscoverBody(cameras, onConnectCamera)
+                }
+                (phase as? PairingPhase.Error)?.let { error ->
+                    Spacer(Modifier.height(10.dp))
+                    Text(
+                        error.message,
+                        color = StartupColors.destructive,
+                        fontSize = 12.sp,
+                        lineHeight = 16.sp,
+                    )
+                }
+            }
+        }
+
+        // Footer nav — mirrors iOS: none on the choose step (tapping a card
+        // advances); Cancel while busy; Back + primary elsewhere.
+        Spacer(Modifier.height(12.dp))
+        if (busy) {
+            Row {
+                Spacer(Modifier.weight(1f))
+                StartupOutlineButton("Cancel", onClick = onCancel, modifier = Modifier.width(116.dp))
+            }
+        } else if (flow.step != PairingStep.CHOOSE_PATH) {
+            Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                if (flow.canRetreat) {
+                    StartupOutlineButton(
+                        "Back",
+                        onClick = onRetreat,
+                        modifier = Modifier.width(116.dp),
+                    )
+                }
+                Spacer(Modifier.weight(1f))
+                when {
+                    flow.step == PairingStep.NETWORK &&
+                        flow.path == PairingPath.CAMERA_ACCESS_POINT ->
+                        StartupFilledButton(
+                            "Join camera Wi‑Fi",
+                            enabled = ssidField.isNotBlank(),
+                            onClick = onJoin,
+                            modifier = Modifier.width(220.dp),
+                        )
+                    !flow.isFinalStep ->
+                        StartupFilledButton(
+                            "Continue",
+                            enabled = flow.step != PairingStep.PERMISSIONS || permissionGranted,
+                            onClick = onAdvance,
+                            modifier = Modifier.width(220.dp),
+                        )
+                    // DISCOVER advances by tapping a found camera — no primary.
+                    else -> {}
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Step bodies
+
+@Composable
+private fun BusyBody(phase: PairingPhase) {
+    Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
+        Text(
+            if (phase == PairingPhase.Joining) {
+                "Joining the camera's Wi‑Fi network…"
+            } else {
+                "Connecting to your camera…"
+            },
+            color = StartupColors.ink,
+            fontSize = 15.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Text(
+            if (phase == PairingPhase.Joining) {
+                "Android asks you to confirm the connection the first time."
+            } else {
+                "Keep the camera powered on — this takes a few seconds."
+            },
+            color = StartupColors.muted,
+            fontSize = 12.sp,
+            lineHeight = 17.sp,
+        )
+        StartupIndeterminateBar()
+    }
+}
+
+@Composable
+private fun PermissionsBody(granted: Boolean, denied: Boolean, onRequest: () -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Column(
+            Modifier.fillMaxWidth()
+                .startupInstructionCard()
+                .clickable(enabled = !granted, onClick = onRequest)
+                .padding(horizontal = 16.dp, vertical = 13.dp)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Column(Modifier.weight(1f)) {
+                    Text(
+                        PairingCopy.permissionTitle,
+                        color = StartupColors.ink,
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        PairingCopy.permissionDetail,
+                        color = StartupColors.muted,
+                        fontSize = 12.sp,
+                        lineHeight = 16.sp,
+                    )
+                }
+                Spacer(Modifier.width(8.dp))
+                when {
+                    granted -> StatusPill("Allowed", StartupColors.ready)
+                    denied -> StatusPill("Settings", StartupColors.muted)
+                    else ->
+                        Text(
+                            "Allow",
+                            color = StartupColors.darkText,
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            modifier =
+                                Modifier.clip(CircleShape)
+                                    .background(StartupColors.accent)
+                                    .padding(horizontal = 14.dp, vertical = 8.dp),
+                        )
+                }
+            }
+        }
+        if (!granted) {
+            Text(
+                "Required to connect to your camera — grant it to continue.",
+                color = StartupColors.dim,
+                fontSize = 11.sp,
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatusPill(text: String, color: androidx.compose.ui.graphics.Color) {
+    Text(
+        text,
+        color = color,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.SemiBold,
+        modifier =
+            Modifier.border(1.dp, color.copy(alpha = 0.5f), CircleShape)
+                .padding(horizontal = 12.dp, vertical = 6.dp),
+    )
+}
+
+@Composable
+private fun ChoosePathBody(onChoose: (PairingPath) -> Unit) {
+    // Tight vertical budget: both cards must clear the card fold without
+    // scrolling on the ~180dp step body of a 720px-tall landscape panel.
+    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+        for (path in PairingPath.entries) {
+            Column(
+                Modifier.weight(1f)
+                    .startupTile()
+                    .clickable { onChoose(path) }
+                    .padding(horizontal = 12.dp, vertical = 10.dp)
+            ) {
+                Text(
+                    PairingCopy.pathTitle(path),
+                    color = StartupColors.ink,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+                Spacer(Modifier.height(6.dp))
+                Text(
+                    PairingCopy.pathBadge(path),
+                    color = StartupColors.accent,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier =
+                        Modifier.clip(CircleShape)
+                            .background(StartupColors.accent.copy(alpha = 0.15f))
+                            .padding(horizontal = 9.dp, vertical = 3.dp),
+                )
+                Spacer(Modifier.height(7.dp))
+                Column(verticalArrangement = Arrangement.spacedBy(3.dp)) {
+                    for (pro in PairingCopy.pathPros(path)) {
+                        TradeoffRow("+", StartupColors.ready, pro)
+                    }
+                    TradeoffRow("−", StartupColors.dim, PairingCopy.pathCon(path))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TradeoffRow(symbol: String, color: androidx.compose.ui.graphics.Color, text: String) {
+    Row(horizontalArrangement = Arrangement.spacedBy(7.dp)) {
+        Text(symbol, color = color, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+        Text(text, color = StartupColors.muted, fontSize = 12.sp, lineHeight = 16.sp)
+    }
+}
+
+/** Numbered instruction cards (iOS `StartupWizardPrepareCards`). */
+@Composable
+private fun NumberedCards(steps: List<String>) {
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        steps.forEachIndexed { index, step ->
+            Row(
+                Modifier.fillMaxWidth()
+                    .startupInstructionCard()
+                    .padding(horizontal = 12.dp, vertical = 9.dp),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    Modifier.size(24.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(StartupColors.accent.copy(alpha = 0.12f))
+                        .border(
+                            1.dp,
+                            StartupColors.accent.copy(alpha = 0.45f),
+                            RoundedCornerShape(8.dp),
+                        ),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        "${index + 1}",
+                        color = StartupColors.accent,
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+                Text(
+                    step,
+                    color = StartupColors.ink,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                    lineHeight = 18.sp,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NetworkBody(
+    path: PairingPath,
+    ssidField: String,
+    onSsidChange: (String) -> Unit,
+    keyField: String,
+    onKeyChange: (String) -> Unit,
+    keyWasRemembered: Boolean,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            PairingCopy.networkSubtitle(path, keyRemembered = keyWasRemembered),
+            color = StartupColors.muted,
+            fontSize = 13.sp,
+            lineHeight = 18.sp,
+        )
+        // Camera-AP: the subtitle already tells the operator where the SSID and
+        // key are — the entry fields must sit above the scroll fold, so no
+        // camera instruction card here (iOS "tight" mode collapses it too).
+        if (path == PairingPath.PHONE_HOTSPOT) {
+            DeviceInstructionCard(
+                label = "ON CAMERA",
+                steps = PairingCopy.hotspotCameraSteps,
+            )
+        }
+        if (path == PairingPath.CAMERA_ACCESS_POINT) {
+            Column(
+                Modifier.fillMaxWidth()
+                    .startupInstructionCard()
+                    .padding(horizontal = 12.dp, vertical = 10.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Text(
+                    "ON THIS PHONE",
+                    color = StartupColors.muted,
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = 1.2.sp,
+                )
+                StartupTextField(
+                    value = ssidField,
+                    onValueChange = onSsidChange,
+                    placeholder = "Network SSID (${CameraDiscovery.NIKON_ZR_SSID_PREFIX}…)",
+                )
+                StartupTextField(
+                    value = keyField,
+                    onValueChange = onKeyChange,
+                    placeholder = "Network key",
+                    password = true,
+                )
+            }
+        }
+    }
+}
+
+/** Device-labelled numbered instruction card (iOS `StartupWizardDeviceInstructionCard`). */
+@Composable
+private fun DeviceInstructionCard(label: String, steps: List<String>) {
+    Column(
+        Modifier.fillMaxWidth()
+            .startupInstructionCard()
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(3.dp),
+    ) {
+        Text(
+            label,
+            color = StartupColors.muted,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Bold,
+            letterSpacing = 1.2.sp,
+        )
+        steps.forEachIndexed { index, step ->
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Text(
+                    "${index + 1}",
+                    color = StartupColors.muted,
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.width(14.dp),
+                )
+                Text(
+                    step,
+                    color = StartupColors.ink,
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Medium,
+                    lineHeight = 16.sp,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DiscoverBody(
+    cameras: List<DiscoveredCamera>,
+    onConnectCamera: (DiscoveredCamera) -> Unit,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        if (cameras.isEmpty()) {
+            Column(
+                Modifier.fillMaxWidth()
+                    .startupInstructionCard()
+                    .padding(horizontal = 12.dp, vertical = 14.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                Text(
+                    "Waiting for the camera to join this phone's hotspot",
+                    color = StartupColors.ink,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Text(
+                    "The camera appears here a few seconds after it joins.",
+                    color = StartupColors.muted,
+                    fontSize = 11.sp,
+                )
+            }
+            StartupIndeterminateBar()
+        } else {
+            for (camera in cameras) {
+                Row(
+                    Modifier.fillMaxWidth()
+                        .startupTile(borderColor = StartupColors.ready.copy(alpha = 0.28f))
+                        .clickable { onConnectCamera(camera) }
+                        .padding(horizontal = 14.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(Modifier.weight(1f)) {
+                        Text(
+                            camera.name,
+                            color = StartupColors.ink,
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Text(
+                            "Wi‑Fi · nearby",
+                            color = StartupColors.muted,
+                            fontSize = 11.sp,
+                        )
+                    }
+                    Text(
+                        "Connect",
+                        color = StartupColors.darkText,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        modifier =
+                            Modifier.clip(RoundedCornerShape(16.dp))
+                                .background(StartupColors.accent)
+                                .padding(horizontal = 14.dp, vertical = 8.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Controls
+
+@Composable
+private fun StartupFilledButton(
+    text: String,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier
+            .height(40.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(
+                if (enabled) StartupColors.accent else StartupColors.control.copy(alpha = 0.6f)
+            )
+            .clickable(enabled = enabled, onClick = onClick)
+            .alpha(if (enabled) 1f else 0.55f),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text,
+            color = if (enabled) StartupColors.darkText else StartupColors.muted,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+        )
+    }
+}
+
+@Composable
+private fun StartupOutlineButton(text: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    Box(
+        modifier
+            .height(40.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(StartupColors.control.copy(alpha = 0.82f))
+            .border(1.dp, StartupColors.border.copy(alpha = 0.12f), RoundedCornerShape(16.dp))
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text,
+            color = StartupColors.ink,
+            fontSize = 14.sp,
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+        )
+    }
+}
+
+/** Single-line field in the startup control style; never logs its contents. */
+@Composable
+private fun StartupTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    password: Boolean = false,
+) {
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        singleLine = true,
+        textStyle =
+            TextStyle(
+                color = StartupColors.ink,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Medium,
+            ),
+        cursorBrush = SolidColor(StartupColors.accent),
+        visualTransformation =
+            if (password) PasswordVisualTransformation() else VisualTransformation.None,
+        decorationBox = { innerTextField ->
+            Box(
+                Modifier.fillMaxWidth()
+                    .height(42.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(StartupColors.control)
+                    .border(
+                        1.dp,
+                        StartupColors.border.copy(alpha = 0.12f),
+                        RoundedCornerShape(16.dp),
+                    )
+                    .padding(horizontal = 13.dp),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                if (value.isEmpty()) {
+                    Text(placeholder, color = StartupColors.dim, fontSize = 14.sp)
+                }
+                innerTextField()
+            }
+        },
+    )
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/PairingExperience.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/PairingExperience.kt
@@ -218,9 +218,8 @@ internal object PairingCopy {
                 if (keyRemembered) {
                     "The key for this camera is remembered — check the SSID and tap Join."
                 } else {
-                    "The camera now shows its Wi‑Fi SSID and key. Enter them below — " +
-                        "Android will confirm the connection, and we remember the key " +
-                        "for next time."
+                    "Enter the SSID and key from the camera's screen — " +
+                        "we remember the key for next time."
                 }
             PairingPath.PHONE_HOTSPOT -> "Keep your phone's Wi‑Fi hotspot on. Then on the camera:"
         }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/PairingFlow.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/PairingFlow.kt
@@ -1,0 +1,110 @@
+package com.opencapture.openzcine.pairing
+
+/**
+ * How the operator plans to reach the camera during first-time pairing — the
+ * Android port of the iOS shell's `FirstPairTransportMethod`
+ * (ios/Runner/NativeAppRoot.swift), minus USB-C which has no Android
+ * transport yet.
+ *
+ * The two paths are HARD-separated (this cost real bugs on iOS):
+ * - [CAMERA_ACCESS_POINT]: the phone joins the camera's own network via
+ *   [CameraApJoiner] — the only class that requests or binds a Wi-Fi network.
+ * - [PHONE_HOTSPOT]: the CAMERA joins the phone's hotspot; the phone hosts
+ *   and must never scan or join anything — this path only ever watches NSD
+ *   discovery for the camera to appear.
+ */
+public enum class PairingPath {
+    CAMERA_ACCESS_POINT,
+    PHONE_HOTSPOT,
+}
+
+/**
+ * Guided wizard steps, mirroring iOS `FirstPairWizardStep`: permissions →
+ * choose path → prepare the camera → set up the network → (hotspot only)
+ * find and pair. Camera-AP pairing ends at [NETWORK] — joining the camera's
+ * Wi-Fi is the last operator action; connect runs against the fixed AP host.
+ */
+public enum class PairingStep {
+    PERMISSIONS,
+    CHOOSE_PATH,
+    PREPARE,
+    NETWORK,
+    DISCOVER,
+}
+
+/**
+ * Immutable first-pair wizard position: the current [step] along the active
+ * [path]'s step sequence. Pure state — all side effects (permission requests,
+ * Wi-Fi joins, discovery, session connects) live with the UI layer.
+ *
+ * @property skipsPermissions Omits the permissions step (and adjusts the
+ *   numbering) when the runtime permission is already granted, mirroring iOS
+ *   `firstPairWizardSkipsPermissions`.
+ */
+public data class PairingFlowState(
+    val step: PairingStep = PairingStep.PERMISSIONS,
+    val path: PairingPath = PairingPath.CAMERA_ACCESS_POINT,
+    val skipsPermissions: Boolean = false,
+) {
+    init {
+        require(!(skipsPermissions && step == PairingStep.PERMISSIONS)) {
+            "The permissions step cannot be current while skipped"
+        }
+        require(!(path == PairingPath.CAMERA_ACCESS_POINT && step == PairingStep.DISCOVER)) {
+            "Camera-AP pairing ends at NETWORK; DISCOVER belongs to the hotspot path"
+        }
+    }
+
+    private val sequence: List<PairingStep>
+        get() = buildList {
+            if (!skipsPermissions) add(PairingStep.PERMISSIONS)
+            add(PairingStep.CHOOSE_PATH)
+            add(PairingStep.PREPARE)
+            add(PairingStep.NETWORK)
+            if (path == PairingPath.PHONE_HOTSPOT) add(PairingStep.DISCOVER)
+        }
+
+    /** Total visible steps for the active path (iOS `stepCount(transport:skipsPermissions:)`). */
+    val stepCount: Int
+        get() = sequence.size
+
+    /** 1-based step index shown in the wizard chrome. */
+    val displayStepNumber: Int
+        get() = sequence.indexOf(step) + 1
+
+    /** Whether this step is the last one for the chosen path. */
+    val isFinalStep: Boolean
+        get() = sequence.last() == step
+
+    /** Whether a Back affordance makes sense (any step after the first). */
+    val canRetreat: Boolean
+        get() = sequence.indexOf(step) > 0
+
+    /** The next step, or this state unchanged when already at the final step. */
+    public fun advance(): PairingFlowState {
+        val index = sequence.indexOf(step)
+        if (index == sequence.lastIndex) return this
+        return copy(step = sequence[index + 1])
+    }
+
+    /** The previous step, or this state unchanged when at the first step. */
+    public fun retreat(): PairingFlowState {
+        val index = sequence.indexOf(step)
+        if (index <= 0) return this
+        return copy(step = sequence[index - 1])
+    }
+
+    /** Selects a path from the choose step and advances (tap = select + advance, like iOS). */
+    public fun choose(path: PairingPath): PairingFlowState =
+        copy(path = path, step = PairingStep.PREPARE)
+
+    public companion object {
+        /** Initial wizard state, skipping straight past permissions when already granted. */
+        public fun initial(permissionGranted: Boolean): PairingFlowState =
+            if (permissionGranted) {
+                PairingFlowState(step = PairingStep.CHOOSE_PATH, skipsPermissions = true)
+            } else {
+                PairingFlowState()
+            }
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/StartupDesign.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/StartupDesign.kt
@@ -1,0 +1,213 @@
+package com.opencapture.openzcine.pairing
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * Startup/pairing design tokens — a 1:1 port of the iOS shell's
+ * `StartupColors` (ios/Runner/StartupDesign.swift). Same float components so
+ * the two shells render identical startup chrome. Keep the lists in sync.
+ * These are the warm connection-screen accents, distinct from the monitor
+ * chrome's [com.opencapture.openzcine.LiveDesign].
+ */
+public object StartupColors {
+    public val surface: Color = Color(0.086f, 0.075f, 0.059f)
+    public val tile: Color = Color(0.141f, 0.122f, 0.102f)
+    public val control: Color = Color(0.173f, 0.149f, 0.125f)
+    public val ink: Color = Color(0.949f, 0.925f, 0.886f)
+    public val muted: Color = Color(0.655f, 0.612f, 0.553f)
+    public val dim: Color = Color(0.490f, 0.447f, 0.392f)
+    public val border: Color = Color.White
+    public val card: Color = surface.copy(alpha = 0.58f)
+    public val accent: Color = Color(0.878f, 0.655f, 0.227f)
+    public val ready: Color = Color(0.247f, 0.710f, 0.416f)
+    public val destructive: Color = Color(0.930f, 0.267f, 0.267f)
+    public val darkText: Color = Color(0.110f, 0.086f, 0.047f)
+
+    /** Warm near-black backdrop base (iOS `StartupColors.backdrop`). */
+    public val backdropBase: Color = Color(0.055f, 0.045f, 0.034f)
+
+    /** Soft glow color at the backdrop's radial center. */
+    public val backdropGlow: Color = Color(0.132f, 0.108f, 0.082f)
+}
+
+/**
+ * Cinematic page backdrop for the connection screens: warm near-black with a
+ * soft glow falling off from the upper area — iOS `StartupColors.backdrop`.
+ */
+public fun Modifier.startupBackdrop(): Modifier = drawBehind {
+    drawRect(StartupColors.backdropBase)
+    drawRect(
+        Brush.radialGradient(
+            colors = listOf(StartupColors.backdropGlow, StartupColors.backdropGlow.copy(alpha = 0f)),
+            center = Offset(size.width * 0.5f, size.height * 0.24f),
+            radius = 760.dp.toPx(),
+        )
+    )
+}
+
+/** Rounded card surface for the two-column startup screens (iOS `StartupCardBackground`). */
+public fun Modifier.startupCard(): Modifier =
+    clip(RoundedCornerShape(20.dp))
+        .background(StartupColors.card)
+        .border(1.dp, StartupColors.border.copy(alpha = 0.08f), RoundedCornerShape(20.dp))
+
+/** Inner tile/row surface (iOS 14pt-radius tile). */
+public fun Modifier.startupTile(borderColor: Color = StartupColors.border.copy(alpha = 0.10f)): Modifier =
+    clip(RoundedCornerShape(14.dp))
+        .background(StartupColors.tile.copy(alpha = 0.45f))
+        .border(1.dp, borderColor, RoundedCornerShape(14.dp))
+
+/** Instruction-card surface (iOS `StartupColors.card` on 16pt radius). */
+public fun Modifier.startupInstructionCard(): Modifier =
+    clip(RoundedCornerShape(16.dp))
+        .background(StartupColors.card)
+        .border(1.dp, StartupColors.border.copy(alpha = 0.10f), RoundedCornerShape(16.dp))
+
+/**
+ * Startup header row: the OPENZCINE wordmark over a contextual title, with a
+ * live status pill on the trailing edge (iOS `StartupHeader`).
+ */
+@Composable
+public fun StartupHeader(title: String, statusTitle: String, isBusy: Boolean) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Column {
+            Text(
+                "OPENZCINE",
+                color = StartupColors.muted,
+                fontSize = 10.sp,
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 1.3.sp,
+            )
+            Text(
+                title,
+                color = StartupColors.ink,
+                fontSize = 17.sp,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+            )
+        }
+        Spacer(Modifier.weight(1f))
+        val statusColor = if (isBusy) StartupColors.accent else StartupColors.ready
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            modifier =
+                Modifier.clip(CircleShape)
+                    .background(StartupColors.surface.copy(alpha = 0.50f))
+                    .border(1.dp, statusColor.copy(alpha = 0.40f), CircleShape)
+                    .padding(horizontal = 14.dp, vertical = 7.dp),
+        ) {
+            Box(Modifier.size(7.dp).background(statusColor, CircleShape))
+            Text(
+                statusTitle,
+                color = statusColor,
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+/** Wizard progress capsules with the step counter (iOS `StartupWizardProgress`, compact). */
+@Composable
+public fun StartupWizardProgress(currentStep: Int, totalSteps: Int) {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+        Row {
+            Text(
+                "Setup",
+                color = StartupColors.muted,
+                fontSize = 10.sp,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(Modifier.weight(1f))
+            Text(
+                "Step $currentStep of $totalSteps",
+                color = StartupColors.dim,
+                fontSize = 10.sp,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            for (step in 1..totalSteps) {
+                val filled = step <= currentStep
+                Box(
+                    Modifier.weight(1f)
+                        .height(3.dp)
+                        .clip(CircleShape)
+                        .background(
+                            if (filled) StartupColors.accent
+                            else StartupColors.control.copy(alpha = 0.55f)
+                        )
+                )
+            }
+        }
+    }
+}
+
+/**
+ * A thin accent line whose segment slides back and forth — the indeterminate
+ * "working" indicator (iOS `StartupIndeterminateBar`).
+ */
+@Composable
+public fun StartupIndeterminateBar(modifier: Modifier = Modifier) {
+    val transition = rememberInfiniteTransition(label = "startup-indeterminate")
+    val progress by
+        transition.animateFloat(
+            initialValue = 0f,
+            targetValue = 1f,
+            animationSpec =
+                infiniteRepeatable(tween(durationMillis = 850), repeatMode = RepeatMode.Reverse),
+            label = "startup-indeterminate-offset",
+        )
+    BoxWithConstraints(
+        modifier
+            .fillMaxWidth()
+            .height(3.dp)
+            .clip(CircleShape)
+            .background(StartupColors.control.copy(alpha = 0.45f))
+    ) {
+        val segment: Dp = maxOf(44.dp, maxWidth * 0.32f)
+        Box(
+            Modifier.width(segment)
+                .height(3.dp)
+                .offset(x = (maxWidth - segment) * progress)
+                .clip(CircleShape)
+                .background(StartupColors.accent)
+        )
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/CameraDiscovery.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/CameraDiscovery.kt
@@ -87,6 +87,12 @@ class CameraDiscovery(private val browser: NsdBrowser) {
          */
         const val NIKON_ZR_ACCESS_POINT_HOST: String = "192.168.1.1"
 
+        /**
+         * Prefix of the camera's own access-point SSID (e.g. `NIKON_ZR_01234`)
+         * — mirrors `CameraWiFiSSID.nikonAccessPointPrefix` in the shared core.
+         */
+        const val NIKON_ZR_SSID_PREFIX: String = "NIKON_ZR_"
+
         /** Direct-host camera for the camera-AP case; no mDNS browse needed. */
         fun accessPointCamera(): DiscoveredCamera =
             DiscoveredCamera(

--- a/Apps/Android/app/src/release/kotlin/com/opencapture/openzcine/DemoHarness.kt
+++ b/Apps/Android/app/src/release/kotlin/com/opencapture/openzcine/DemoHarness.kt
@@ -3,6 +3,7 @@ package com.opencapture.openzcine
 import android.content.Intent
 import com.opencapture.openzcine.core.CameraSession
 import com.opencapture.openzcine.core.LiveFrameSource
+import com.opencapture.openzcine.pairing.PairingScript
 
 /**
  * Release stub — the demo harness does not exist outside debug builds. The
@@ -16,4 +17,8 @@ object DemoHarness {
     /** Always null: release builds carry no demo frame source. */
     @Suppress("UNUSED_PARAMETER")
     fun demoLiveFeed(intent: Intent): Pair<CameraSession, LiveFrameSource>? = null
+
+    /** Always null: release builds carry no scripted pairing wizard. */
+    @Suppress("UNUSED_PARAMETER")
+    fun pairingScript(intent: Intent): PairingScript? = null
 }

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/pairing/PairingFlowTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/pairing/PairingFlowTest.kt
@@ -1,0 +1,104 @@
+package com.opencapture.openzcine.pairing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PairingFlowTest {
+    @Test
+    fun `camera-AP path walks permissions to network and ends there`() {
+        var state = PairingFlowState.initial(permissionGranted = false)
+        assertEquals(PairingStep.PERMISSIONS, state.step)
+        assertEquals(4, state.stepCount)
+        assertEquals(1, state.displayStepNumber)
+        assertFalse(state.canRetreat)
+
+        state = state.advance()
+        assertEquals(PairingStep.CHOOSE_PATH, state.step)
+
+        state = state.choose(PairingPath.CAMERA_ACCESS_POINT)
+        assertEquals(PairingStep.PREPARE, state.step)
+        assertEquals(3, state.displayStepNumber)
+
+        state = state.advance()
+        assertEquals(PairingStep.NETWORK, state.step)
+        assertEquals(4, state.displayStepNumber)
+        assertTrue(state.isFinalStep)
+
+        // Advancing past the final step is a no-op.
+        assertEquals(state, state.advance())
+    }
+
+    @Test
+    fun `hotspot path adds the discover step as its final step`() {
+        var state = PairingFlowState.initial(permissionGranted = false)
+        state = state.advance().choose(PairingPath.PHONE_HOTSPOT)
+        assertEquals(5, state.stepCount)
+
+        state = state.advance()
+        assertEquals(PairingStep.NETWORK, state.step)
+        assertFalse(state.isFinalStep)
+
+        state = state.advance()
+        assertEquals(PairingStep.DISCOVER, state.step)
+        assertEquals(5, state.displayStepNumber)
+        assertTrue(state.isFinalStep)
+        assertEquals(state, state.advance())
+    }
+
+    @Test
+    fun `granted permission skips the permissions step and renumbers`() {
+        var state = PairingFlowState.initial(permissionGranted = true)
+        assertEquals(PairingStep.CHOOSE_PATH, state.step)
+        assertEquals(3, state.stepCount)
+        assertEquals(1, state.displayStepNumber)
+        assertFalse(state.canRetreat)
+
+        state = state.choose(PairingPath.PHONE_HOTSPOT)
+        assertEquals(4, state.stepCount)
+        assertEquals(2, state.displayStepNumber)
+    }
+
+    @Test
+    fun `retreat walks back and stops at the first step`() {
+        var state = PairingFlowState.initial(permissionGranted = false)
+        state = state.advance().choose(PairingPath.CAMERA_ACCESS_POINT).advance()
+        assertEquals(PairingStep.NETWORK, state.step)
+
+        state = state.retreat()
+        assertEquals(PairingStep.PREPARE, state.step)
+        state = state.retreat()
+        assertEquals(PairingStep.CHOOSE_PATH, state.step)
+        state = state.retreat()
+        assertEquals(PairingStep.PERMISSIONS, state.step)
+        assertEquals(state, state.retreat())
+    }
+
+    @Test
+    fun `choosing a new path from choose step resets onto that path`() {
+        var state = PairingFlowState.initial(permissionGranted = false).advance()
+        state = state.choose(PairingPath.PHONE_HOTSPOT)
+        assertEquals(PairingPath.PHONE_HOTSPOT, state.path)
+
+        // Back to choose, pick the other path.
+        state = state.retreat().choose(PairingPath.CAMERA_ACCESS_POINT)
+        assertEquals(PairingPath.CAMERA_ACCESS_POINT, state.path)
+        assertEquals(4, state.stepCount)
+    }
+
+    @Test
+    fun `discover step is rejected on the camera-AP path`() {
+        assertFailsWith<IllegalArgumentException> {
+            PairingFlowState(step = PairingStep.DISCOVER, path = PairingPath.CAMERA_ACCESS_POINT)
+        }
+    }
+
+    @Test
+    fun `permissions step is rejected while skipped`() {
+        assertFailsWith<IllegalArgumentException> {
+            PairingFlowState(step = PairingStep.PERMISSIONS, skipsPermissions = true)
+        }
+    }
+}


### PR DESCRIPTION
Part of #70 (Kaneo OPE-27). Ports the iOS first-pair wizard (LinkExperience/StartupDesign) to Android in the app's startup design language: permissions → choose path → prepare → network (→ find and pair), two-column landscape layout with the OPENZCINE header, status pill, and progress capsules; copy body-agnostic per the Z-lineup pass.

- **Camera-AP path**: joins the `NIKON_ZR_…` network via `WifiNetworkSpecifier` + `requestNetwork` (no-internet capability, 45s timeout) with `bindProcessToNetwork` so PTP-IP routes over the camera link even with mobile data on; the key is entered first time only and remembered in a Keystore-encrypted store (AES/GCM, non-exportable key — EncryptedSharedPreferences rejected as deprecated). Callback stays registered for the session's life; release/cancel unbinds cleanly (device-verified: live specifier dialog + app-side cancel).
- **Phone-hotspot path**: instructions + NSD discovery only — the camera joins the phone; the phone never scans or joins. The separation is structural: `CameraApJoiner` is the entire AP network surface and only the AP path invokes it.
- Runtime permission step (`NEARBY_WIFI_DEVICES` with neverForLocation on 33+; fine+coarse location below) mirroring the iOS explainer flow, with Settings deep-link on denial and re-check on resume.
- Debug demo hooks for every wizard state (release-inert); 7 JVM state-machine tests; on-device screenshot pass of all states (two layout bugs found and fixed by it). Zero credential logging (grep-verified).

Real camera-AP join against the ZR remains hardware validation — steps documented, including the mobile-data-on routing check and the hotspot-path "phone never shows a join dialog" assertion. ZR menu wording marked `[VERIFY-ON-HW]` in PairingCopy.

`just android-check` + `just check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
