### PR TITLE
feat(android): GPU feed-effects chain — LUT, false colour, peaking, zebra

### DIFF
--- a/Apps/Android/README.md
+++ b/Apps/Android/README.md
@@ -34,4 +34,14 @@ app falls back to the placeholder monitor ("No camera").
   (logcat tag `SwiftCoreCameraSession`). For a fake-ZR server on the development Mac (scripted
   twin: `Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift`), forward the port with
   `adb reverse tcp:15740 tcp:15740` and use host `127.0.0.1`.
+- **Feed effects (view assists):** `FeedEffectsRenderer` bakes LUT preview, false colour,
+  focus peaking, and zebras into the live feed in one AGSL pass. All colour math is baked in
+  the shared Swift core (`Sources/OpenZCineAndroidFacade/FeedEffectsWire.swift` — cubes from
+  `MonitorLUT`/`FalseColorMap`, thresholds from `ExposureSignalMapping`); Kotlin only uploads
+  textures/uniforms and interpolates. Requires **API 33 (AGSL)** and the staged Swift core —
+  below that the plain feed still renders (minSdk 29) and a warning is logged. Debug-only
+  activation until the assist toolbar lands:
+  `adb shell am start -n com.opencapture.openzcine/.MainActivity --ez zc.demo.feed true
+  --es zc.assist lut,peaking,zebra --es zc.lut log3g10` (`zc.assist` also takes `falsecolor`,
+  with `--es zc.fc.scale stops|ire`; false colour replaces the LUT, like iOS).
 - **Local SDK:** put `sdk.dir=<your Android SDK path>` in `Apps/Android/local.properties` (gitignored).

--- a/Apps/Android/app/src/debug/kotlin/com/opencapture/openzcine/DemoHarness.kt
+++ b/Apps/Android/app/src/debug/kotlin/com/opencapture/openzcine/DemoHarness.kt
@@ -17,6 +17,13 @@ import com.opencapture.openzcine.core.LiveFrameSource
  * ```
  * adb shell am start -n com.opencapture.openzcine/.MainActivity --ez zc.demo.feed true
  * ```
+ *
+ * Feed effects (needs API 33 + the staged Swift core; combine freely):
+ * ```
+ * --es zc.assist lut,falsecolor,peaking,zebra   which effects are on
+ * --es zc.lut log3g10|nlog|mono                 built-in look (default log3g10)
+ * --es zc.fc.scale stops|ire                    false-colour scale (default stops)
+ * ```
  */
 object DemoHarness {
     /** Boolean intent extra that switches the synthetic demo feed on. */
@@ -27,10 +34,17 @@ object DemoHarness {
      * [EXTRA_DEMO_FEED]; null in a normal launch. Also the debug intent entry
      * point for the Swift-core session probe (`zc.session.host` — see
      * [SwiftCoreSessionProbe]), which runs as a logcat side effect without
-     * replacing the shell's session.
+     * replacing the shell's session, and for the feed-effect flags
+     * (`zc.assist` — applied to whichever feed renders, demo or live).
      */
     fun demoLiveFeed(intent: Intent): Pair<CameraSession, LiveFrameSource>? {
         SwiftCoreSessionProbe.maybeStart(intent)
+        FeedEffectsState.current =
+            FeedEffects.parse(
+                intent.getStringExtra("zc.assist"),
+                intent.getStringExtra("zc.lut"),
+                intent.getStringExtra("zc.fc.scale"),
+            )
         if (!intent.getBooleanExtra(EXTRA_DEMO_FEED, false)) return null
         val session =
             FakeCameraSession(

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/FeedEffects.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/FeedEffects.kt
@@ -1,0 +1,83 @@
+package com.opencapture.openzcine
+
+/**
+ * Built-in monitor looks. [wireOrdinal] mirrors `FeedEffectsWire.look` in the
+ * Swift facade — the core generates each look's cube, Kotlin only uploads it.
+ */
+enum class FeedLut(val id: String, val wireOrdinal: Int) {
+    LOG3G10_709("log3g10", 0),
+    NLOG_709("nlog", 1),
+    MONO("mono", 2);
+
+    companion object {
+        fun fromId(id: String): FeedLut? = entries.firstOrNull { it.id == id }
+    }
+}
+
+/** False-colour scales. [wireOrdinal] mirrors `FeedEffectsWire.bakedFalseColor`. */
+enum class FeedFalseColorScale(val id: String, val wireOrdinal: Int) {
+    STOPS("stops", 0),
+    IRE("ire", 1);
+
+    companion object {
+        fun fromId(id: String): FeedFalseColorScale? = entries.firstOrNull { it.id == id }
+    }
+}
+
+/**
+ * Which analysis effects the live feed bakes in, mirroring the iOS shell's
+ * `LiveImageEffects`. False colour and the LUT are mutually exclusive — false
+ * colour *is* the monitoring image, so it replaces the creative look.
+ *
+ * Until the assist toolbar lands this is driven by debug intent extras only
+ * (see `DemoHarness`): `--es zc.assist lut,falsecolor,peaking,zebra`
+ * plus `--es zc.lut <log3g10|nlog|mono>` and `--es zc.fc.scale <stops|ire>`.
+ */
+data class FeedEffects(
+    val lut: FeedLut? = null,
+    val falseColor: FeedFalseColorScale? = null,
+    val peaking: Boolean = false,
+    val zebra: Boolean = false,
+) {
+    /** True when the feed renders untouched — the renderer skips the GPU chain. */
+    val isIdentity: Boolean
+        get() = lut == null && falseColor == null && !peaking && !zebra
+
+    companion object {
+        val NONE = FeedEffects()
+
+        /**
+         * Parses the debug intent extras. [assist] is a comma-separated token
+         * list (`lut`, `falsecolor`, `peaking`, `zebra`; unknown tokens are
+         * ignored); [lutId]/[falseColorScaleId] select variants, falling back
+         * to the iOS defaults (Log3G10→709, Stops) when absent or unknown.
+         */
+        fun parse(assist: String?, lutId: String?, falseColorScaleId: String?): FeedEffects {
+            val tokens =
+                assist.orEmpty()
+                    .split(',')
+                    .map { it.trim().lowercase() }
+                    .filter { it.isNotEmpty() }
+                    .toSet()
+            val falseColor =
+                if ("falsecolor" in tokens) {
+                    falseColorScaleId?.let(FeedFalseColorScale::fromId)
+                        ?: FeedFalseColorScale.STOPS
+                } else {
+                    null
+                }
+            return FeedEffects(
+                // False colour replaces the creative look, like iOS.
+                lut =
+                    if (falseColor == null && "lut" in tokens) {
+                        lutId?.let(FeedLut::fromId) ?: FeedLut.LOG3G10_709
+                    } else {
+                        null
+                    },
+                falseColor = falseColor,
+                peaking = "peaking" in tokens,
+                zebra = "zebra" in tokens,
+            )
+        }
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/FeedEffectsRenderer.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/FeedEffectsRenderer.kt
@@ -1,0 +1,275 @@
+package com.opencapture.openzcine
+
+import android.graphics.Bitmap
+import android.graphics.BitmapShader
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RuntimeShader
+import android.graphics.Shader
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.opencapture.openzcine.bridge.SwiftCore
+import java.nio.ByteBuffer
+
+private const val TAG = "ZCFeedEffects"
+
+/**
+ * Effects [LiveFeedView] applies by default. Debug-intent driven (see
+ * `DemoHarness`) until the assist toolbar owns it; release builds never set it.
+ */
+object FeedEffectsState {
+    var current: FeedEffects by mutableStateOf(FeedEffects.NONE)
+}
+
+/**
+ * GPU effect chain for the live feed — one AGSL pass over the decoded frame,
+ * mirroring the iOS `LiveFrameProcessor` order of operations:
+ *
+ * 1. **Base look**: false colour (which replaces the creative grade) or the
+ *    selected LUT, as a 3D-LUT sample of the encoded source pixel. The cube is
+ *    baked by the Swift core and uploaded once as a packed-2D texture
+ *    (`width = size²`, `height = size`; slice tiles along x). The shader takes
+ *    two bilinear taps on adjacent blue slices and mixes — trilinear, the same
+ *    interpolation `CIColorCube`/`CubeLUT.map` perform.
+ * 2. **Focus peaking**, measured from the *source* frame: the de-logged grey
+ *    (the core's black→clip stretch, uniforms from `feedEffectsScalars`) runs a
+ *    two-scale gradient difference — first-derivative magnitude peaks ON the
+ *    edge (single line), and subtracting the coarse-scale gradient cancels
+ *    defocused background edges. Overlay colour is `LiveDesign.accent`.
+ * 3. **Zebra**, also measured from the source frame: Rec.709 luma against the
+ *    core-supplied highlight threshold and midtone band, drawn as diagonal
+ *    stripes over the graded image.
+ *
+ * All colour math lives in the Swift core; this class uploads baked payloads
+ * and interpolates. Requires API 33 (AGSL) and the staged Swift core —
+ * [create] returns null otherwise and the feed renders plain.
+ */
+@RequiresApi(33)
+class FeedEffectsRenderer private constructor(private val shader: RuntimeShader) {
+    private val paint = Paint().apply { shader = this@FeedEffectsRenderer.shader }
+
+    /** One shader wrapper per ring bitmap; content updates are picked up via generation id. */
+    private val feedShaders = HashMap<Bitmap, BitmapShader>()
+
+    /** Draws [frame] with the effect chain into the letterboxed destination rect. */
+    fun draw(
+        canvas: Canvas,
+        frame: Bitmap,
+        dstLeft: Float,
+        dstTop: Float,
+        dstWidth: Float,
+        dstHeight: Float,
+    ) {
+        // The decode ring holds 3 bitmaps; a growing map means the feed size
+        // changed and the old ring was dropped — start over.
+        if (feedShaders.size > 4) feedShaders.clear()
+        val feed =
+            feedShaders.getOrPut(frame) {
+                BitmapShader(frame, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP).apply {
+                    filterMode = BitmapShader.FILTER_MODE_LINEAR
+                }
+            }
+        shader.setInputShader("feed", feed)
+        shader.setFloatUniform("dstOffset", dstLeft, dstTop)
+        shader.setFloatUniform("srcScale", frame.width / dstWidth)
+        canvas.drawRect(dstLeft, dstTop, dstLeft + dstWidth, dstTop + dstHeight, paint)
+    }
+
+    companion object {
+        /** Curve ordinal for RED Log3G10 — the offline-monitoring default (see iOS
+         * `playbackExposureSignalMapping`); camera-driven curve selection lands with
+         * the session-backed feed. Mirrors `FeedEffectsWire.curve`. */
+        private const val CURVE_LOG3G10 = 0
+
+        /** iOS `ZebraSettings` defaults: highlight at monitor 100%, midtone at 55%. */
+        private const val ZEBRA_HIGHLIGHT_IRE = 100f
+        private const val ZEBRA_MIDTONE_IRE = 55f
+
+        /** 33³ matches the iOS built-in looks; false colour uses the core's 64³. */
+        private const val LUT_SIZE = 33
+
+        /**
+         * Renderer for [effects], or null when nothing is on or the Swift
+         * core isn't staged — callers fall back to the plain feed. Callers
+         * own the API 33 (AGSL) gate, per the class annotation.
+         */
+        fun create(effects: FeedEffects): FeedEffectsRenderer? {
+            if (effects.isIdentity) return null
+            if (!SwiftCore.isAvailable) {
+                Log.w(TAG, "feed effects need the Swift core (just android-core); rendering plain")
+                return null
+            }
+            return try {
+                build(effects)
+            } catch (e: RuntimeException) {
+                Log.e(TAG, "feed-effects pipeline setup failed; rendering the plain feed", e)
+                null
+            }
+        }
+
+        /** Bakes once per selection: cube upload + threshold uniforms, never per frame. */
+        private fun build(effects: FeedEffects): FeedEffectsRenderer {
+            val shader = RuntimeShader(EFFECTS_AGSL)
+
+            val cube: ByteArray?
+            val cubeSize: Int
+            when {
+                effects.falseColor != null -> {
+                    cube = SwiftCore.bakeFalseColorCube(effects.falseColor.wireOrdinal, CURVE_LOG3G10)
+                    cubeSize = 64
+                }
+                effects.lut != null -> {
+                    cube = SwiftCore.bakeLut(effects.lut.wireOrdinal, LUT_SIZE)
+                    cubeSize = LUT_SIZE
+                }
+                else -> {
+                    cube = null
+                    cubeSize = 0
+                }
+            }
+            if (cubeSize > 0 && cube == null) {
+                Log.w(TAG, "core returned no cube for $effects; base look disabled")
+            }
+            if (cube != null) {
+                check(cube.size == cubeSize * cubeSize * cubeSize * 4) { "bad cube payload" }
+                val lut = Bitmap.createBitmap(cubeSize * cubeSize, cubeSize, Bitmap.Config.ARGB_8888)
+                lut.copyPixelsFromBuffer(ByteBuffer.wrap(cube))
+                shader.setInputShader(
+                    "lut",
+                    BitmapShader(lut, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP).apply {
+                        filterMode = BitmapShader.FILTER_MODE_LINEAR
+                    },
+                )
+                shader.setFloatUniform("lutSize", cubeSize.toFloat())
+            } else {
+                // Every declared child must be bound; lutSize 0 keeps grade() a no-op.
+                val stub = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+                shader.setInputShader(
+                    "lut",
+                    BitmapShader(stub, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP),
+                )
+                shader.setFloatUniform("lutSize", 0f)
+            }
+
+            val scalars =
+                requireNotNull(
+                    SwiftCore.feedEffectsScalars(
+                        CURVE_LOG3G10,
+                        ZEBRA_HIGHLIGHT_IRE,
+                        ZEBRA_MIDTONE_IRE,
+                    ),
+                ) { "core rejected the effect scalars" }
+            shader.setFloatUniform("deLogRange", scalars[0], scalars[1])
+            shader.setFloatUniform("peakingOn", if (effects.peaking) 1f else 0f)
+            shader.setFloatUniform(
+                "peakingColor",
+                LiveDesign.accent.red,
+                LiveDesign.accent.green,
+                LiveDesign.accent.blue,
+            )
+            shader.setFloatUniform("zebraOn", if (effects.zebra) 1f else 0f)
+            shader.setFloatUniform("zebraHighlight", scalars[2])
+            shader.setFloatUniform("zebraMidtone", scalars[3])
+            if (BuildConfig.DEBUG) {
+                Log.d(
+                    TAG,
+                    "pipeline up: $effects cube=${cube?.size ?: 0}B " +
+                        "scalars=${scalars.joinToString()}",
+                )
+            }
+            return FeedEffectsRenderer(shader)
+        }
+    }
+}
+
+/**
+ * The single-pass effect shader. Peaking/zebra measure the SOURCE pixel so a
+ * grade never changes what reads as in-focus or clipped (iOS invariant).
+ *
+ * Renderer-tuning constants (thresholds, gains, stripe pitch) mirror the iOS
+ * compositor's; the colour math (cube contents, de-log anchors, zebra
+ * thresholds) arrives baked from the Swift core via uniforms/textures.
+ */
+private val EFFECTS_AGSL =
+    """
+    uniform shader feed;          // decoded frame, bitmap px
+    uniform shader lut;           // packed cube: width = n*n, height = n
+    uniform float lutSize;        // cube edge n; < 2 disables the base look
+    uniform float2 dstOffset;     // letterbox origin, canvas px
+    uniform float srcScale;       // canvas px -> bitmap px
+
+    uniform float peakingOn;
+    uniform float3 peakingColor;
+    uniform float2 deLogRange;    // core black/clip anchors, normalized code
+
+    uniform float zebraOn;
+    uniform float zebraHighlight; // core threshold, normalized code
+    uniform float zebraMidtone;   // core band centre, normalized code
+
+    const float3 LUMA709 = float3(0.2126, 0.7152, 0.0722);
+    const float PEAKING_THRESHOLD = 0.04;   // on the defocus-cancelled gradient
+    const float PEAKING_RAMP = 24.0;
+    const float DEFOCUS_REJECTION = 1.35;   // iOS ImageEffectsCompositor
+    const float ZEBRA_GAIN = 40.0;          // iOS soft-threshold ramp
+    const float ZEBRA_HALF_WIDTH = 5.0 / 255.0;
+    const float STRIPE_PITCH = 14.14;       // iOS 5 px stripes rotated 45 deg
+
+    float3 grade(float3 c) {
+        if (lutSize < 2.0) return c;
+        float n = lutSize;
+        float b = clamp(c.b, 0.0, 1.0) * (n - 1.0);
+        float s0 = floor(b);
+        float s1 = min(s0 + 1.0, n - 1.0);
+        float x = clamp(c.r, 0.0, 1.0) * (n - 1.0) + 0.5;
+        float y = clamp(c.g, 0.0, 1.0) * (n - 1.0) + 0.5;
+        float3 lo = float3(lut.eval(float2(s0 * n + x, y)).rgb);
+        float3 hi = float3(lut.eval(float2(s1 * n + x, y)).rgb);
+        return mix(lo, hi, b - s0);
+    }
+
+    // De-logged grey: the core's black->clip stretch of the mean channel.
+    float deLogGrey(float2 p) {
+        float3 c = float3(feed.eval(p).rgb);
+        float g = (c.r + c.g + c.b) / 3.0;
+        return clamp((g - deLogRange.x) / (deLogRange.y - deLogRange.x), 0.0, 1.0);
+    }
+
+    // Central-difference gradient magnitude per pixel at sampling distance d.
+    float gradMag(float2 p, float d) {
+        float gx = deLogGrey(p + float2(d, 0.0)) - deLogGrey(p - float2(d, 0.0));
+        float gy = deLogGrey(p + float2(0.0, d)) - deLogGrey(p - float2(0.0, d));
+        return length(float2(gx, gy)) / (2.0 * d);
+    }
+
+    half4 main(float2 fragCoord) {
+        float2 src = (fragCoord - dstOffset) * srcScale;
+        float3 source = float3(feed.eval(src).rgb);
+        float3 color = grade(source);
+
+        if (peakingOn > 0.5) {
+            // fine - k*coarse: a sharp edge keeps fine-scale gradient a wide
+            // (defocused) edge lacks; both scales cancel on blurred edges.
+            float fine = gradMag(src, 1.0);
+            float coarse = gradMag(src, 2.6);
+            float response = fine - DEFOCUS_REJECTION * coarse;
+            float mask = clamp((response - PEAKING_THRESHOLD) * PEAKING_RAMP, 0.0, 1.0);
+            color = mix(color, peakingColor, mask);
+        }
+
+        if (zebraOn > 0.5) {
+            float luma = dot(source, LUMA709);
+            float stripe = step(0.5, fract((fragCoord.x + fragCoord.y) / STRIPE_PITCH));
+            float hi = clamp((luma - zebraHighlight) * ZEBRA_GAIN, 0.0, 1.0);
+            color = mix(color, float3(1.0), hi * stripe);
+            float mid = clamp((luma - (zebraMidtone - ZEBRA_HALF_WIDTH)) * ZEBRA_GAIN, 0.0, 1.0)
+                * clamp(((zebraMidtone + ZEBRA_HALF_WIDTH) - luma) * ZEBRA_GAIN, 0.0, 1.0);
+            color = mix(color, float3(1.0, 0.72, 0.2), mid * stripe);
+        }
+
+        return half4(half3(color), 1.0);
+    }
+    """
+        .trimIndent()

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/LiveFeedView.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/LiveFeedView.kt
@@ -3,6 +3,7 @@ package com.opencapture.openzcine
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.media.MediaCodecList
+import android.os.Build
 import android.util.Log
 import androidx.compose.foundation.Canvas
 import androidx.compose.runtime.Composable
@@ -11,7 +12,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import com.opencapture.openzcine.core.LiveFrameSource
@@ -76,10 +79,30 @@ class JpegFrameDecoder {
  *
  * The frame state is read inside the [Canvas] draw lambda only, so a new
  * frame costs one draw invalidation — no recomposition, no layout.
+ *
+ * [effects] bakes the GPU assist chain (LUT / false colour / peaking / zebra,
+ * see [FeedEffectsRenderer]) into the drawn frame. The default preserves the
+ * plain feed unless the debug harness switched effects on; devices below
+ * API 33 (AGSL) or builds without the staged Swift core always render plain.
  */
 @Composable
-fun LiveFeedView(source: LiveFrameSource, modifier: Modifier = Modifier) {
+fun LiveFeedView(
+    source: LiveFrameSource,
+    modifier: Modifier = Modifier,
+    effects: FeedEffects = FeedEffectsState.current,
+) {
     val frame = remember { mutableStateOf<ImageBitmap?>(null) }
+    val renderer =
+        remember(effects) {
+            when {
+                effects.isIdentity -> null
+                Build.VERSION.SDK_INT >= 33 -> FeedEffectsRenderer.create(effects)
+                else -> {
+                    Log.w(TAG, "feed effects need Android 13+ (AGSL); rendering the plain feed")
+                    null
+                }
+            }
+        }
 
     LaunchedEffect(source) {
         if (BuildConfig.DEBUG) {
@@ -108,7 +131,18 @@ fun LiveFeedView(source: LiveFrameSource, modifier: Modifier = Modifier) {
                 ((size.width - dstSize.width) / 2f).roundToInt(),
                 ((size.height - dstSize.height) / 2f).roundToInt(),
             )
-        drawImage(image, dstOffset = dstOffset, dstSize = dstSize)
+        if (Build.VERSION.SDK_INT >= 33 && renderer != null) {
+            renderer.draw(
+                canvas = drawContext.canvas.nativeCanvas,
+                frame = image.asAndroidBitmap(),
+                dstLeft = dstOffset.x.toFloat(),
+                dstTop = dstOffset.y.toFloat(),
+                dstWidth = dstSize.width.toFloat(),
+                dstHeight = dstSize.height.toFloat(),
+            )
+        } else {
+            drawImage(image, dstOffset = dstOffset, dstSize = dstSize)
+        }
     }
 }
 

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCore.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCore.kt
@@ -73,6 +73,40 @@ object SwiftCore {
      */
     external fun startConnectionDemo(listener: ConnectionPhaseListener)
 
+    // ── Feed effects (colour math baked in the core, uploaded by Kotlin) ──
+
+    /**
+     * A built-in monitor look baked by the core into a packed-2D RGBA8 grid
+     * (`size³ × 4` bytes) for a `width = size²`, `height = size` texture:
+     * pixel `(x = b·size + r, y = g)` — slice tiles along x, so a shader
+     * trilinearly samples with two bilinear taps. Null for an unknown
+     * [lookOrdinal] (`FeedLut.wireOrdinal`) or size outside 2–64. Bake once
+     * per selection (the cube generation is ~10⁵ transcendental calls), never
+     * per frame.
+     */
+    external fun bakeLut(lookOrdinal: Int, size: Int): ByteArray?
+
+    /**
+     * The core's false-colour cube (64³) in the same packed-2D RGBA8 grid.
+     * [scaleOrdinal] is `FeedFalseColorScale.wireOrdinal`; [curveOrdinal]
+     * selects the signal curve (0 = Log3G10, 1 = N-Log). Null for unknown
+     * ordinals.
+     */
+    external fun bakeFalseColorCube(scaleOrdinal: Int, curveOrdinal: Int): ByteArray?
+
+    /**
+     * Assist thresholds on the normalized 0–1 code axis:
+     * `[deLogBlack, deLogClip, zebraHighlight, zebraMidtoneCentre]` — the
+     * peaking de-log anchors and zebra comparison codes, computed by the
+     * core's `ExposureSignalMapping` for [curveOrdinal] and the given
+     * monitor-percent thresholds. Null for an unknown curve ordinal.
+     */
+    external fun feedEffectsScalars(
+        curveOrdinal: Int,
+        zebraHighlightIre: Float,
+        zebraMidtoneIre: Float,
+    ): FloatArray?
+
     // ── Camera session (PTP-IP protocol/session layer in the Swift core) ──
 
     /** Receives session lifecycle callbacks pushed from Swift (non-main thread). */

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/FeedEffectsTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/FeedEffectsTest.kt
@@ -1,0 +1,65 @@
+package com.opencapture.openzcine
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class FeedEffectsTest {
+    @Test
+    fun `no extras means the identity feed`() {
+        val effects = FeedEffects.parse(null, null, null)
+        assertEquals(FeedEffects.NONE, effects)
+        assertTrue(effects.isIdentity)
+    }
+
+    @Test
+    fun `parses a combined assist list`() {
+        val effects = FeedEffects.parse("lut,zebra,peaking", null, null)
+        assertEquals(FeedLut.LOG3G10_709, effects.lut)
+        assertNull(effects.falseColor)
+        assertTrue(effects.peaking)
+        assertTrue(effects.zebra)
+        assertFalse(effects.isIdentity)
+    }
+
+    @Test
+    fun `false colour replaces the lut like iOS`() {
+        val effects = FeedEffects.parse("lut,falsecolor", "mono", "ire")
+        assertNull(effects.lut)
+        assertEquals(FeedFalseColorScale.IRE, effects.falseColor)
+    }
+
+    @Test
+    fun `variant ids select looks and scales`() {
+        assertEquals(FeedLut.MONO, FeedEffects.parse("lut", "mono", null).lut)
+        assertEquals(FeedLut.NLOG_709, FeedEffects.parse("lut", "nlog", null).lut)
+        assertEquals(
+            FeedFalseColorScale.STOPS,
+            FeedEffects.parse("falsecolor", null, null).falseColor,
+        )
+    }
+
+    @Test
+    fun `unknown tokens and ids fall back to defaults`() {
+        val effects = FeedEffects.parse("sparkle, LUT , zebra", "not-a-look", null)
+        assertEquals(FeedLut.LOG3G10_709, effects.lut)
+        assertTrue(effects.zebra)
+        assertFalse(effects.peaking)
+        assertEquals(
+            FeedFalseColorScale.STOPS,
+            FeedEffects.parse("falsecolor", null, "bogus").falseColor,
+        )
+    }
+
+    @Test
+    fun `wire ordinals stay pinned to the Swift facade contract`() {
+        // FeedEffectsWire.look / .curve / .bakedFalseColor in the Swift facade.
+        assertEquals(0, FeedLut.LOG3G10_709.wireOrdinal)
+        assertEquals(1, FeedLut.NLOG_709.wireOrdinal)
+        assertEquals(2, FeedLut.MONO.wireOrdinal)
+        assertEquals(0, FeedFalseColorScale.STOPS.wireOrdinal)
+        assertEquals(1, FeedFalseColorScale.IRE.wireOrdinal)
+    }
+}

--- a/Sources/OpenZCineAndroidFacade/FeedEffectsWire.swift
+++ b/Sources/OpenZCineAndroidFacade/FeedEffectsWire.swift
@@ -1,0 +1,116 @@
+// Baked feed-effect payloads crossing the JNI seam.
+//
+// Like `MonitorZoneMapWire`, this file compiles on every platform so the baking
+// is exercised by `just native-check` on macOS against the exact colour math
+// the iOS shell renders with. The Kotlin consumer is
+// `Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/FeedEffectsRenderer.kt`.
+//
+// Single source of truth rule: the CORE bakes every curve and cube
+// (`MonitorLUT`, `FalseColorMap`, `ExposureSignalMapping`); Android only uploads
+// the result as textures/uniforms and interpolates. No colour math is re-derived
+// in Kotlin or AGSL.
+
+import OpenZCineCore
+
+/// Bakes monitor looks, false-colour cubes, and assist thresholds into flat
+/// byte/float payloads for the Android GPU effect chain.
+///
+/// Cube payloads use a packed-2D RGBA8 layout ready for a `width = size²`,
+/// `height = size` bitmap: pixel `(x = b·size + r, y = g)` carries the
+/// red-fastest cube entry `r + g·size + b·size²`, so a shader samples slice `b`
+/// as a `size × size` tile at x-offset `b·size` (bilinear in-tile, two taps +
+/// mix across slices = trilinear).
+public enum FeedEffectsWire {
+    /// Built-in look ordinals, mirroring `FeedLut` in Kotlin:
+    /// 0 = Log3G10→709, 1 = N-Log→709, 2 = Mono.
+    static func look(_ ordinal: Int) -> MonitorLUT? {
+        switch ordinal {
+        case 0: .log3G10Rec709
+        case 1: .nLogRec709
+        case 2: .monochrome
+        default: nil
+        }
+    }
+
+    /// Signal-curve ordinals, mirroring the Kotlin constants:
+    /// 0 = RED Log3G10, 1 = Nikon N-Log.
+    static func curve(_ ordinal: Int) -> ExposureToneCurve? {
+        switch ordinal {
+        case 0: .redLog3G10
+        case 1: .nikonNLog
+        default: nil
+        }
+    }
+
+    /// A built-in monitor look as a packed-2D RGBA8 grid (`size³ × 4` bytes),
+    /// or `nil` for an unknown ordinal / unsupported size. 33³ matches the iOS
+    /// built-ins (`MonitorLUT.cube`'s professional-`.cube` default).
+    public static func bakedLUT(lookOrdinal: Int, size: Int = 33) -> [UInt8]? {
+        guard let look = look(lookOrdinal), CubeLUT.supportedSizeRange.contains(size)
+        else { return nil }
+        return packedRGBA(cube: look.cube(size: size))
+    }
+
+    /// A false-colour cube (scale ordinal 0 = Stops, 1 = IRE) for the default
+    /// camera mapping of the selected curve, as a packed-2D RGBA8 grid at the
+    /// core's 64³ false-colour resolution. `nil` for unknown ordinals.
+    /// (The Limits scale composites two cubes over the graded feed and ships
+    /// with the assist-toolbar work, not this debug surface.)
+    public static func bakedFalseColor(scaleOrdinal: Int, curveOrdinal: Int) -> [UInt8]? {
+        guard let curve = curve(curveOrdinal) else { return nil }
+        let scale: FalseColorScale? =
+            switch scaleOrdinal {
+            case 0: .stops
+            case 1: .ire
+            default: nil
+            }
+        guard let scale else { return nil }
+        return packedRGBA(
+            cube: FalseColorMap.cube(scale: scale, mapping: ExposureSignalMapping(curve: curve)))
+    }
+
+    /// Assist thresholds on the normalized 0–1 code axis, for shader uniforms:
+    /// `[deLogBlack, deLogClip, zebraHighlight, zebraMidtoneCentre]`.
+    ///
+    /// The first pair anchors focus peaking's de-log stretch (the same
+    /// `ExposureScale.referenceIRE(signalNative:)` remap the iOS peaking path
+    /// applies before edge detection); the second pair converts the operator's
+    /// monitor-percent zebra thresholds to native code exactly like
+    /// `ImageEffectsCompositor.applyZebra`. `nil` for an unknown curve ordinal.
+    public static func scalars(
+        curveOrdinal: Int, zebraHighlightIRE: Double, zebraMidtoneIRE: Double
+    ) -> [Float]? {
+        guard let curve = curve(curveOrdinal) else { return nil }
+        let mapping = ExposureSignalMapping(curve: curve)
+        return [
+            Float(mapping.blackNative / 255),
+            Float(mapping.clipNative / 255),
+            Float(mapping.signalNative(monitorPercent: zebraHighlightIRE) / 255),
+            Float(mapping.signalNative(monitorPercent: zebraMidtoneIRE) / 255),
+        ]
+    }
+
+    /// Reorders a red-fastest cube into the packed-2D bitmap layout and
+    /// quantizes to RGBA8 (alpha 255).
+    static func packedRGBA(cube: CubeLUT) -> [UInt8] {
+        let size = cube.size
+        var out = [UInt8](repeating: 255, count: size * size * size * 4)
+        for g in 0..<size {
+            for b in 0..<size {
+                for r in 0..<size {
+                    let src = (r + g * size + b * size * size) * 3
+                    let dst = (g * size * size + b * size + r) * 4
+                    out[dst] = quantized(cube.rgb[src])
+                    out[dst + 1] = quantized(cube.rgb[src + 1])
+                    out[dst + 2] = quantized(cube.rgb[src + 2])
+                }
+            }
+        }
+        return out
+    }
+
+    /// `[0, 1]` float component to an 8-bit code, round-to-nearest.
+    static func quantized(_ value: Float) -> UInt8 {
+        UInt8((min(max(value, 0), 1) * 255).rounded())
+    }
+}

--- a/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
+++ b/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
@@ -42,6 +42,32 @@
         return String(cString: chars)
     }
 
+    /// Copies a Swift byte buffer into a new JVM `byte[]` local reference.
+    private func javaByteArray(
+        _ env: UnsafeMutablePointer<JNIEnv?>, _ bytes: [UInt8]
+    ) -> jbyteArray? {
+        let fns = table(env)
+        guard let array = fns.NewByteArray!(env, jsize(bytes.count)) else { return nil }
+        bytes.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress else { return }
+            fns.SetByteArrayRegion!(
+                env, array, 0, jsize(bytes.count), base.assumingMemoryBound(to: jbyte.self))
+        }
+        return array
+    }
+
+    /// Copies a Swift float buffer into a new JVM `float[]` local reference.
+    private func javaFloatArray(
+        _ env: UnsafeMutablePointer<JNIEnv?>, _ values: [Float]
+    ) -> jfloatArray? {
+        let fns = table(env)
+        guard let array = fns.NewFloatArray!(env, jsize(values.count)) else { return nil }
+        values.withUnsafeBufferPointer { buffer in
+            fns.SetFloatArrayRegion!(env, array, 0, jsize(values.count), buffer.baseAddress)
+        }
+        return array
+    }
+
     // MARK: - Info
 
     /// `SwiftCore.coreVersion(): String` — proves the Swift core is alive in-process.
@@ -119,6 +145,53 @@
             fns.SetFloatArrayRegion!(env, array, 0, jsize(flat.count), buffer.baseAddress)
         }
         return array
+    }
+
+    // MARK: - Feed effects (baked in the core, uploaded by Kotlin)
+
+    /// `SwiftCore.bakeLut(lookOrdinal, size): ByteArray?` — a built-in monitor
+    /// look baked by the core into the packed-2D RGBA8 grid described in
+    /// `FeedEffectsWire`. Null for unknown ordinals/sizes.
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_bakeLut")
+    public func swiftCoreBakeLut(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?, lookOrdinal: jint, size: jint
+    ) -> jbyteArray? {
+        guard
+            let bytes = FeedEffectsWire.bakedLUT(
+                lookOrdinal: Int(lookOrdinal), size: Int(size))
+        else { return nil }
+        return javaByteArray(env, bytes)
+    }
+
+    /// `SwiftCore.bakeFalseColorCube(scaleOrdinal, curveOrdinal): ByteArray?` —
+    /// the core's false-colour cube (64³) in the same packed-2D RGBA8 grid.
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_bakeFalseColorCube")
+    public func swiftCoreBakeFalseColorCube(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?, scaleOrdinal: jint,
+        curveOrdinal: jint
+    ) -> jbyteArray? {
+        guard
+            let bytes = FeedEffectsWire.bakedFalseColor(
+                scaleOrdinal: Int(scaleOrdinal), curveOrdinal: Int(curveOrdinal))
+        else { return nil }
+        return javaByteArray(env, bytes)
+    }
+
+    /// `SwiftCore.feedEffectsScalars(curveOrdinal, zebraHighlightIre, zebraMidtoneIre):
+    /// FloatArray?` — `[deLogBlack, deLogClip, zebraHighlight, zebraMidtoneCentre]`
+    /// on the normalized 0–1 code axis (see `FeedEffectsWire.scalars`).
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_feedEffectsScalars")
+    public func swiftCoreFeedEffectsScalars(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?, curveOrdinal: jint,
+        zebraHighlightIre: jfloat, zebraMidtoneIre: jfloat
+    ) -> jfloatArray? {
+        guard
+            let values = FeedEffectsWire.scalars(
+                curveOrdinal: Int(curveOrdinal),
+                zebraHighlightIRE: Double(zebraHighlightIre),
+                zebraMidtoneIRE: Double(zebraMidtoneIre))
+        else { return nil }
+        return javaFloatArray(env, values)
     }
 
     // MARK: - Callback / streaming shape

--- a/Tests/OpenZCineAndroidFacadeTests/FeedEffectsWireTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/FeedEffectsWireTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import OpenZCineCore
+import Testing
+
+@testable import OpenZCineAndroidFacade
+
+/// The packed-2D payloads Compose uploads as effect textures must carry the
+/// core's cube values exactly — pixel `(x = b·size + r, y = g)` ↔ red-fastest
+/// cube index — and the scalar thresholds must be the core's, not re-derived.
+struct FeedEffectsWireTests {
+    /// RGBA of the packed pixel for cube lattice coordinates `(r, g, b)`.
+    private func packedPixel(
+        _ bytes: [UInt8], size: Int, r: Int, g: Int, b: Int
+    ) -> (red: UInt8, green: UInt8, blue: UInt8, alpha: UInt8) {
+        let offset = (g * size * size + b * size + r) * 4
+        return (bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3])
+    }
+
+    /// The wire's own quantization, so expectations share the exact rounding.
+    private func byte(_ value: Float) -> UInt8 {
+        FeedEffectsWire.quantized(value)
+    }
+
+    @Test("Packed LUT grid carries MonitorLUT cube values byte-for-value")
+    func packedLutMatchesCoreCube() throws {
+        let size = 33
+        let bytes = try #require(FeedEffectsWire.bakedLUT(lookOrdinal: 0, size: size))
+        #expect(bytes.count == size * size * size * 4)
+        let cube = MonitorLUT.log3G10Rec709.cube(size: size)
+        for (r, g, b) in [(0, 0, 0), (32, 32, 32), (16, 8, 24), (32, 0, 0), (5, 21, 13)] {
+            let index = (r + g * size + b * size * size) * 3
+            let pixel = packedPixel(bytes, size: size, r: r, g: g, b: b)
+            #expect(pixel.red == byte(cube.rgb[index]))
+            #expect(pixel.green == byte(cube.rgb[index + 1]))
+            #expect(pixel.blue == byte(cube.rgb[index + 2]))
+            #expect(pixel.alpha == 255)
+        }
+    }
+
+    @Test("Mono look bakes achromatic and neutral input maps near-identity greys")
+    func monoLookIsAchromatic() throws {
+        let size = 17
+        let bytes = try #require(FeedEffectsWire.bakedLUT(lookOrdinal: 2, size: size))
+        for (r, g, b) in [(0, 16, 8), (16, 0, 0), (4, 4, 4), (12, 3, 9)] {
+            let pixel = packedPixel(bytes, size: size, r: r, g: g, b: b)
+            #expect(pixel.red == pixel.green)
+            #expect(pixel.green == pixel.blue)
+        }
+        // Neutral axis: Rec.709 luma of an achromatic input is the input itself
+        // (±1 code for float rounding).
+        let mid = packedPixel(bytes, size: size, r: 8, g: 8, b: 8)
+        #expect(abs(Int(mid.red) - Int(byte(8.0 / 16.0))) <= 1)
+    }
+
+    @Test("False-colour grid matches the core cube and paints the documented clip zone")
+    func falseColorCubeMatchesCore() throws {
+        let bytes = try #require(FeedEffectsWire.bakedFalseColor(scaleOrdinal: 1, curveOrdinal: 0))
+        let cube = FalseColorMap.cube(
+            scale: .ire, mapping: ExposureSignalMapping(curve: .redLog3G10))
+        let size = cube.size
+        #expect(bytes.count == size * size * size * 4)
+        for (r, g, b) in [(0, 0, 0), (63, 63, 63), (40, 20, 10), (10, 40, 55)] {
+            let index = (r + g * size + b * size * size) * 3
+            let pixel = packedPixel(bytes, size: size, r: r, g: g, b: b)
+            #expect(pixel.red == byte(cube.rgb[index]))
+            #expect(pixel.green == byte(cube.rgb[index + 1]))
+            #expect(pixel.blue == byte(cube.rgb[index + 2]))
+        }
+        // Encoded 1.0 sits past the clip warning → the documented 99+ IRE red zone.
+        let clip = packedPixel(bytes, size: size, r: 63, g: 63, b: 63)
+        #expect(clip.red == byte(0.78))
+        #expect(clip.green == byte(0.28))
+        #expect(clip.blue == byte(0.18))
+    }
+
+    @Test("Scalars are the core's black/clip anchors and zebra thresholds")
+    func scalarsCarryCoreThresholds() throws {
+        let scalars = try #require(
+            FeedEffectsWire.scalars(curveOrdinal: 0, zebraHighlightIRE: 100, zebraMidtoneIRE: 55))
+        #expect(scalars.count == 4)
+        let mapping = ExposureSignalMapping(curve: .redLog3G10)
+        #expect(scalars[0] == Float(mapping.blackNative / 255))
+        #expect(scalars[1] == Float(mapping.clipNative / 255))
+        // Log3G10's default clip warning is native 180; monitor 100% maps onto it.
+        #expect(scalars[1] == Float(180.0 / 255.0))
+        #expect(scalars[2] == Float(mapping.signalNative(monitorPercent: 100) / 255))
+        #expect(scalars[3] == Float(mapping.signalNative(monitorPercent: 55) / 255))
+        #expect(scalars[2] > scalars[3])
+        #expect(scalars[3] > scalars[0])
+    }
+
+    @Test("Unknown ordinals and unsupported sizes are rejected")
+    func unknownOrdinalsAreRejected() {
+        #expect(FeedEffectsWire.bakedLUT(lookOrdinal: 3, size: 33) == nil)
+        #expect(FeedEffectsWire.bakedLUT(lookOrdinal: 0, size: 65) == nil)
+        #expect(FeedEffectsWire.bakedFalseColor(scaleOrdinal: 2, curveOrdinal: 0) == nil)
+        #expect(FeedEffectsWire.bakedFalseColor(scaleOrdinal: 0, curveOrdinal: 5) == nil)
+        #expect(
+            FeedEffectsWire.scalars(curveOrdinal: 9, zebraHighlightIRE: 100, zebraMidtoneIRE: 55)
+                == nil)
+    }
+}


### PR DESCRIPTION
Part of #73 (Kaneo OPE-30, view-assist half). The Android GPU feed-effects chain — LUT preview, false colour, focus peaking, zebras — with the core as the single source of every curve and cube.

- **Facade bake surface** (`FeedEffectsWire`, Darwin-tested): built-in LUTs (`MonitorLUT`) and false-colour cubes baked by the core into packed-2D RGBA grids; de-log anchors + zebra thresholds as scalars from `ExposureSignalMapping`. Kotlin bakes once per selection, uploads textures, re-derives nothing.
- **One AGSL pass, iOS order of operations**: base look (false colour XOR LUT, trilinear cube sampling matching `CubeLUT.map`) → peaking (two-scale gradient difference on the de-logged source — single-line, defocus-rejecting, LiveDesign accent) → zebra (source-luma threshold, 45° stripes). Peaking/zebra measure the *source*, so grading never changes what reads as in-focus or clipped. API 33+ (AGSL); below, the plain feed renders.
- **Pixel spot-checks** on device: LUT max Δ 1/255 vs core expectation; false-colour zones land on the documented colors (max Δ 3/255 on JPEG chroma); zebra stripes exactly above the clip threshold and not at it; peaking outlines glyph edges, flat areas clean.
- **Perf gate PASS** (SM-A127F, 25fps feed, gfxinfo): all effects simultaneously = 753/753 frames vs baseline, 0% janky, p99 13ms.
- Debug intents (`--es zc.assist lut,falsecolor,peaking,zebra`); 5 Darwin wire tests + 6 JVM tests.

Deferred to the assist-toolbar slice: Limits false-colour scale, camera-driven curve selection, stored `.cube` import, operator-facing controls.

`just check` / `just native-check` (667 tests) / `just android-check` / `just android-core` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
