### PR TITLE
feat(android): complete monitor chrome, DISP, and rotation

### DIFF
--- a/Apps/Android/README.md
+++ b/Apps/Android/README.md
@@ -34,4 +34,14 @@ app falls back to the placeholder monitor ("No camera").
   (logcat tag `SwiftCoreCameraSession`). For a fake-ZR server on the development Mac (scripted
   twin: `Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift`), forward the port with
   `adb reverse tcp:15740 tcp:15740` and use host `127.0.0.1`.
+- **Feed effects (view assists):** `FeedEffectsRenderer` bakes LUT preview, false colour,
+  focus peaking, and zebras into the live feed in one AGSL pass. All colour math is baked in
+  the shared Swift core (`Sources/OpenZCineAndroidFacade/FeedEffectsWire.swift` — cubes from
+  `MonitorLUT`/`FalseColorMap`, thresholds from `ExposureSignalMapping`); Kotlin only uploads
+  textures/uniforms and interpolates. Requires **API 33 (AGSL)** and the staged Swift core —
+  below that the plain feed still renders (minSdk 29) and a warning is logged. Debug-only
+  activation until the assist toolbar lands:
+  `adb shell am start -n com.opencapture.openzcine/.MainActivity --ez zc.demo.feed true
+  --es zc.assist lut,peaking,zebra --es zc.lut log3g10` (`zc.assist` also takes `falsecolor`,
+  with `--es zc.fc.scale stops|ire`; false colour replaces the LUT, like iOS).
 - **Local SDK:** put `sdk.dir=<your Android SDK path>` in `Apps/Android/local.properties` (gitignored).

--- a/Apps/Android/README.md
+++ b/Apps/Android/README.md
@@ -34,4 +34,10 @@ app falls back to the placeholder monitor ("No camera").
   (logcat tag `SwiftCoreCameraSession`). For a fake-ZR server on the development Mac (scripted
   twin: `Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift`), forward the port with
   `adb reverse tcp:15740 tcp:15740` and use host `127.0.0.1`.
+- **Liquid-glass chrome:** monitor chrome glass is a custom GPU treatment (`GlassChrome.kt`) —
+  one shared blurred backdrop texture per feed frame, sampled by every pill (AGSL edge refraction
+  on API 33+, plain pre-blurred fill on 31–32, the hand-rolled flat fill below). A frame-budget
+  counter auto-degrades one tier under sustained overruns. Debug override:
+  `adb shell am start -n com.opencapture.openzcine/.MainActivity --es zc.glass.tier blur`
+  (`full`/`blur`/`flat`; lowers only).
 - **Local SDK:** put `sdk.dir=<your Android SDK path>` in `Apps/Android/local.properties` (gitignored).

--- a/Apps/Android/README.md
+++ b/Apps/Android/README.md
@@ -4,7 +4,7 @@ Production Jetpack Compose shell. The landscape monitor screen is a 1:1 port of 
 shell's chrome, laid out by the shared core's zone map (`SwiftCore.monitorZoneMap` →
 `MonitorZoneLayout.map`) — no layout math lives in Kotlin. v1 covers the live feed, top
 info deck, capture readout strip, lock/battery band, and the record/DISP/media/settings
-rail with DISP 1↔2 cycling; assists, scopes, pickers, and portrait land later. Readouts
+rail with DISP 1↔2 cycling; assists, pickers, and portrait land later. Readouts
 are fake demo values until the session facade arrives. Without the staged Swift core the
 app falls back to the placeholder monitor ("No camera").
 
@@ -34,4 +34,12 @@ app falls back to the placeholder monitor ("No camera").
   (logcat tag `SwiftCoreCameraSession`). For a fake-ZR server on the development Mac (scripted
   twin: `Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift`), forward the port with
   `adb reverse tcp:15740 tcp:15740` and use host `127.0.0.1`.
+- **Scopes v1:** waveform, RGB parade, histogram, and vectorscope render at ~10 Hz from the
+  live feed. All axis/curve math lives in the shared core behind the facade
+  (`Sources/OpenZCineAndroidFacade/ScopeFrameWire.swift` ↔ `bridge/ScopeWire.kt`): the 3-anchor
+  display axis (log-black floor → 5% crush line, fixed per-curve mid grey, clip warning → 95%
+  line) and the tone-mapped vectorscope come back as flat payloads; Kotlin only reduces the
+  JPEG (1/2ⁿ decode to ≤160 px wide) and draws (`ScopeView.kt`). Debug toggle until the scope
+  picker chrome lands:
+  `adb shell am start -n com.opencapture.openzcine/.MainActivity --ez zc.demo.feed true --es zc.scopes wave|parade|histo|vector`.
 - **Local SDK:** put `sdk.dir=<your Android SDK path>` in `Apps/Android/local.properties` (gitignored).

--- a/Apps/Android/README.md
+++ b/Apps/Android/README.md
@@ -1,12 +1,15 @@
 # OpenZCine Android
 
-Production Jetpack Compose shell. The landscape monitor screen is a 1:1 port of the iOS
-shell's chrome, laid out by the shared core's zone map (`SwiftCore.monitorZoneMap` →
-`MonitorZoneLayout.map`) — no layout math lives in Kotlin. v1 covers the live feed, top
-info deck, capture readout strip, lock/battery band, and the record/DISP/media/settings
-rail with DISP 1↔2 cycling; assists, pickers, and portrait land later. Readouts
-are fake demo values until the session facade arrives. Without the staged Swift core the
-app falls back to the placeholder monitor ("No camera").
+Production Jetpack Compose shell. The monitor screen is a 1:1 port of the iOS shell's
+chrome, laid out by the shared core's zone map (`SwiftCore.monitorZoneMap` →
+`MonitorZoneLayout.map`) in both orientations — no layout math lives in Kotlin. It covers
+the live feed, top info deck, capture readout strip, the assist toolbar (wired to the
+feed-effects engine + scope panels, toggles persisted), lock/battery band, the
+record/DISP/media/settings controls with DISP 1→2→3 cycling (3 = the command dashboard),
+and the portrait fit layout (sensor rotation; the activity survives it). Deferred:
+pickers/panels, the portrait fill aspect, command tile interaction. Readouts are fake demo
+values until the session facade arrives. Without the staged Swift core the app falls back
+to the placeholder monitor ("No camera").
 
 - **Build:** `just android-build` from the repo root (or `just android-check` for build + tests + lint).
 - **Swift core:** the camera brain is the shared Swift core (`Sources/OpenZCineCore`), cross-compiled
@@ -45,16 +48,18 @@ app falls back to the placeholder monitor ("No camera").
   (`Sources/OpenZCineAndroidFacade/ScopeFrameWire.swift` ↔ `bridge/ScopeWire.kt`): the 3-anchor
   display axis (log-black floor → 5% crush line, fixed per-curve mid grey, clip warning → 95%
   line) and the tone-mapped vectorscope come back as flat payloads; Kotlin only reduces the
-  JPEG (1/2ⁿ decode to ≤160 px wide) and draws (`ScopeView.kt`). Debug toggle until the scope
-  picker chrome lands:
+  JPEG (1/2ⁿ decode to ≤160 px wide) and draws (`ScopeView.kt`). The assist toolbar owns the
+  scope toggle; the debug intent still seeds it for tests:
   `adb shell am start -n com.opencapture.openzcine/.MainActivity --ez zc.demo.feed true --es zc.scopes wave|parade|histo|vector`.
 - **Feed effects (view assists):** `FeedEffectsRenderer` bakes LUT preview, false colour,
   focus peaking, and zebras into the live feed in one AGSL pass. All colour math is baked in
   the shared Swift core (`Sources/OpenZCineAndroidFacade/FeedEffectsWire.swift` — cubes from
   `MonitorLUT`/`FalseColorMap`, thresholds from `ExposureSignalMapping`); Kotlin only uploads
   textures/uniforms and interpolates. Requires **API 33 (AGSL)** and the staged Swift core —
-  below that the plain feed still renders (minSdk 29) and a warning is logged. Debug-only
-  activation until the assist toolbar lands:
+  below that the plain feed still renders (minSdk 29) and a warning is logged. The assist
+  toolbar (`AssistToolbar.kt`) is the operator switch — LUT/PEAK/FALSE/ZEBRA plus the four
+  scope pills, toggles persisted in SharedPreferences. The debug intent still seeds an exact
+  session state for tests (intent beats persistence):
   `adb shell am start -n com.opencapture.openzcine/.MainActivity --ez zc.demo.feed true
   --es zc.assist lut,peaking,zebra --es zc.lut log3g10` (`zc.assist` also takes `falsecolor`,
   with `--es zc.fc.scale stops|ire`; false colour replaces the LUT, like iOS).

--- a/Apps/Android/app/src/debug/kotlin/com/opencapture/openzcine/DemoHarness.kt
+++ b/Apps/Android/app/src/debug/kotlin/com/opencapture/openzcine/DemoHarness.kt
@@ -22,6 +22,17 @@ object DemoHarness {
     /** Boolean intent extra that switches the synthetic demo feed on. */
     const val EXTRA_DEMO_FEED = "zc.demo.feed"
 
+    /** String intent extra forcing a glass tier (`full`/`blur`/`flat`) for testing. */
+    const val EXTRA_GLASS_TIER = "zc.glass.tier"
+
+    /**
+     * Glass-tier override: `--es zc.glass.tier blur` (or `flat`/`full`) pins
+     * the chrome glass to that tier so each fallback can be exercised on one
+     * device. Null (the default, and always in release) lets [resolveTier]
+     * pick the platform ceiling. The override can only lower the tier.
+     */
+    fun glassTierOverride(intent: Intent): String? = intent.getStringExtra(EXTRA_GLASS_TIER)
+
     /**
      * A demo session + synthetic 25 fps frame source when [intent] carries
      * [EXTRA_DEMO_FEED]; null in a normal launch. Also the debug intent entry

--- a/Apps/Android/app/src/debug/kotlin/com/opencapture/openzcine/DemoHarness.kt
+++ b/Apps/Android/app/src/debug/kotlin/com/opencapture/openzcine/DemoHarness.kt
@@ -22,6 +22,19 @@ object DemoHarness {
     /** Boolean intent extra that switches the synthetic demo feed on. */
     const val EXTRA_DEMO_FEED = "zc.demo.feed"
 
+    /** String intent extra selecting a scope: `wave|parade|histo|vector`. */
+    const val EXTRA_SCOPES = "zc.scopes"
+
+    /**
+     * The scope selected by the debug intent, or null. Activate with e.g.
+     * ```
+     * adb shell am start -n com.opencapture.openzcine/.MainActivity \
+     *   --ez zc.demo.feed true --es zc.scopes wave
+     * ```
+     */
+    fun scopeKind(intent: Intent): ScopeKind? =
+        ScopeKind.fromToken(intent.getStringExtra(EXTRA_SCOPES))
+
     /**
      * A demo session + synthetic 25 fps frame source when [intent] carries
      * [EXTRA_DEMO_FEED]; null in a normal launch. Also the debug intent entry

--- a/Apps/Android/app/src/debug/kotlin/com/opencapture/openzcine/DemoHarness.kt
+++ b/Apps/Android/app/src/debug/kotlin/com/opencapture/openzcine/DemoHarness.kt
@@ -17,6 +17,13 @@ import com.opencapture.openzcine.core.LiveFrameSource
  * ```
  * adb shell am start -n com.opencapture.openzcine/.MainActivity --ez zc.demo.feed true
  * ```
+ *
+ * Feed effects (needs API 33 + the staged Swift core; combine freely):
+ * ```
+ * --es zc.assist lut,falsecolor,peaking,zebra   which effects are on
+ * --es zc.lut log3g10|nlog|mono                 built-in look (default log3g10)
+ * --es zc.fc.scale stops|ire                    false-colour scale (default stops)
+ * ```
  */
 object DemoHarness {
     /** Boolean intent extra that switches the synthetic demo feed on. */
@@ -27,10 +34,17 @@ object DemoHarness {
      * [EXTRA_DEMO_FEED]; null in a normal launch. Also the debug intent entry
      * point for the Swift-core session probe (`zc.session.host` — see
      * [SwiftCoreSessionProbe]), which runs as a logcat side effect without
-     * replacing the shell's session.
+     * replacing the shell's session, and for the feed-effect flags
+     * (`zc.assist` — applied to whichever feed renders, demo or live).
      */
     fun demoLiveFeed(intent: Intent): Pair<CameraSession, LiveFrameSource>? {
         SwiftCoreSessionProbe.maybeStart(intent)
+        FeedEffectsState.current =
+            FeedEffects.parse(
+                intent.getStringExtra("zc.assist"),
+                intent.getStringExtra("zc.lut"),
+                intent.getStringExtra("zc.fc.scale"),
+            )
         if (!intent.getBooleanExtra(EXTRA_DEMO_FEED, false)) return null
         val session =
             FakeCameraSession(

--- a/Apps/Android/app/src/main/AndroidManifest.xml
+++ b/Apps/Android/app/src/main/AndroidManifest.xml
@@ -8,10 +8,17 @@
         android:label="OpenZCine"
         android:supportsRtl="true"
         android:theme="@android:style/Theme.Material.NoActionBar.Fullscreen">
+        <!-- Sensor-based portrait + landscape (iOS allows Portrait + LandscapeRight;
+          "user" is the closest platform posture: it follows the rotation lock).
+          configChanges keeps the activity (camera session, live feed, glass
+          pipeline) alive across rotation; the zone map recomputes in compose.
+          ponytail: reverse-landscape also rotates here (Android convention);
+          pinning to one landscape would need a manual OrientationEventListener. -->
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:screenOrientation="landscape">
+            android:screenOrientation="user"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/AssistToolbar.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/AssistToolbar.kt
@@ -1,0 +1,420 @@
+package com.opencapture.openzcine
+
+import android.content.Context
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * The eight v1 assist-toolbar tools, mirroring the iOS bottom-left strip
+ * (`MonitorAssistTool` in the shared core): four feed effects and four scopes.
+ * The iOS-only framing aids (guides/grid/crosshair/level/de-sq) and audio
+ * meters land with their engines.
+ */
+enum class AssistTool(val label: String) {
+    LUT("LUT"),
+    PEAK("PEAK"),
+    FALSE("FALSE"),
+    ZEBRA("ZEBRA"),
+    WAVE("WAVE"),
+    PARADE("PARADE"),
+    HISTO("HISTO"),
+    VECTOR("VECTOR"),
+}
+
+/**
+ * Assist toggle state behind the toolbar: the feed-effect set (LUT / false
+ * colour / peaking / zebra, baked by [FeedEffectsRenderer]) and the active
+ * scope panel. Every change is mirrored into [FeedEffectsState.current] (the
+ * engine input `LiveFeedView` reads) and handed to [persist].
+ *
+ * Debug intents still win a session: when the launch intent carried any
+ * `zc.assist`/`zc.scopes` selection, [restore] seeds from it verbatim instead
+ * of the persisted toggles, keeping the intent-driven tests deterministic.
+ */
+class AssistState(
+    initialEffects: FeedEffects,
+    initialScope: ScopeKind?,
+    private val persist: (FeedEffects, ScopeKind?) -> Unit = { _, _ -> },
+) {
+    var effects: FeedEffects by mutableStateOf(initialEffects)
+        private set
+
+    var scope: ScopeKind? by mutableStateOf(initialScope)
+        private set
+
+    init {
+        FeedEffectsState.current = initialEffects
+    }
+
+    /** Whether [tool]'s pill renders lit. */
+    fun isOn(tool: AssistTool): Boolean =
+        when (tool) {
+            AssistTool.LUT -> effects.lut != null
+            AssistTool.PEAK -> effects.peaking
+            AssistTool.FALSE -> effects.falseColor != null
+            AssistTool.ZEBRA -> effects.zebra
+            AssistTool.WAVE -> scope == ScopeKind.WAVEFORM
+            AssistTool.PARADE -> scope == ScopeKind.PARADE
+            AssistTool.HISTO -> scope == ScopeKind.HISTOGRAM
+            AssistTool.VECTOR -> scope == ScopeKind.VECTORSCOPE
+        }
+
+    /**
+     * Toggles [tool]. LUT and false colour are mutually exclusive (false
+     * colour *is* the monitoring image, iOS semantics); scopes are
+     * single-active in v1 — tapping another scope switches to it.
+     */
+    // ponytail: no LUT-restore memory when false colour turns off, and one
+    // scope at a time; multi-scope + remembered looks arrive with the iOS
+    // preference model.
+    fun toggle(tool: AssistTool) {
+        when (tool) {
+            AssistTool.LUT ->
+                update(
+                    effects.copy(
+                        lut = if (effects.lut == null) FeedLut.LOG3G10_709 else null,
+                        falseColor = null,
+                    ),
+                )
+            AssistTool.FALSE ->
+                update(
+                    effects.copy(
+                        falseColor =
+                            if (effects.falseColor == null) FeedFalseColorScale.STOPS else null,
+                        lut = null,
+                    ),
+                )
+            AssistTool.PEAK -> update(effects.copy(peaking = !effects.peaking))
+            AssistTool.ZEBRA -> update(effects.copy(zebra = !effects.zebra))
+            AssistTool.WAVE -> toggleScope(ScopeKind.WAVEFORM)
+            AssistTool.PARADE -> toggleScope(ScopeKind.PARADE)
+            AssistTool.HISTO -> toggleScope(ScopeKind.HISTOGRAM)
+            AssistTool.VECTOR -> toggleScope(ScopeKind.VECTORSCOPE)
+        }
+    }
+
+    private fun toggleScope(kind: ScopeKind) {
+        scope = if (scope == kind) null else kind
+        persist(effects, scope)
+    }
+
+    private fun update(next: FeedEffects) {
+        effects = next
+        FeedEffectsState.current = next
+        persist(effects, scope)
+    }
+
+    companion object {
+        private const val PREFS = "assist"
+
+        /** Serializes [effects] back into the `zc.assist` token grammar. */
+        fun tokens(effects: FeedEffects): String =
+            listOfNotNull(
+                "lut".takeIf { effects.lut != null },
+                "falsecolor".takeIf { effects.falseColor != null },
+                "peaking".takeIf { effects.peaking },
+                "zebra".takeIf { effects.zebra },
+            ).joinToString(",")
+
+        /**
+         * Restores the persisted toggles from SharedPreferences — unless the
+         * launch intent specified a selection ([intentEffects] non-identity or
+         * [intentScope] non-null), which then IS the session state.
+         */
+        fun restore(context: Context, intentEffects: FeedEffects, intentScope: ScopeKind?): AssistState {
+            val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+            val fromIntent = !intentEffects.isIdentity || intentScope != null
+            val effects =
+                if (fromIntent) {
+                    intentEffects
+                } else {
+                    FeedEffects.parse(
+                        prefs.getString("tokens", null),
+                        prefs.getString("lut", null),
+                        prefs.getString("fcScale", null),
+                    )
+                }
+            val scope =
+                if (fromIntent) intentScope else ScopeKind.fromToken(prefs.getString("scope", null))
+            return AssistState(effects, scope) { nextEffects, nextScope ->
+                prefs.edit()
+                    .putString("tokens", tokens(nextEffects))
+                    .putString("lut", nextEffects.lut?.id)
+                    .putString("fcScale", nextEffects.falseColor?.id)
+                    .putString("scope", nextScope?.token)
+                    .apply()
+            }
+        }
+    }
+}
+
+/**
+ * The bottom assist toolbar (iOS `MonitorAssistStrip`, `axis: .horizontal`):
+ * a glass pill holding a horizontal scroller of tool cells, grouped into
+ * threes by hairline dividers, with gold edge chevrons + fades hinting at
+ * off-screen tools. Mounted at the zone map's `assistStrip` zone in landscape
+ * live mode and the portrait fit-mode toolbar band.
+ */
+@Composable
+fun AssistToolbar(state: AssistState, modifier: Modifier = Modifier) {
+    val scroll = rememberScrollState()
+    val leadingFade = scroll.canScrollBackward
+    val trailingFade = scroll.canScrollForward
+    Box(modifier.glass(ChromeShape)) {
+        Row(
+            Modifier
+                .fillMaxHeight()
+                .padding(start = 7.dp, end = 14.dp)
+                .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
+                .drawWithContent {
+                    drawContent()
+                    // Edge fades (iOS ScrollEdgeFades.gradient): scrolled-under
+                    // tools dissolve at the active edge.
+                    val fade = size.width * 0.09f
+                    if (leadingFade) {
+                        drawRect(
+                            Brush.horizontalGradient(
+                                0f to Color.Transparent, 1f to Color.Black, endX = fade,
+                            ),
+                            size = Size(fade, size.height),
+                            blendMode = BlendMode.DstIn,
+                        )
+                    }
+                    if (trailingFade) {
+                        drawRect(
+                            Brush.horizontalGradient(
+                                0f to Color.Black, 1f to Color.Transparent,
+                                startX = size.width - fade, endX = size.width,
+                            ),
+                            topLeft = Offset(size.width - fade, 0f),
+                            size = Size(fade, size.height),
+                            blendMode = BlendMode.DstIn,
+                        )
+                    }
+                }
+                .horizontalScroll(scroll),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            AssistTool.entries.forEachIndexed { index, tool ->
+                if (index > 0 && index % 3 == 0) {
+                    Box(
+                        Modifier.padding(horizontal = 4.dp)
+                            .size(width = 1.dp, height = 28.dp)
+                            .background(LiveDesign.hairlineStrong),
+                    )
+                }
+                AssistToolCell(tool, state.isOn(tool)) { state.toggle(tool) }
+            }
+        }
+        ScrollChevron(leading = true, visible = leadingFade, Modifier.align(Alignment.CenterStart))
+        ScrollChevron(leading = false, visible = trailingFade, Modifier.align(Alignment.CenterEnd))
+    }
+}
+
+/** Gold edge chevron hinting at off-screen tools (iOS `scrollChevron`). */
+@Composable
+private fun ScrollChevron(leading: Boolean, visible: Boolean, modifier: Modifier = Modifier) {
+    Canvas(
+        modifier
+            .padding(horizontal = 5.dp)
+            .size(8.dp, 12.dp)
+            .alpha(if (visible) 1f else 0f),
+    ) {
+        val path =
+            Path().apply {
+                if (leading) {
+                    moveTo(size.width, 0f)
+                    lineTo(0f, size.height / 2)
+                    lineTo(size.width, size.height)
+                } else {
+                    moveTo(0f, 0f)
+                    lineTo(size.width, size.height / 2)
+                    lineTo(0f, size.height)
+                }
+            }
+        drawPath(
+            path,
+            LiveDesign.accent,
+            style = Stroke(2.dp.toPx(), cap = StrokeCap.Round, join = StrokeJoin.Round),
+        )
+    }
+}
+
+/**
+ * One tool pill: glyph over a mono label, gold-on-dim-accent while on (iOS
+ * `AssistToolButton`, the mockup `.tool` box model with its 52pt floor).
+ */
+@Composable
+private fun AssistToolCell(tool: AssistTool, isOn: Boolean, onClick: () -> Unit) {
+    val tint = if (isOn) LiveDesign.accent else LiveDesign.muted
+    Column(
+        modifier =
+            Modifier
+                .background(if (isOn) LiveDesign.accentDim else Color.Transparent, ChromeShape)
+                .chromeClickable(onClick)
+                .padding(vertical = 5.dp, horizontal = 8.dp)
+                .widthIn(min = 36.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Box(Modifier.height(23.dp), contentAlignment = Alignment.Center) {
+            AssistToolGlyph(tool, tint, Modifier.size(19.dp))
+        }
+        Text(
+            tool.label,
+            style = chromeStyle(9f, FontWeight.Medium, mono = true),
+            color = tint,
+            maxLines = 1,
+        )
+    }
+}
+
+/** Canvas stand-ins for the iOS SF Symbol per tool (`MonitorAssistTool.icon`). */
+@Composable
+private fun AssistToolGlyph(tool: AssistTool, tint: Color, modifier: Modifier = Modifier) {
+    Canvas(modifier) {
+        val stroke = Stroke(1.6.dp.toPx(), cap = StrokeCap.Round, join = StrokeJoin.Round)
+        when (tool) {
+            // SF `camera.filters`: three overlapping circles.
+            AssistTool.LUT -> {
+                val r = size.minDimension * 0.28f
+                drawCircle(tint, r, Offset(size.width / 2, r), style = stroke)
+                drawCircle(tint, r, Offset(r, size.height - r), style = stroke)
+                drawCircle(tint, r, Offset(size.width - r, size.height - r), style = stroke)
+            }
+            // SF `mountain.2`: two peaks.
+            AssistTool.PEAK -> {
+                val base = size.height * 0.85f
+                val path =
+                    Path().apply {
+                        moveTo(0f, base)
+                        lineTo(size.width * 0.32f, size.height * 0.25f)
+                        lineTo(size.width * 0.52f, base * 0.72f)
+                        lineTo(size.width * 0.70f, size.height * 0.42f)
+                        lineTo(size.width, base)
+                    }
+                drawPath(path, tint, style = stroke)
+            }
+            // SF `circle.lefthalf.filled`.
+            AssistTool.FALSE -> {
+                val r = size.minDimension / 2 - 1.dp.toPx()
+                val c = Offset(size.width / 2, size.height / 2)
+                drawCircle(tint, r, c, style = stroke)
+                drawArc(
+                    tint,
+                    startAngle = 90f,
+                    sweepAngle = 180f,
+                    useCenter = true,
+                    topLeft = Offset(c.x - r, c.y - r),
+                    size = Size(2 * r, 2 * r),
+                )
+            }
+            // Three diagonal stripes (iOS `ZebraStripesShape`).
+            AssistTool.ZEBRA -> {
+                val diag = 0.7071f
+                val halfLen = size.minDimension * 0.40f / 2
+                val step = size.minDimension * 0.27f
+                for (index in 0 until 3) {
+                    val offset = index - 1f
+                    val cx = size.width / 2 + offset * step * diag
+                    val cy = size.height / 2 + offset * step * diag
+                    drawLine(
+                        tint,
+                        Offset(cx - halfLen * 2 * diag, cy + halfLen * 2 * diag),
+                        Offset(cx + halfLen * 2 * diag, cy - halfLen * 2 * diag),
+                        strokeWidth = 2.dp.toPx(),
+                        cap = StrokeCap.Round,
+                    )
+                }
+            }
+            // SF `waveform.path`: one luma trace line.
+            AssistTool.WAVE -> {
+                val midY = size.height / 2
+                val path =
+                    Path().apply {
+                        moveTo(0f, midY)
+                        lineTo(size.width * 0.2f, midY - size.height * 0.32f)
+                        lineTo(size.width * 0.4f, midY + size.height * 0.28f)
+                        lineTo(size.width * 0.6f, midY - size.height * 0.18f)
+                        lineTo(size.width * 0.8f, midY + size.height * 0.34f)
+                        lineTo(size.width, midY)
+                    }
+                drawPath(path, tint, style = stroke)
+            }
+            // SF `chart.bar.xaxis`: bars on a baseline.
+            AssistTool.PARADE -> {
+                val base = size.height * 0.82f
+                drawLine(tint, Offset(0f, base), Offset(size.width, base), 1.6.dp.toPx())
+                val barW = size.width * 0.17f
+                for ((index, heightScale) in listOf(0.45f, 0.75f, 0.6f).withIndex()) {
+                    drawRoundRect(
+                        tint,
+                        topLeft =
+                            Offset(size.width * (0.1f + 0.3f * index), base - base * heightScale),
+                        size = Size(barW, base * heightScale),
+                        cornerRadius = CornerRadius(barW * 0.3f),
+                    )
+                }
+            }
+            // SF `waveform`: symmetric level bars.
+            AssistTool.HISTO -> {
+                val midY = size.height / 2
+                for ((index, heightScale) in
+                    listOf(0.25f, 0.55f, 0.9f, 0.45f, 0.7f, 0.3f).withIndex()) {
+                    val x = size.width * (0.08f + 0.168f * index)
+                    drawLine(
+                        tint,
+                        Offset(x, midY - size.height * heightScale / 2),
+                        Offset(x, midY + size.height * heightScale / 2),
+                        strokeWidth = 1.8.dp.toPx(),
+                        cap = StrokeCap.Round,
+                    )
+                }
+            }
+            // SF `circle.grid.cross`: graticule circle + cross.
+            AssistTool.VECTOR -> {
+                val r = size.minDimension / 2 - 1.dp.toPx()
+                val c = Offset(size.width / 2, size.height / 2)
+                drawCircle(tint, r, c, style = stroke)
+                val gap = r * 0.4f
+                drawLine(tint, Offset(c.x, c.y - r), Offset(c.x, c.y - gap), 1.6.dp.toPx())
+                drawLine(tint, Offset(c.x, c.y + gap), Offset(c.x, c.y + r), 1.6.dp.toPx())
+                drawLine(tint, Offset(c.x - r, c.y), Offset(c.x - gap, c.y), 1.6.dp.toPx())
+                drawLine(tint, Offset(c.x + gap, c.y), Offset(c.x + r, c.y), 1.6.dp.toPx())
+            }
+        }
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/CommandMonitor.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/CommandMonitor.kt
@@ -1,0 +1,156 @@
+package com.opencapture.openzcine
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * The DISP 3 command dashboard (iOS `CommandMonitor`, ios/Runner/
+ * MonitorPanels.swift): record chip + hero timecode, the health strip, and
+ * the primary control-tile grid. The feed is unmounted in this mode — the
+ * dashboard fills the deck span between the side rails (landscape) or the
+ * controls-grid zone (portrait, timecode band + grid split by the caller).
+ *
+ * v1 renders read-only tiles from the demo session state; tap-to-open pickers
+ * and long-press-drag reorder arrive with the picker chrome. The iOS
+ * Image/Focus/Audio side column is deferred with them.
+ */
+@Composable
+fun CommandDashboard(recording: Boolean, frameCount: Long, modifier: Modifier = Modifier) {
+    Column(modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(11.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            RecordChip(recording)
+            CommandTimecode(frameCount, sizeSp = 44f)
+        }
+        CommandHealthStrip()
+        CommandGrid(Modifier.fillMaxWidth().weight(1f))
+    }
+}
+
+/** Hero timecode with the accent frame field (iOS `CommandTimecodeReadout`). */
+@Composable
+fun CommandTimecode(frameCount: Long, sizeSp: Float, modifier: Modifier = Modifier) {
+    Text(
+        timecodeAnnotated(frameCount, DemoMonitorState.FRAME_RATE),
+        style = chromeStyle(sizeSp, FontWeight.Normal, mono = true),
+        maxLines = 1,
+        modifier = modifier,
+    )
+}
+
+/** Temp / Storage / Camera / Lens blocks + the FPS chip (iOS `CommandHealthStrip`). */
+@Composable
+private fun CommandHealthStrip() {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .background(LiveDesign.surface, ChromeShape)
+            .border(1.dp, LiveDesign.hairline, ChromeShape)
+            .padding(horizontal = 10.dp, vertical = 6.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CommandStatusBlock("Temp", "OK · 41°C", valueColor = LiveDesign.good)
+        CommandStatusBlock("Storage", DemoMonitorState.MEDIA)
+        CommandStatusBlock("Camera", "NIKON ZR")
+        CommandStatusBlock("Lens", "NIKKOR Z 24-70")
+        Box(Modifier.weight(1f))
+        FpsChip(DemoMonitorState.SIGNAL_BARS, DemoMonitorState.FPS)
+    }
+}
+
+@Composable
+private fun CommandStatusBlock(label: String, value: String, valueColor: androidx.compose.ui.graphics.Color = LiveDesign.text) {
+    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        Text(label.uppercase(), style = chromeStyle(8.5f, FontWeight.Bold), color = LiveDesign.faint)
+        Text(
+            value,
+            style = chromeStyle(12f, FontWeight.Medium, mono = true),
+            color = valueColor,
+            maxLines = 1,
+        )
+    }
+}
+
+/** Title/value pairs for the eight primary tiles, from the demo session state. */
+private fun commandTiles(): List<Pair<String, String>> {
+    fun demoValue(label: String): String =
+        DemoMonitorState.VALUES.firstOrNull { it.first == label }?.second ?: "—"
+    return listOf(
+        "Mode" to "M",
+        "ISO" to demoValue("ISO"),
+        "Shutter" to demoValue("SHUTTER"),
+        "Iris" to demoValue("IRIS"),
+        "White Bal" to demoValue("WB"),
+        "Resolution Framerate" to DemoMonitorState.RESOLUTION,
+        "Codec" to DemoMonitorState.CODEC,
+        "VR / e-VR" to "—",
+    )
+}
+
+/**
+ * The 3-column primary tile grid (iOS `CommandPrimaryGrid`). Shared by the
+ * landscape DISP 3 dashboard and the portrait fit-mode/command controls zone.
+ * Rows split the available height evenly, floored at 44dp.
+ */
+@Composable
+fun CommandGrid(modifier: Modifier = Modifier) {
+    val tiles = commandTiles()
+    val columns = 3
+    val spacing = 9.dp
+    val rows = (tiles.size + columns - 1) / columns
+    BoxWithConstraints(modifier) {
+        val rowHeight = maxOf(44.dp, (maxHeight - spacing * (rows - 1)) / rows)
+        Column(verticalArrangement = Arrangement.spacedBy(spacing)) {
+            tiles.chunked(columns).forEach { row ->
+                Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
+                    row.forEach { (title, value) ->
+                        CommandTile(title, value, Modifier.weight(1f).height(rowHeight))
+                    }
+                    repeat(columns - row.size) { Box(Modifier.weight(1f)) }
+                }
+            }
+        }
+    }
+}
+
+/** One read-only control tile (iOS `CommandTile`). */
+@Composable
+private fun CommandTile(title: String, value: String, modifier: Modifier = Modifier) {
+    Column(
+        modifier
+            .background(LiveDesign.surface, ChromeShape)
+            .border(1.dp, LiveDesign.hairline, ChromeShape)
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            title.uppercase(),
+            style = chromeStyle(10f, FontWeight.Bold),
+            color = LiveDesign.faint,
+            maxLines = 1,
+        )
+        Text(
+            value,
+            style = chromeStyle(24f, FontWeight.Medium, mono = true),
+            color = LiveDesign.text,
+            maxLines = 1,
+        )
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/FeedEffects.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/FeedEffects.kt
@@ -1,0 +1,83 @@
+package com.opencapture.openzcine
+
+/**
+ * Built-in monitor looks. [wireOrdinal] mirrors `FeedEffectsWire.look` in the
+ * Swift facade — the core generates each look's cube, Kotlin only uploads it.
+ */
+enum class FeedLut(val id: String, val wireOrdinal: Int) {
+    LOG3G10_709("log3g10", 0),
+    NLOG_709("nlog", 1),
+    MONO("mono", 2);
+
+    companion object {
+        fun fromId(id: String): FeedLut? = entries.firstOrNull { it.id == id }
+    }
+}
+
+/** False-colour scales. [wireOrdinal] mirrors `FeedEffectsWire.bakedFalseColor`. */
+enum class FeedFalseColorScale(val id: String, val wireOrdinal: Int) {
+    STOPS("stops", 0),
+    IRE("ire", 1);
+
+    companion object {
+        fun fromId(id: String): FeedFalseColorScale? = entries.firstOrNull { it.id == id }
+    }
+}
+
+/**
+ * Which analysis effects the live feed bakes in, mirroring the iOS shell's
+ * `LiveImageEffects`. False colour and the LUT are mutually exclusive — false
+ * colour *is* the monitoring image, so it replaces the creative look.
+ *
+ * Until the assist toolbar lands this is driven by debug intent extras only
+ * (see `DemoHarness`): `--es zc.assist lut,falsecolor,peaking,zebra`
+ * plus `--es zc.lut <log3g10|nlog|mono>` and `--es zc.fc.scale <stops|ire>`.
+ */
+data class FeedEffects(
+    val lut: FeedLut? = null,
+    val falseColor: FeedFalseColorScale? = null,
+    val peaking: Boolean = false,
+    val zebra: Boolean = false,
+) {
+    /** True when the feed renders untouched — the renderer skips the GPU chain. */
+    val isIdentity: Boolean
+        get() = lut == null && falseColor == null && !peaking && !zebra
+
+    companion object {
+        val NONE = FeedEffects()
+
+        /**
+         * Parses the debug intent extras. [assist] is a comma-separated token
+         * list (`lut`, `falsecolor`, `peaking`, `zebra`; unknown tokens are
+         * ignored); [lutId]/[falseColorScaleId] select variants, falling back
+         * to the iOS defaults (Log3G10→709, Stops) when absent or unknown.
+         */
+        fun parse(assist: String?, lutId: String?, falseColorScaleId: String?): FeedEffects {
+            val tokens =
+                assist.orEmpty()
+                    .split(',')
+                    .map { it.trim().lowercase() }
+                    .filter { it.isNotEmpty() }
+                    .toSet()
+            val falseColor =
+                if ("falsecolor" in tokens) {
+                    falseColorScaleId?.let(FeedFalseColorScale::fromId)
+                        ?: FeedFalseColorScale.STOPS
+                } else {
+                    null
+                }
+            return FeedEffects(
+                // False colour replaces the creative look, like iOS.
+                lut =
+                    if (falseColor == null && "lut" in tokens) {
+                        lutId?.let(FeedLut::fromId) ?: FeedLut.LOG3G10_709
+                    } else {
+                        null
+                    },
+                falseColor = falseColor,
+                peaking = "peaking" in tokens,
+                zebra = "zebra" in tokens,
+            )
+        }
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/FeedEffectsRenderer.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/FeedEffectsRenderer.kt
@@ -1,0 +1,275 @@
+package com.opencapture.openzcine
+
+import android.graphics.Bitmap
+import android.graphics.BitmapShader
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.RuntimeShader
+import android.graphics.Shader
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.opencapture.openzcine.bridge.SwiftCore
+import java.nio.ByteBuffer
+
+private const val TAG = "ZCFeedEffects"
+
+/**
+ * Effects [LiveFeedView] applies by default. Debug-intent driven (see
+ * `DemoHarness`) until the assist toolbar owns it; release builds never set it.
+ */
+object FeedEffectsState {
+    var current: FeedEffects by mutableStateOf(FeedEffects.NONE)
+}
+
+/**
+ * GPU effect chain for the live feed — one AGSL pass over the decoded frame,
+ * mirroring the iOS `LiveFrameProcessor` order of operations:
+ *
+ * 1. **Base look**: false colour (which replaces the creative grade) or the
+ *    selected LUT, as a 3D-LUT sample of the encoded source pixel. The cube is
+ *    baked by the Swift core and uploaded once as a packed-2D texture
+ *    (`width = size²`, `height = size`; slice tiles along x). The shader takes
+ *    two bilinear taps on adjacent blue slices and mixes — trilinear, the same
+ *    interpolation `CIColorCube`/`CubeLUT.map` perform.
+ * 2. **Focus peaking**, measured from the *source* frame: the de-logged grey
+ *    (the core's black→clip stretch, uniforms from `feedEffectsScalars`) runs a
+ *    two-scale gradient difference — first-derivative magnitude peaks ON the
+ *    edge (single line), and subtracting the coarse-scale gradient cancels
+ *    defocused background edges. Overlay colour is `LiveDesign.accent`.
+ * 3. **Zebra**, also measured from the source frame: Rec.709 luma against the
+ *    core-supplied highlight threshold and midtone band, drawn as diagonal
+ *    stripes over the graded image.
+ *
+ * All colour math lives in the Swift core; this class uploads baked payloads
+ * and interpolates. Requires API 33 (AGSL) and the staged Swift core —
+ * [create] returns null otherwise and the feed renders plain.
+ */
+@RequiresApi(33)
+class FeedEffectsRenderer private constructor(private val shader: RuntimeShader) {
+    private val paint = Paint().apply { shader = this@FeedEffectsRenderer.shader }
+
+    /** One shader wrapper per ring bitmap; content updates are picked up via generation id. */
+    private val feedShaders = HashMap<Bitmap, BitmapShader>()
+
+    /** Draws [frame] with the effect chain into the letterboxed destination rect. */
+    fun draw(
+        canvas: Canvas,
+        frame: Bitmap,
+        dstLeft: Float,
+        dstTop: Float,
+        dstWidth: Float,
+        dstHeight: Float,
+    ) {
+        // The decode ring holds 3 bitmaps; a growing map means the feed size
+        // changed and the old ring was dropped — start over.
+        if (feedShaders.size > 4) feedShaders.clear()
+        val feed =
+            feedShaders.getOrPut(frame) {
+                BitmapShader(frame, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP).apply {
+                    filterMode = BitmapShader.FILTER_MODE_LINEAR
+                }
+            }
+        shader.setInputShader("feed", feed)
+        shader.setFloatUniform("dstOffset", dstLeft, dstTop)
+        shader.setFloatUniform("srcScale", frame.width / dstWidth)
+        canvas.drawRect(dstLeft, dstTop, dstLeft + dstWidth, dstTop + dstHeight, paint)
+    }
+
+    companion object {
+        /** Curve ordinal for RED Log3G10 — the offline-monitoring default (see iOS
+         * `playbackExposureSignalMapping`); camera-driven curve selection lands with
+         * the session-backed feed. Mirrors `FeedEffectsWire.curve`. */
+        private const val CURVE_LOG3G10 = 0
+
+        /** iOS `ZebraSettings` defaults: highlight at monitor 100%, midtone at 55%. */
+        private const val ZEBRA_HIGHLIGHT_IRE = 100f
+        private const val ZEBRA_MIDTONE_IRE = 55f
+
+        /** 33³ matches the iOS built-in looks; false colour uses the core's 64³. */
+        private const val LUT_SIZE = 33
+
+        /**
+         * Renderer for [effects], or null when nothing is on or the Swift
+         * core isn't staged — callers fall back to the plain feed. Callers
+         * own the API 33 (AGSL) gate, per the class annotation.
+         */
+        fun create(effects: FeedEffects): FeedEffectsRenderer? {
+            if (effects.isIdentity) return null
+            if (!SwiftCore.isAvailable) {
+                Log.w(TAG, "feed effects need the Swift core (just android-core); rendering plain")
+                return null
+            }
+            return try {
+                build(effects)
+            } catch (e: RuntimeException) {
+                Log.e(TAG, "feed-effects pipeline setup failed; rendering the plain feed", e)
+                null
+            }
+        }
+
+        /** Bakes once per selection: cube upload + threshold uniforms, never per frame. */
+        private fun build(effects: FeedEffects): FeedEffectsRenderer {
+            val shader = RuntimeShader(EFFECTS_AGSL)
+
+            val cube: ByteArray?
+            val cubeSize: Int
+            when {
+                effects.falseColor != null -> {
+                    cube = SwiftCore.bakeFalseColorCube(effects.falseColor.wireOrdinal, CURVE_LOG3G10)
+                    cubeSize = 64
+                }
+                effects.lut != null -> {
+                    cube = SwiftCore.bakeLut(effects.lut.wireOrdinal, LUT_SIZE)
+                    cubeSize = LUT_SIZE
+                }
+                else -> {
+                    cube = null
+                    cubeSize = 0
+                }
+            }
+            if (cubeSize > 0 && cube == null) {
+                Log.w(TAG, "core returned no cube for $effects; base look disabled")
+            }
+            if (cube != null) {
+                check(cube.size == cubeSize * cubeSize * cubeSize * 4) { "bad cube payload" }
+                val lut = Bitmap.createBitmap(cubeSize * cubeSize, cubeSize, Bitmap.Config.ARGB_8888)
+                lut.copyPixelsFromBuffer(ByteBuffer.wrap(cube))
+                shader.setInputShader(
+                    "lut",
+                    BitmapShader(lut, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP).apply {
+                        filterMode = BitmapShader.FILTER_MODE_LINEAR
+                    },
+                )
+                shader.setFloatUniform("lutSize", cubeSize.toFloat())
+            } else {
+                // Every declared child must be bound; lutSize 0 keeps grade() a no-op.
+                val stub = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
+                shader.setInputShader(
+                    "lut",
+                    BitmapShader(stub, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP),
+                )
+                shader.setFloatUniform("lutSize", 0f)
+            }
+
+            val scalars =
+                requireNotNull(
+                    SwiftCore.feedEffectsScalars(
+                        CURVE_LOG3G10,
+                        ZEBRA_HIGHLIGHT_IRE,
+                        ZEBRA_MIDTONE_IRE,
+                    ),
+                ) { "core rejected the effect scalars" }
+            shader.setFloatUniform("deLogRange", scalars[0], scalars[1])
+            shader.setFloatUniform("peakingOn", if (effects.peaking) 1f else 0f)
+            shader.setFloatUniform(
+                "peakingColor",
+                LiveDesign.accent.red,
+                LiveDesign.accent.green,
+                LiveDesign.accent.blue,
+            )
+            shader.setFloatUniform("zebraOn", if (effects.zebra) 1f else 0f)
+            shader.setFloatUniform("zebraHighlight", scalars[2])
+            shader.setFloatUniform("zebraMidtone", scalars[3])
+            if (BuildConfig.DEBUG) {
+                Log.d(
+                    TAG,
+                    "pipeline up: $effects cube=${cube?.size ?: 0}B " +
+                        "scalars=${scalars.joinToString()}",
+                )
+            }
+            return FeedEffectsRenderer(shader)
+        }
+    }
+}
+
+/**
+ * The single-pass effect shader. Peaking/zebra measure the SOURCE pixel so a
+ * grade never changes what reads as in-focus or clipped (iOS invariant).
+ *
+ * Renderer-tuning constants (thresholds, gains, stripe pitch) mirror the iOS
+ * compositor's; the colour math (cube contents, de-log anchors, zebra
+ * thresholds) arrives baked from the Swift core via uniforms/textures.
+ */
+private val EFFECTS_AGSL =
+    """
+    uniform shader feed;          // decoded frame, bitmap px
+    uniform shader lut;           // packed cube: width = n*n, height = n
+    uniform float lutSize;        // cube edge n; < 2 disables the base look
+    uniform float2 dstOffset;     // letterbox origin, canvas px
+    uniform float srcScale;       // canvas px -> bitmap px
+
+    uniform float peakingOn;
+    uniform float3 peakingColor;
+    uniform float2 deLogRange;    // core black/clip anchors, normalized code
+
+    uniform float zebraOn;
+    uniform float zebraHighlight; // core threshold, normalized code
+    uniform float zebraMidtone;   // core band centre, normalized code
+
+    const float3 LUMA709 = float3(0.2126, 0.7152, 0.0722);
+    const float PEAKING_THRESHOLD = 0.04;   // on the defocus-cancelled gradient
+    const float PEAKING_RAMP = 24.0;
+    const float DEFOCUS_REJECTION = 1.35;   // iOS ImageEffectsCompositor
+    const float ZEBRA_GAIN = 40.0;          // iOS soft-threshold ramp
+    const float ZEBRA_HALF_WIDTH = 5.0 / 255.0;
+    const float STRIPE_PITCH = 14.14;       // iOS 5 px stripes rotated 45 deg
+
+    float3 grade(float3 c) {
+        if (lutSize < 2.0) return c;
+        float n = lutSize;
+        float b = clamp(c.b, 0.0, 1.0) * (n - 1.0);
+        float s0 = floor(b);
+        float s1 = min(s0 + 1.0, n - 1.0);
+        float x = clamp(c.r, 0.0, 1.0) * (n - 1.0) + 0.5;
+        float y = clamp(c.g, 0.0, 1.0) * (n - 1.0) + 0.5;
+        float3 lo = float3(lut.eval(float2(s0 * n + x, y)).rgb);
+        float3 hi = float3(lut.eval(float2(s1 * n + x, y)).rgb);
+        return mix(lo, hi, b - s0);
+    }
+
+    // De-logged grey: the core's black->clip stretch of the mean channel.
+    float deLogGrey(float2 p) {
+        float3 c = float3(feed.eval(p).rgb);
+        float g = (c.r + c.g + c.b) / 3.0;
+        return clamp((g - deLogRange.x) / (deLogRange.y - deLogRange.x), 0.0, 1.0);
+    }
+
+    // Central-difference gradient magnitude per pixel at sampling distance d.
+    float gradMag(float2 p, float d) {
+        float gx = deLogGrey(p + float2(d, 0.0)) - deLogGrey(p - float2(d, 0.0));
+        float gy = deLogGrey(p + float2(0.0, d)) - deLogGrey(p - float2(0.0, d));
+        return length(float2(gx, gy)) / (2.0 * d);
+    }
+
+    half4 main(float2 fragCoord) {
+        float2 src = (fragCoord - dstOffset) * srcScale;
+        float3 source = float3(feed.eval(src).rgb);
+        float3 color = grade(source);
+
+        if (peakingOn > 0.5) {
+            // fine - k*coarse: a sharp edge keeps fine-scale gradient a wide
+            // (defocused) edge lacks; both scales cancel on blurred edges.
+            float fine = gradMag(src, 1.0);
+            float coarse = gradMag(src, 2.6);
+            float response = fine - DEFOCUS_REJECTION * coarse;
+            float mask = clamp((response - PEAKING_THRESHOLD) * PEAKING_RAMP, 0.0, 1.0);
+            color = mix(color, peakingColor, mask);
+        }
+
+        if (zebraOn > 0.5) {
+            float luma = dot(source, LUMA709);
+            float stripe = step(0.5, fract((fragCoord.x + fragCoord.y) / STRIPE_PITCH));
+            float hi = clamp((luma - zebraHighlight) * ZEBRA_GAIN, 0.0, 1.0);
+            color = mix(color, float3(1.0), hi * stripe);
+            float mid = clamp((luma - (zebraMidtone - ZEBRA_HALF_WIDTH)) * ZEBRA_GAIN, 0.0, 1.0)
+                * clamp(((zebraMidtone + ZEBRA_HALF_WIDTH) - luma) * ZEBRA_GAIN, 0.0, 1.0);
+            color = mix(color, float3(1.0, 0.72, 0.2), mid * stripe);
+        }
+
+        return half4(half3(color), 1.0);
+    }
+    """
+        .trimIndent()

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/GlassChrome.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/GlassChrome.kt
@@ -1,0 +1,561 @@
+package com.opencapture.openzcine
+
+import android.graphics.Bitmap
+import android.graphics.BitmapShader
+import android.graphics.Canvas
+import android.graphics.Matrix
+import android.graphics.Paint
+import android.graphics.RectF
+import android.graphics.RuntimeShader
+import android.graphics.Shader
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.unit.dp
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+// Custom GPU liquid-glass treatment for the monitor chrome (OPE-47).
+//
+// The rejected library eval (branch task/glass-eval) proved the failure mode
+// to avoid: every glass node re-recording the full-screen backdrop into its
+// own offscreen layer costs ~4 ms of MAIN-THREAD CPU per node per frame while
+// the GPU idles. The structural fix here is ONE shared backdrop, many
+// samplers:
+//
+//  1. [GlassBackdrop] turns each decoded feed frame into a single tiny
+//     blurred texture covering the whole viewport (feed + black letterbox),
+//     produced ONCE per feed frame on the decode thread — no per-node
+//     capture anywhere.
+//  2. Every glass pill samples that shared texture at screen-mapped UVs:
+//     tier FULL adds an AGSL edge-refraction lens (API 33+), tier BLUR draws
+//     the pre-blurred texture straight (the blur is baked into the texture,
+//     so no RenderEffect is even needed), tier FLAT is the original
+//     hand-rolled translucent fill.
+//  3. [FrameBudgetWindow] auto-degrades one tier when frame timing blows the
+//     budget for a sustained window — a counter and a threshold, nothing more.
+
+private const val TAG = "ZCGlass"
+
+/** Backdrop texture scale: 1/16 of screen resolution (~100×45 px on the A12 floor device). */
+private const val BACKDROP_DOWNSCALE = 16
+
+/** Box-blur radius (backdrop texels ≈ 16 screen px each) and pass count (2 ≈ tent kernel). */
+private const val BLUR_RADIUS = 1
+private const val BLUR_PASSES = 2
+
+/** Refraction geometry, dp: the rim band width and the max inward sample displacement. */
+private const val REFRACTION_BEVEL_DP = 8f
+private const val REFRACTION_AMOUNT_DP = 12f
+
+/**
+ * Glass quality tiers, ascending. [resolveTier] picks the platform ceiling;
+ * [MonitorGlass.demote] steps down one tier under sustained frame-budget
+ * overruns.
+ */
+enum class GlassTier {
+    /** Hand-rolled translucent fill + hairline — the original treatment, zero extra cost. */
+    FLAT,
+
+    /** Shared pre-blurred backdrop under the pill fill, no refraction. */
+    BLUR,
+
+    /** Shared backdrop + per-pill AGSL edge refraction (needs `RuntimeShader`, API 33). */
+    FULL,
+}
+
+/**
+ * The tier this device runs: platform capability (API 33+ FULL, 31–32 BLUR,
+ * below FLAT) clamped by an optional debug [override] (`full`/`blur`/`flat`,
+ * the `zc.glass.tier` intent extra). The override can only lower the tier —
+ * FULL physically needs `RuntimeShader`.
+ *
+ * BLUR would technically run on API 29 (it is just a bitmap draw), but
+ * devices that old are also the weakest; keeping them on FLAT skips the
+ * per-frame backdrop production entirely.
+ */
+fun resolveTier(sdkInt: Int, override: String? = null): GlassTier {
+    val capability =
+        when {
+            sdkInt >= 33 -> GlassTier.FULL
+            sdkInt >= 31 -> GlassTier.BLUR
+            else -> GlassTier.FLAT
+        }
+    val requested =
+        when (override?.lowercase()) {
+            "full" -> GlassTier.FULL
+            "blur" -> GlassTier.BLUR
+            "flat" -> GlassTier.FLAT
+            else -> capability
+        }
+    return if (requested.ordinal < capability.ordinal) requested else capability
+}
+
+/**
+ * Sustained frame-budget detector: feed every frame interval, and when more
+ * than [maxOverBudget] of a [window]-frame block exceed [budgetNanos] (i.e.
+ * the block's p90 is worse than the budget), it answers demote-now.
+ * The first [warmup] frames are ignored so app startup jank never demotes.
+ *
+ * ponytail: a counter + threshold, not a jank framework — no percentile
+ * buckets, no re-promotion; upgrade to JankStats if this ever needs nuance.
+ */
+class FrameBudgetWindow(
+    private val budgetNanos: Long = 48_000_000L,
+    private val window: Int = 240,
+    private val maxOverBudget: Int = 24,
+    private val warmup: Int = 60,
+) {
+    private var skipped = 0
+    private var seen = 0
+    private var overBudget = 0
+
+    /** Records one frame interval; true means the budget was blown for a full window. */
+    fun frame(deltaNanos: Long): Boolean {
+        if (skipped < warmup) {
+            skipped++
+            return false
+        }
+        seen++
+        if (deltaNanos > budgetNanos) overBudget++
+        if (seen < window) return false
+        val demote = overBudget > maxOverBudget
+        seen = 0
+        overBudget = 0
+        return demote
+    }
+}
+
+/**
+ * Shared blurred backdrop texture, rebuilt once per feed frame: the decoded
+ * frame is downsampled hard (two bilinear steps, ≤4× each, to avoid
+ * shimmer), composited over black at its aspect-fit screen rect (so the
+ * letterbox is IN the texture — pills over pure black sample the same map),
+ * then box-blurred at the tiny resolution. Total cost is a fraction of a
+ * millisecond on the decode thread; the render side only ever samples.
+ *
+ * ONE texture, ONE [BitmapShader], mutated in place: keeping the shader
+ * object (and its uniforms/matrix) untouched across frames means a pill's
+ * per-frame re-record replays a CACHED native shader instead of rebuilding
+ * it — rebinding a fresh shader per frame is exactly the per-node cost the
+ * rejected library died of. The RenderThread may sample the bitmap while the
+ * decode thread rewrites it; a torn row inside a 16×-downscaled blur is
+ * invisible, and the pixel buffer itself is stable (no realloc), so the race
+ * is benign. ponytail: revisit with a double buffer only if visible shimmer
+ * ever shows up.
+ */
+class GlassBackdrop {
+    private val bilinear = Paint(Paint.FILTER_BITMAP_FLAG)
+    private var canvas: Canvas? = null
+    private var intermediate: Bitmap? = null
+    private var pixels = IntArray(0)
+    private var scratch = IntArray(0)
+    private var rootWidth = 0f
+    private var rootHeight = 0f
+    private var feedRect = RectF()
+
+    /**
+     * The shared texture. Each glass pill wraps it in its own [BitmapShader]
+     * (all wrappers share the one GPU upload, keyed by the bitmap), so
+     * per-pill matrices/uniforms never dirty each other.
+     */
+    var texture: Bitmap? = null
+        private set
+
+    /**
+     * Count of textures produced (0 before the first). Pills read this in
+     * their draw phase, so a new backdrop costs one draw invalidation per
+     * pill — no recomposition, no layout, no shader rebuild.
+     */
+    var frame: Int by mutableIntStateOf(0)
+        private set
+
+    /** Horizontal backdrop-texels-per-screen-px factor (0 until configured). */
+    fun uvScaleX(): Float = texture?.let { it.width / rootWidth } ?: 0f
+
+    /** Vertical backdrop-texels-per-screen-px factor (0 until configured). */
+    fun uvScaleY(): Float = texture?.let { it.height / rootHeight } ?: 0f
+
+    /** True when the rect ([left],[top])–([right],[bottom]) overlaps the feed zone. */
+    fun overlapsFeed(left: Float, top: Float, right: Float, bottom: Float): Boolean =
+        left < feedRect.right &&
+            right > feedRect.left &&
+            top < feedRect.bottom &&
+            bottom > feedRect.top
+
+    /** (Re)configures viewport + feed-zone geometry, in root px. Idempotent per layout. */
+    fun setLayout(rootWidthPx: Float, rootHeightPx: Float, feedRectPx: RectF) {
+        synchronized(this) {
+            feedRect = feedRectPx
+            if (rootWidth == rootWidthPx && rootHeight == rootHeightPx && texture != null) return
+            rootWidth = rootWidthPx
+            rootHeight = rootHeightPx
+            val w = max(1, (rootWidthPx / BACKDROP_DOWNSCALE).roundToInt())
+            val h = max(1, (rootHeightPx / BACKDROP_DOWNSCALE).roundToInt())
+            val fresh = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+            texture = fresh
+            canvas = Canvas(fresh)
+            pixels = IntArray(w * h)
+            scratch = IntArray(w * h)
+            frame = 0
+        }
+    }
+
+    /** Rebuilds the backdrop from a decoded feed [bitmap]. Decode-thread only. */
+    fun submit(bitmap: Bitmap) {
+        synchronized(this) {
+            val target = texture ?: return
+            val canvas = this.canvas ?: return
+            // Aspect-fit rect of the frame inside the feed zone (same math as
+            // LiveFeedView), in root px.
+            val scale = min(feedRect.width() / bitmap.width, feedRect.height() / bitmap.height)
+            val fitW = bitmap.width * scale
+            val fitH = bitmap.height * scale
+            val fitLeft = feedRect.left + (feedRect.width() - fitW) / 2f
+            val fitTop = feedRect.top + (feedRect.height() - fitH) / 2f
+
+            // Two-step downsample: frame → ~4× the final region → backdrop.
+            val sx = uvScaleX()
+            val sy = uvScaleY()
+            val midW = max(1, (fitW * sx * 4f).roundToInt())
+            val midH = max(1, (fitH * sy * 4f).roundToInt())
+            val mid =
+                intermediate?.takeIf { it.width == midW && it.height == midH }
+                    ?: Bitmap.createBitmap(midW, midH, Bitmap.Config.ARGB_8888)
+                        .also { intermediate = it }
+            Canvas(mid).drawBitmap(bitmap, null, RectF(0f, 0f, midW.toFloat(), midH.toFloat()), bilinear)
+
+            canvas.drawColor(android.graphics.Color.BLACK)
+            canvas.drawBitmap(
+                mid,
+                null,
+                RectF(fitLeft * sx, fitTop * sy, (fitLeft + fitW) * sx, (fitTop + fitH) * sy),
+                bilinear,
+            )
+            blur(target)
+            frame++
+        }
+    }
+
+    // ponytail: CPU box blur — at 1/16 resolution this is ~4.5k pixels, a few
+    // microseconds per frame; a GPU RenderEffect pass would cost more in
+    // layer/readback plumbing than it saves.
+    private fun blur(bitmap: Bitmap) {
+        val w = bitmap.width
+        val h = bitmap.height
+        bitmap.getPixels(pixels, 0, w, 0, 0, w, h)
+        repeat(BLUR_PASSES) {
+            boxBlur(pixels, scratch, w, h, horizontal = true)
+            boxBlur(scratch, pixels, w, h, horizontal = false)
+        }
+        bitmap.setPixels(pixels, 0, w, 0, 0, w, h)
+    }
+
+    /** One separable box-blur pass (radius [BLUR_RADIUS], clamped edges, opaque RGB). */
+    private fun boxBlur(src: IntArray, dst: IntArray, w: Int, h: Int, horizontal: Boolean) {
+        val outer = if (horizontal) h else w
+        val inner = if (horizontal) w else h
+        val div = 2 * BLUR_RADIUS + 1
+        for (o in 0 until outer) {
+            fun idx(i: Int) = if (horizontal) o * w + i else i * w + o
+            var r = 0
+            var g = 0
+            var b = 0
+            for (k in -BLUR_RADIUS..BLUR_RADIUS) {
+                val c = src[idx(k.coerceIn(0, inner - 1))]
+                r += (c ushr 16) and 0xFF
+                g += (c ushr 8) and 0xFF
+                b += c and 0xFF
+            }
+            for (i in 0 until inner) {
+                dst[idx(i)] =
+                    (0xFF shl 24) or ((r / div) shl 16) or ((g / div) shl 8) or (b / div)
+                val drop = src[idx((i - BLUR_RADIUS).coerceIn(0, inner - 1))]
+                val add = src[idx((i + BLUR_RADIUS + 1).coerceIn(0, inner - 1))]
+                r += ((add ushr 16) and 0xFF) - ((drop ushr 16) and 0xFF)
+                g += ((add ushr 8) and 0xFF) - ((drop ushr 8) and 0xFF)
+                b += (add and 0xFF) - (drop and 0xFF)
+            }
+        }
+    }
+}
+
+/**
+ * Per-screen glass state: the active [tier] plus the shared [backdrop].
+ * Created once by the monitor screen and provided through
+ * [LocalMonitorGlass].
+ */
+class MonitorGlass(initialTier: GlassTier) {
+    /** Active tier; drops via [demote], never re-promotes within a process. */
+    var tier: GlassTier by mutableStateOf(initialTier)
+        private set
+
+    /** The shared blurred backdrop all glass pills sample. */
+    val backdrop = GlassBackdrop()
+
+    /** Feeds one decoded frame into the backdrop; free when the tier is FLAT. */
+    fun submit(bitmap: Bitmap) {
+        if (tier != GlassTier.FLAT) backdrop.submit(bitmap)
+    }
+
+    /** Steps down one tier after a sustained frame-budget overrun. */
+    fun demote() {
+        if (tier == GlassTier.FLAT) return
+        val downgraded = GlassTier.entries[tier.ordinal - 1]
+        Log.w(TAG, "sustained frame-budget overrun — degrading glass $tier -> $downgraded")
+        tier = downgraded
+    }
+}
+
+/**
+ * Glass state for the monitor chrome. Null (the default, and every screen
+ * that never provides it) keeps [glass] on the hand-rolled FLAT treatment.
+ */
+val LocalMonitorGlass = compositionLocalOf<MonitorGlass?> { null }
+
+/**
+ * AGSL liquid-glass pill shader (tier FULL): samples the shared blurred
+ * backdrop at screen-mapped UVs and bends the samples near the rim like a
+ * convex lens edge — the piece of the rejected library eval that genuinely
+ * read closer to iOS.
+ *
+ * Uniforms: `size`/`radius` describe the pill in local px, `origin` is the
+ * pill's top-left in root px, `uvScale` maps root px → backdrop texels,
+ * `bevel` is the rim band width and `refraction` the max inward sample
+ * displacement (both px). The smoky surface tint and the rim highlight are
+ * composited on top in Compose, shared with tier BLUR.
+ */
+private val GLASS_SHADER_SRC =
+    """
+    uniform shader backdrop;
+    uniform float2 size;
+    uniform float radius;
+    uniform float2 origin;
+    uniform float2 uvScale;
+    uniform float bevel;
+    uniform float refraction;
+
+    // Signed distance to a rounded rect centred at the origin (negative inside).
+    float roundedBoxSDF(float2 p, float2 halfSize, float r) {
+        float2 q = abs(p) - halfSize + r;
+        return length(max(q, 0.0)) + min(max(q.x, q.y), 0.0) - r;
+    }
+
+    half4 main(float2 coord) {
+        float2 halfSize = size * 0.5;
+        float2 p = coord - halfSize;
+        float sd = roundedBoxSDF(p, halfSize, radius);
+
+        // Lens profile: 0 in the interior, ramping quadratically to 1 at the rim.
+        float t = clamp(1.0 + sd / bevel, 0.0, 1.0);
+
+        // Outward normal: exact in the corner circles, axis-aligned on the
+        // straight edges (q picks the nearest edge).
+        float2 q = abs(p) - halfSize + radius;
+        float2 n;
+        if (q.x > 0.0 && q.y > 0.0) {
+            n = normalize(max(q, 0.001)) * sign(p);
+        } else if (q.x > q.y) {
+            n = float2(sign(p.x), 0.0);
+        } else {
+            n = float2(0.0, sign(p.y));
+        }
+
+        // Displace the sample inward near the rim: the interior content
+        // stretches out to the edge, reading as a glass bulge.
+        float2 sample = coord - n * (refraction * t * t);
+        half4 bg = backdrop.eval((sample + origin) * uvScale);
+
+        // Mild vibrancy: the smoky surface tint on top mutes color, so nudge
+        // saturation back up — never past the iOS reference's restraint.
+        half lum = dot(bg.rgb, half3(0.299, 0.587, 0.114));
+        half3 vib = mix(half3(lum), bg.rgb, 1.25);
+        return half4(vib, 1.0);
+    }
+    """
+        .trimIndent()
+
+/**
+ * Top-weighted rim highlight (stolen from the eval — it reads better than
+ * the uniform hairline): bright warm-white at the top edge fading to nearly
+ * nothing at the bottom.
+ */
+private val RimHighlight =
+    Brush.verticalGradient(
+        listOf(
+            Color(0.968f, 0.937f, 0.882f, 0.45f),
+            Color(0.968f, 0.937f, 0.882f, 0.06f),
+        ),
+    )
+
+/**
+ * Per-call-site draw state: the pill's root position, reusable paint
+ * objects, and the last-bound geometry. Uniforms/matrices are only re-set
+ * when geometry actually changed — every set dirties the shader's native
+ * instance and forces a per-frame rebuild otherwise.
+ */
+private class GlassPillNode(refract: Boolean) {
+    var origin = Offset.Zero
+    val runtime: RuntimeShader? =
+        if (refract && Build.VERSION.SDK_INT >= 33) RuntimeShader(GLASS_SHADER_SRC) else null
+    val paint = Paint(Paint.FILTER_BITMAP_FLAG or Paint.ANTI_ALIAS_FLAG)
+    val matrix = Matrix()
+    var shader: BitmapShader? = null
+    private var boundTexture: Bitmap? = null
+    private var boundOrigin = Offset.Unspecified
+    private var boundWidth = -1f
+    private var boundHeight = -1f
+
+    /** True when the shader binding must be refreshed for this draw. */
+    fun rebindNeeded(texture: Bitmap, width: Float, height: Float): Boolean =
+        texture !== boundTexture ||
+            origin != boundOrigin ||
+            width != boundWidth ||
+            height != boundHeight
+
+    /** This node's own [BitmapShader] over the shared [texture]. */
+    fun shaderFor(texture: Bitmap): BitmapShader {
+        if (texture === boundTexture) shader?.let { return it }
+        return BitmapShader(texture, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP)
+            .also {
+                if (Build.VERSION.SDK_INT >= 33) {
+                    // Sampling through the AGSL lens bypasses the paint's filter
+                    // flag; without this the 16× upscale is blocky nearest-neighbor.
+                    it.filterMode = BitmapShader.FILTER_MODE_LINEAR
+                }
+                shader = it
+            }
+    }
+
+    fun markBound(texture: Bitmap, width: Float, height: Float) {
+        boundTexture = texture
+        boundOrigin = origin
+        boundWidth = width
+        boundHeight = height
+    }
+}
+
+/**
+ * iOS `liquidGlass` equivalent — the single entry point for chrome glass
+ * styling (mirrors `ios/Runner/DesignShared.swift`), tiered by
+ * [MonitorGlass.tier]:
+ *
+ * - FULL: AGSL edge refraction over the shared backdrop, smoky surface fill,
+ *   top-weighted rim highlight.
+ * - BLUR: the shared pre-blurred backdrop straight under the same fill+rim.
+ * - FLAT (and any screen without [LocalMonitorGlass]): the original
+ *   hand-rolled fill + uniform hairline.
+ *
+ * All drawing stays inside the pill geometry (a native rounded-rect fill),
+ * so the glass never repaints outside its bounds and the zone-frame tap
+ * targets are untouched.
+ */
+@Composable
+fun Modifier.glass(shape: Shape = ChromeShape): Modifier {
+    val glass = LocalMonitorGlass.current
+    val tier = glass?.tier ?: GlassTier.FLAT
+    if (glass == null || tier == GlassTier.FLAT) {
+        return background(LiveDesign.glass, shape).border(1.dp, LiveDesign.hairline, shape)
+    }
+    val node = remember(glass, tier) { GlassPillNode(refract = tier == GlassTier.FULL) }
+    return onGloballyPositioned { node.origin = it.positionInRoot() }
+        .drawBehind { drawGlassBackdrop(node, glass.backdrop, shape) }
+        .background(LiveDesign.glass, shape)
+        .border(1.dp, RimHighlight, shape)
+}
+
+/**
+ * Glass for chips nested INSIDE a glass slab (the info deck's readout
+ * capsules): always the flat treatment. Matches iOS, where nested chips are
+ * tinted overlays on the slab, not stacked glass — and it keeps the
+ * refracting-node count at the slab level (6 nodes, not 10).
+ */
+fun Modifier.chipGlass(shape: Shape = ChromeShape): Modifier =
+    background(LiveDesign.glass, shape).border(1.dp, LiveDesign.hairline, shape)
+
+/**
+ * Draws the shared backdrop clipped to the pill's rounded rect. Reading
+ * [GlassBackdrop.frame] here means each new backdrop invalidates draw only.
+ *
+ * ponytail: chrome uses exactly two shapes (capsule / 16dp rounded rect), so
+ * the corner radius is resolved by shape identity — generalize via
+ * Shape.createOutline if a third ever appears.
+ */
+private fun DrawScope.drawGlassBackdrop(node: GlassPillNode, backdrop: GlassBackdrop, shape: Shape) {
+    if (backdrop.frame <= 0) return
+    val texture = backdrop.texture ?: return
+    val radius =
+        if (shape === CircleShape) size.minDimension / 2f
+        else min(LiveDesign.CORNER_RADIUS_DP.dp.toPx(), size.minDimension / 2f)
+    if (node.rebindNeeded(texture, size.width, size.height)) {
+        val source = node.shaderFor(texture)
+        val runtime = node.runtime
+        // Pills entirely over the letterbox (side rails, capture strip on
+        // tall feeds) skip the AGSL lens: refracting near-black is visually
+        // identical to sampling it straight (judged by eye on the A12), and
+        // it keeps the per-frame runtime-effect count at the pills actually
+        // over the image.
+        val overFeed =
+            backdrop.overlapsFeed(
+                node.origin.x,
+                node.origin.y,
+                node.origin.x + size.width,
+                node.origin.y + size.height,
+            )
+        if (Build.VERSION.SDK_INT >= 33 && runtime != null && overFeed) {
+            setRefractionUniforms(runtime, node, backdrop, source, radius)
+        } else {
+            // Tier BLUR (and letterbox pills on FULL): map the backdrop
+            // straight into pill-local space.
+            node.matrix.setScale(1f / backdrop.uvScaleX(), 1f / backdrop.uvScaleY())
+            node.matrix.postTranslate(-node.origin.x, -node.origin.y)
+            source.setLocalMatrix(node.matrix)
+            node.paint.shader = source
+        }
+        node.markBound(texture, size.width, size.height)
+    }
+    drawIntoCanvas {
+        it.nativeCanvas.drawRoundRect(0f, 0f, size.width, size.height, radius, radius, node.paint)
+    }
+}
+
+/** Tier FULL only: binds this frame's geometry + backdrop to the AGSL lens. */
+@RequiresApi(33)
+private fun DrawScope.setRefractionUniforms(
+    runtime: RuntimeShader,
+    node: GlassPillNode,
+    backdrop: GlassBackdrop,
+    source: BitmapShader,
+    radius: Float,
+) {
+    runtime.setFloatUniform("size", size.width, size.height)
+    runtime.setFloatUniform("radius", radius)
+    runtime.setFloatUniform("origin", node.origin.x, node.origin.y)
+    runtime.setFloatUniform("uvScale", backdrop.uvScaleX(), backdrop.uvScaleY())
+    runtime.setFloatUniform("bevel", REFRACTION_BEVEL_DP.dp.toPx())
+    runtime.setFloatUniform("refraction", REFRACTION_AMOUNT_DP.dp.toPx())
+    runtime.setInputShader("backdrop", source)
+    node.paint.shader = runtime
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/LiveFeedView.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/LiveFeedView.kt
@@ -76,9 +76,17 @@ class JpegFrameDecoder {
  *
  * The frame state is read inside the [Canvas] draw lambda only, so a new
  * frame costs one draw invalidation — no recomposition, no layout.
+ *
+ * [onFrame] observes each presented frame on the decode thread — the glass
+ * backdrop producer hooks in here ([MonitorGlass.submit]). The bitmap is
+ * pooled; it stays valid until two more frames have been decoded.
  */
 @Composable
-fun LiveFeedView(source: LiveFrameSource, modifier: Modifier = Modifier) {
+fun LiveFeedView(
+    source: LiveFrameSource,
+    modifier: Modifier = Modifier,
+    onFrame: ((Bitmap) -> Unit)? = null,
+) {
     val frame = remember { mutableStateOf<ImageBitmap?>(null) }
 
     LaunchedEffect(source) {
@@ -94,7 +102,10 @@ fun LiveFeedView(source: LiveFrameSource, modifier: Modifier = Modifier) {
                 frames = source.frames,
                 stats = stats,
                 decode = decoder::decode,
-                present = { frame.value = it.asImageBitmap() },
+                present = {
+                    frame.value = it.asImageBitmap()
+                    onFrame?.invoke(it)
+                },
             )
         }
     }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/LiveFeedView.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/LiveFeedView.kt
@@ -3,6 +3,7 @@ package com.opencapture.openzcine
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.media.MediaCodecList
+import android.os.Build
 import android.util.Log
 import androidx.compose.foundation.Canvas
 import androidx.compose.runtime.Composable
@@ -11,7 +12,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import com.opencapture.openzcine.core.LiveFrameSource
@@ -76,10 +79,30 @@ class JpegFrameDecoder {
  *
  * The frame state is read inside the [Canvas] draw lambda only, so a new
  * frame costs one draw invalidation — no recomposition, no layout.
+ *
+ * [effects] bakes the GPU assist chain (LUT / false colour / peaking / zebra,
+ * see [FeedEffectsRenderer]) into the drawn frame. The default preserves the
+ * plain feed unless the debug harness switched effects on; devices below
+ * API 33 (AGSL) or builds without the staged Swift core always render plain.
  */
 @Composable
-fun LiveFeedView(source: LiveFrameSource, modifier: Modifier = Modifier) {
+fun LiveFeedView(
+    source: LiveFrameSource,
+    modifier: Modifier = Modifier,
+    effects: FeedEffects = FeedEffectsState.current,
+) {
     val frame = remember { mutableStateOf<ImageBitmap?>(null) }
+    val renderer =
+        remember(effects) {
+            when {
+                effects.isIdentity -> null
+                Build.VERSION.SDK_INT >= 33 -> FeedEffectsRenderer.create(effects)
+                else -> {
+                    Log.w(TAG, "feed effects need Android 13+ (AGSL); rendering the plain feed")
+                    null
+                }
+            }
+        }
 
     LaunchedEffect(source) {
         if (BuildConfig.DEBUG) {
@@ -108,7 +131,18 @@ fun LiveFeedView(source: LiveFrameSource, modifier: Modifier = Modifier) {
                 ((size.width - dstSize.width) / 2f).roundToInt(),
                 ((size.height - dstSize.height) / 2f).roundToInt(),
             )
-        drawImage(image, dstOffset = dstOffset, dstSize = dstSize)
+        if (Build.VERSION.SDK_INT >= 33 && renderer != null) {
+            renderer.draw(
+                canvas = drawContext.canvas.nativeCanvas,
+                frame = image.asAndroidBitmap(),
+                dstLeft = dstOffset.x.toFloat(),
+                dstTop = dstOffset.y.toFloat(),
+                dstWidth = dstSize.width.toFloat(),
+                dstHeight = dstSize.height.toFloat(),
+            )
+        } else {
+            drawImage(image, dstOffset = dstOffset, dstSize = dstSize)
+        }
     }
 }
 

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
@@ -77,7 +77,11 @@ class MainActivity : ComponentActivity() {
                     // The real shell needs the shared core's zone map. An APK
                     // built without `just android-core` (plain CI android-check)
                     // has no native library, so it keeps the placeholder.
-                    MonitorScreen(session, frameSource = demo?.second)
+                    MonitorScreen(
+                        session,
+                        frameSource = demo?.second,
+                        scopeKind = DemoHarness.scopeKind(intent),
+                    )
                 } else {
                     MonitorShell(session, frameSource = demo?.second)
                 }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
@@ -77,7 +77,11 @@ class MainActivity : ComponentActivity() {
                     // The real shell needs the shared core's zone map. An APK
                     // built without `just android-core` (plain CI android-check)
                     // has no native library, so it keeps the placeholder.
-                    MonitorScreen(session, frameSource = demo?.second)
+                    MonitorScreen(
+                        session,
+                        frameSource = demo?.second,
+                        glassTierOverride = DemoHarness.glassTierOverride(intent),
+                    )
                 } else {
                     MonitorShell(session, frameSource = demo?.second)
                 }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorChrome.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorChrome.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
@@ -54,9 +53,8 @@ import androidx.compose.ui.unit.Dp
 /** Rounded chrome shape (iOS `LiveDesign.cornerRadius`). */
 val ChromeShape = RoundedCornerShape(LiveDesign.CORNER_RADIUS_DP.dp)
 
-/** iOS `liquidGlass` fallback treatment: glass fill + hairline stroke. */
-fun Modifier.glass(shape: Shape = ChromeShape): Modifier =
-    background(LiveDesign.glass, shape).border(1.dp, LiveDesign.hairline, shape)
+// The glass treatment itself (Modifier.glass / Modifier.chipGlass and the
+// tiered GPU backdrop pipeline behind it) lives in GlassChrome.kt.
 
 /** Click without the Material ripple (chrome buttons highlight by state, not ripple). */
 @Composable
@@ -92,7 +90,7 @@ fun timecodeAnnotated(frameCount: Long, fps: Int): AnnotatedString {
 @Composable
 fun RecordChip(recording: Boolean) {
     Row(
-        modifier = Modifier.glass(CircleShape).padding(horizontal = 12.dp, vertical = 7.dp),
+        modifier = Modifier.chipGlass(CircleShape).padding(horizontal = 12.dp, vertical = 7.dp),
         horizontalArrangement = Arrangement.spacedBy(7.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -112,7 +110,7 @@ fun RecordChip(recording: Boolean) {
 @Composable
 fun ReadoutPill(value: String, icon: @Composable () -> Unit) {
     Row(
-        modifier = Modifier.glass(CircleShape).padding(horizontal = 10.dp, vertical = 6.dp),
+        modifier = Modifier.chipGlass(CircleShape).padding(horizontal = 10.dp, vertical = 6.dp),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -137,7 +135,7 @@ fun FpsChip(signalBars: Int, fps: String) {
             else -> LiveDesign.faint
         }
     Row(
-        modifier = Modifier.glass(CircleShape).padding(horizontal = 11.dp, vertical = 7.dp),
+        modifier = Modifier.chipGlass(CircleShape).padding(horizontal = 11.dp, vertical = 7.dp),
         horizontalArrangement = Arrangement.spacedBy(6.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
@@ -34,6 +35,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalView
@@ -57,7 +59,7 @@ import kotlinx.coroutines.delay
  * (`CameraDisplayState.preview`) so side-by-side screenshots match. Real
  * values arrive with the session facade later.
  */
-private object DemoMonitorState {
+internal object DemoMonitorState {
     const val RESOLUTION = "6K·25p"
     const val CODEC = "R3D NE"
     const val MEDIA = "521 GB·47%"
@@ -79,7 +81,7 @@ private object DemoMonitorState {
 }
 
 /** Places a composable at an absolute zone frame (full-viewport dp coordinates). */
-private fun Modifier.zone(frame: ZoneFrame): Modifier =
+internal fun Modifier.zone(frame: ZoneFrame): Modifier =
     offset(frame.x.dp, frame.y.dp).size(frame.width.dp, frame.height.dp)
 
 /**
@@ -118,18 +120,22 @@ private tailrec fun android.content.Context.findActivity(): android.app.Activity
     }
 
 /**
- * The landscape monitor shell — a 1:1 port of the iOS `MonitorShell`
- * (ios/Runner/MonitorUnified.swift) landscape branch, laid out by the SAME
- * shared-core zone map via [SwiftCore.monitorZoneMap].
+ * The monitor shell — a 1:1 port of the iOS `MonitorShell`
+ * (ios/Runner/MonitorUnified.swift), laid out by the SAME shared-core zone
+ * map via [SwiftCore.monitorZoneMap] in both orientations.
  *
- * v1 scope: feed, top info pill, lock/battery band, capture strip, record /
- * DISP / media / settings rail, DISP 1↔2 cycling. Deferred: the assist
- * toolbar zone (skipped — its capture-strip sibling renders at its own zone),
- * scopes, pickers/panels, portrait.
+ * Scope: feed, top info deck (landscape pill / portrait bar), lock/battery
+ * band, capture strip, assist toolbar (wired to the feed-effects engine and
+ * the scope panels), record / DISP / media / settings controls, DISP 1→2→3
+ * cycling incl. the command dashboard, and the portrait fit layout. Deferred:
+ * pickers/panels, portrait fill aspect, command tile interaction.
  *
  * Chrome glass runs the tiered GPU treatment (GlassChrome.kt) at this
  * device's [resolveTier] ceiling; [glassTierOverride] (`zc.glass.tier`
  * debug intent extra) forces a lower tier for testing.
+ *
+ * [scopeKind] (`zc.scopes` debug intent) seeds the assist state; the assist
+ * toolbar owns it from there.
  */
 @Composable
 fun MonitorScreen(
@@ -140,6 +146,12 @@ fun MonitorScreen(
 ) {
     val sessionState by session.state.collectAsState()
     LaunchedEffect(session) { session.connect() }
+
+    // Assist toggles: seeded from the debug intent when present (exact,
+    // deterministic test state), else the persisted toolbar toggles; every
+    // change feeds the effects engine + scope mount and persists.
+    val appContext = LocalContext.current.applicationContext
+    val assist = remember { AssistState.restore(appContext, FeedEffectsState.current, scopeKind) }
 
     // Shared glass state: the active tier plus the one blurred backdrop
     // texture every glass pill samples. The frame-clock loop is the perf
@@ -159,8 +171,9 @@ fun MonitorScreen(
         }
     }
 
-    // Shell state, iOS-model-equivalent: DISP index (0 live, 1 clean), the
-    // interface lock, the record toggle, and the fake-clock timecode tick.
+    // Shell state, iOS-model-equivalent: DISP index (0 live, 1 clean,
+    // 2 command), the interface lock, the record toggle, and the fake-clock
+    // timecode tick.
     var dispIndex by remember { mutableIntStateOf(0) }
     var locked by remember { mutableStateOf(false) }
     var recording by remember { mutableStateOf(false) }
@@ -246,6 +259,7 @@ fun MonitorScreen(
     ) {
         val density = LocalDensity.current
         val direction = LocalLayoutDirection.current
+        val isPortrait = maxHeight > maxWidth
         // Live safe area: the punch-hole cutout plus the applied system-bar
         // lanes published by the cycle above. Each edge animates so the
         // chrome glides off the bars and back instead of jumping. The top
@@ -269,25 +283,38 @@ fun MonitorScreen(
             label = "safeBottom",
         )
         // Leading carries the synthesized iPhone island lane (see
-        // monitorLeadingInsetDp); trailing gets NO floor — in the landscape
-        // zone map the trailing inset only feeds the which-side-is-the-cutout
-        // comparison and moves no frame (iOS's 44pt trailing is < the 59pt
-        // leading, same branch), the rail centering in the letterbox lane on
-        // both platforms.
+        // monitorLeadingInsetDp) in LANDSCAPE only; the floor exists to move
+        // the feed off the side chrome lane, which portrait doesn't have —
+        // there the raw cutout flows through. Trailing gets NO floor — in the
+        // landscape zone map the trailing inset only feeds the
+        // which-side-is-the-cutout comparison and moves no frame (iOS's 44pt
+        // trailing is < the 59pt leading, same branch), the rail centering in
+        // the letterbox lane on both platforms.
         val safeLeading by animateFloatAsState(
             with(density) {
-                monitorLeadingInsetDp(
-                    cutoutDp = cutout.getLeft(this, direction).toDp().value,
-                    transientBarDp = barInsets.left.toDp().value,
-                )
+                val cutoutDp = cutout.getLeft(this, direction).toDp().value
+                if (isPortrait) {
+                    cutoutDp
+                } else {
+                    monitorLeadingInsetDp(
+                        cutoutDp = cutoutDp,
+                        transientBarDp = barInsets.left.toDp().value,
+                    )
+                }
             },
             label = "safeLeading",
         )
         val safeTrailing =
             with(density) { cutout.getRight(this, direction).toDp().value }
+        // Landscape-only right-hand nav-bar lane (portrait bars are top/bottom
+        // and already flow through safeTop/safeBottom).
         val navLane by animateFloatAsState(
-            with(density) {
-                maxOf(0, barInsets.right - cutout.getRight(this, direction)).toDp().value
+            if (isPortrait) {
+                0f
+            } else {
+                with(density) {
+                    maxOf(0, barInsets.right - cutout.getRight(this, direction)).toDp().value
+                }
             },
             label = "navLane",
         )
@@ -295,10 +322,15 @@ fun MonitorScreen(
         val viewportHeight = maxHeight.value
 
         // Same core call the iOS shell makes once per layout pass. The
-        // landscape map is mode-invariant (iOS gates chrome shell-side), so
-        // the map is keyed on geometry only.
+        // landscape map is mode-invariant (iOS gates chrome shell-side), but
+        // the portrait map encodes per-mode zones, so mode/scope key the map
+        // alongside geometry.
+        val scopeCount = if (assist.scope != null) 1 else 0
         val zones =
-            remember(viewportWidth, viewportHeight, safeTop, safeLeading, safeBottom, safeTrailing) {
+            remember(
+                viewportWidth, viewportHeight, safeTop, safeLeading, safeBottom, safeTrailing,
+                isPortrait, dispIndex, scopeCount,
+            ) {
                 MonitorZones.parse(
                     SwiftCore.monitorZoneMap(
                         viewportWidth = viewportWidth,
@@ -308,15 +340,16 @@ fun MonitorScreen(
                         safeBottom = safeBottom,
                         safeTrailing = safeTrailing,
                         mode = dispIndex,
-                        isPortrait = false,
+                        isPortrait = isPortrait,
                         aspectFill = false,
-                        scopeCount = if (scopeKind != null) 1 else 0,
+                        scopeCount = scopeCount,
                         mirrored = false,
                         bottomBarHeight = LiveDesign.CONTROL_HEIGHT_DP,
                     ),
                 )
             }
         val isClean = dispIndex == 1
+        val isCommand = dispIndex == 2
 
         // Backdrop geometry for the glass pipeline: the viewport and the feed
         // zone in root px. The blurred texture covers the whole viewport
@@ -337,94 +370,144 @@ fun MonitorScreen(
             )
         }
 
-        // Feed at the zone map's feed frame; LiveFeedView aspect-fits within it.
-        Box(Modifier.zone(zones.feed), contentAlignment = Alignment.Center) {
-            if (frameSource != null) {
-                LiveFeedView(frameSource, Modifier.fillMaxSize(), onFrame = glass::submit)
-            } else {
-                Text(
-                    text =
-                        when (val current = sessionState) {
-                            is CameraSessionState.Connected -> current.identity.name
-                            CameraSessionState.Connecting -> "Connecting…"
-                            CameraSessionState.Disconnected -> "No camera"
-                        },
-                    style = chromeStyle(15f, FontWeight.Medium),
-                    color = LiveDesign.muted,
-                )
+        // Feed at the zone map's feed frame; LiveFeedView aspect-fits within
+        // it. Command (DISP 3) unmounts the feed behind the dashboard, iOS
+        // semantics.
+        if (!isCommand) {
+            Box(Modifier.zone(zones.feed), contentAlignment = Alignment.Center) {
+                if (frameSource != null) {
+                    LiveFeedView(frameSource, Modifier.fillMaxSize(), onFrame = glass::submit)
+                } else {
+                    Text(
+                        text =
+                            when (val current = sessionState) {
+                                is CameraSessionState.Connected -> current.identity.name
+                                CameraSessionState.Connecting -> "Connecting…"
+                                CameraSessionState.Disconnected -> "No camera"
+                            },
+                        style = chromeStyle(15f, FontWeight.Medium),
+                        color = LiveDesign.muted,
+                    )
+                }
             }
         }
 
         CompositionLocalProvider(LocalMonitorGlass provides glass) {
-            // Top info pill, centered in the deck band; compact in clean mode.
-            // The deck is feed-anchored and the synthesized island lane (see
-            // monitorLeadingInsetDp) starts the feed right of the lock, so the
-            // band always clears it — same as iPhone geometry.
-            Box(Modifier.zone(zones.infoBar), contentAlignment = Alignment.Center) {
-                FitScale(zones.infoBar.width.dp) {
-                    InfoPill(compact = isClean, recording = recording, frameCount = frameCount)
-                }
-            }
+            if (isPortrait) {
+                PortraitChrome(
+                    zones = zones,
+                    viewportHeight = viewportHeight,
+                    isCommand = isCommand,
+                    locked = locked,
+                    recording = recording,
+                    frameCount = frameCount,
+                    assist = assist,
+                    dispIndex = dispIndex,
+                    onLock = { locked = !locked },
+                    onRecord = { recording = !recording },
+                    onDisp = { dispIndex = (dispIndex + 1) % 3 },
+                )
+            } else {
+                if (isCommand) {
+                    // The DISP 3 dashboard fills the deck span between the
+                    // rails on the warm command background (iOS CommandMonitor).
+                    Box(Modifier.fillMaxSize().background(LiveDesign.background))
+                    val top = maxOf(14f, safeTop)
+                    CommandDashboard(
+                        recording = recording,
+                        frameCount = frameCount,
+                        modifier =
+                            Modifier.zone(
+                                ZoneFrame(
+                                    zones.infoBar.x,
+                                    top,
+                                    zones.infoBar.width,
+                                    maxOf(0f, viewportHeight - top - safeBottom - 16f),
+                                ),
+                            ).alpha(if (locked) 0.4f else 1f),
+                    )
+                } else {
+                    // Top info pill, centered in the deck band; compact in clean
+                    // mode. The deck is feed-anchored and the synthesized island
+                    // lane (see monitorLeadingInsetDp) starts the feed right of
+                    // the lock, so the band always clears it — same as iPhone
+                    // geometry.
+                    Box(Modifier.zone(zones.infoBar), contentAlignment = Alignment.Center) {
+                        FitScale(zones.infoBar.width.dp) {
+                            InfoPill(compact = isClean, recording = recording, frameCount = frameCount)
+                        }
+                    }
 
-            // Bottom capture strip — live mode only, dimmed while locked; the
-            // glass hugs its readouts against the band's trailing edge like the
-            // iOS content-hugging strip. The assist toolbar zone to its left is
-            // deferred (v1 skips assists).
-            if (!isClean) {
-                zones.captureStrip?.let { strip ->
-                    Box(
-                        Modifier.zone(strip).alpha(if (locked) 0.4f else 1f),
-                        contentAlignment = Alignment.CenterEnd,
-                    ) {
-                        FitScale(strip.width.dp) { CaptureStrip() }
+                    // Bottom bars — live mode only, dimmed while locked: the
+                    // assist toolbar at its zone, and the capture strip whose
+                    // glass hugs its readouts against the band's trailing edge
+                    // like the iOS content-hugging strip.
+                    if (!isClean) {
+                        zones.assistStrip?.let { strip ->
+                            AssistToolbar(
+                                assist,
+                                Modifier.zone(strip).alpha(if (locked) 0.4f else 1f),
+                            )
+                        }
+                        zones.captureStrip?.let { strip ->
+                            Box(
+                                Modifier.zone(strip).alpha(if (locked) 0.4f else 1f),
+                                contentAlignment = Alignment.CenterEnd,
+                            ) {
+                                FitScale(strip.width.dp) { CaptureStrip() }
+                            }
+                        }
                     }
                 }
-            }
 
-            // Side rails: lock + battery indicators + record / DISP / media / settings.
-            LockButton(locked, Modifier.zone(zones.lock)) { locked = !locked }
-            zones.batteryPhone?.let {
-                BatteryIndicatorColumn(
-                    percent = DemoMonitorState.PHONE_BATTERY,
-                    isCamera = false,
-                    modifier = Modifier.zone(it),
-                )
-            }
-            zones.batteryCamera?.let {
-                BatteryIndicatorColumn(
-                    percent = DemoMonitorState.CAMERA_BATTERY,
-                    isCamera = true,
-                    modifier = Modifier.zone(it),
-                )
-            }
-            AuxCircleButton(Modifier.zone(zones.settings)) { glyphModifier, tint ->
-                GearGlyph(tint, glyphModifier)
-            }
-            AuxCircleButton(Modifier.zone(zones.media)) { glyphModifier, tint ->
-                MediaStackGlyph(tint, glyphModifier)
-            }
-            RecordButton(recording, Modifier.zone(zones.record)) { recording = !recording }
-            DispButton(
-                activeIndex = dispIndex,
-                modeCount = 3, // Live / Clean / Command dashes, matching iOS; Command lands later.
-                modifier = Modifier.zone(zones.disp),
-            ) {
-                dispIndex = (dispIndex + 1) % 2
+                // Side rails: lock + battery indicators + record / DISP /
+                // media / settings — mounted in every mode, like iOS.
+                LockButton(locked, Modifier.zone(zones.lock)) { locked = !locked }
+                zones.batteryPhone?.let {
+                    BatteryIndicatorColumn(
+                        percent = DemoMonitorState.PHONE_BATTERY,
+                        isCamera = false,
+                        modifier = Modifier.zone(it),
+                    )
+                }
+                zones.batteryCamera?.let {
+                    BatteryIndicatorColumn(
+                        percent = DemoMonitorState.CAMERA_BATTERY,
+                        isCamera = true,
+                        modifier = Modifier.zone(it),
+                    )
+                }
+                AuxCircleButton(Modifier.zone(zones.settings)) { glyphModifier, tint ->
+                    GearGlyph(tint, glyphModifier)
+                }
+                AuxCircleButton(Modifier.zone(zones.media)) { glyphModifier, tint ->
+                    MediaStackGlyph(tint, glyphModifier)
+                }
+                RecordButton(recording, Modifier.zone(zones.record)) { recording = !recording }
+                DispButton(
+                    activeIndex = dispIndex,
+                    modeCount = 3, // Live / Clean / Command, matching iOS.
+                    modifier = Modifier.zone(zones.disp),
+                ) {
+                    dispIndex = (dispIndex + 1) % 3
+                }
             }
         }
 
-        // Scopes v1: one debug-selected scope (`--es zc.scopes`), mounted at the
-        // zone map's scopes zone when the core emits one; the landscape map
-        // floats scopes over the feed (like iOS), so it falls back to the
-        // iOS-parity floating frame.
-        if (scopeKind != null && frameSource != null) {
-            ScopePanel(
-                scopeKind,
-                frameSource,
-                Modifier.zone(
-                    zones.scopes ?: floatingScopeFrame(scopeKind, zones.feed, zones.infoBar),
-                ),
-            )
+        // Scope panel: toolbar-toggled (seeded by `--es zc.scopes`). Landscape
+        // floats it over the feed (the map carries no scopes zone there);
+        // portrait mounts the stacked zone the map emits (fit + live only).
+        val activeScope = assist.scope
+        if (!isCommand && activeScope != null && frameSource != null) {
+            val scopeFrame =
+                if (isPortrait) {
+                    zones.scopes?.let {
+                        ZoneFrame(it.x + 12f, it.y, it.width - 24f, it.height)
+                    }
+                } else {
+                    zones.scopes ?: floatingScopeFrame(activeScope, zones.feed, zones.infoBar)
+                }
+            scopeFrame?.let { ScopePanel(activeScope, frameSource, Modifier.zone(it)) }
         }
 
         // Recording tally border at the physical edge (iOS `RecordingBorderModule`).
@@ -457,6 +540,154 @@ private fun InfoPill(compact: Boolean, recording: Boolean, frameCount: Long) {
             ReadoutPill(DemoMonitorState.MEDIA) { SdCardGlyph(LiveDesign.muted) }
         }
         FpsChip(DemoMonitorState.SIGNAL_BARS, DemoMonitorState.FPS)
+    }
+}
+
+/**
+ * The portrait chrome tree, every region at its zone-map frame (iOS
+ * `portraitShell`): full-width top bar, fit-mode assist toolbar + tile grid
+ * (or the command timecode band + grid), stacked scopes (mounted by the
+ * caller), and the bottom system band. The fill aspect (capture strip over
+ * the feed + vertical assist rail) is deferred with the aspect toggle.
+ */
+@Composable
+private fun PortraitChrome(
+    zones: MonitorZones,
+    viewportHeight: Float,
+    isCommand: Boolean,
+    locked: Boolean,
+    recording: Boolean,
+    frameCount: Long,
+    assist: AssistState,
+    dispIndex: Int,
+    onLock: () -> Unit,
+    onRecord: () -> Unit,
+    onDisp: () -> Unit,
+) {
+    PortraitInfoBar(frameCount, Modifier.zone(zones.infoBar))
+
+    // Fit-mode horizontal assist toolbar between the scopes zone and the tile
+    // grid (live only — the map emits the zone). 12/4dp insets float the
+    // glass pill off the screen edges, like iOS.
+    if (!isCommand) {
+        zones.assistStrip?.let { strip ->
+            AssistToolbar(
+                assist,
+                Modifier.zone(
+                    ZoneFrame(strip.x + 12f, strip.y + 4f, strip.width - 24f, strip.height - 8f),
+                ).alpha(if (locked) 0.4f else 1f),
+            )
+        }
+    }
+
+    // Controls zone: fit-mode live tiles, or the command hero-timecode band +
+    // grid (iOS reserves 80pt off the top of the tile region for it).
+    zones.controlsGrid?.takeIf { it.height > 0 }?.let { grid ->
+        val tcBand = if (isCommand) 80f else 0f
+        if (isCommand) {
+            Box(
+                Modifier.zone(ZoneFrame(grid.x, grid.y, grid.width, tcBand))
+                    .padding(horizontal = 12.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                CommandTimecode(frameCount, sizeSp = 52f)
+            }
+        }
+        CommandGrid(
+            Modifier.zone(
+                ZoneFrame(
+                    grid.x,
+                    grid.y + tcBand,
+                    grid.width,
+                    maxOf(0f, grid.height - tcBand - (if (isCommand) 0f else 8f)),
+                ),
+            )
+                .padding(horizontal = 12.dp)
+                .alpha(if (locked) 0.4f else 1f),
+        )
+    }
+
+    // Opaque band behind the system controls through the physical bottom
+    // edge, so the record button never floats on bare black (iOS R4).
+    Box(
+        Modifier.zone(
+            ZoneFrame(
+                zones.systemCluster.x,
+                zones.systemCluster.y,
+                zones.systemCluster.width,
+                maxOf(0f, viewportHeight - zones.systemCluster.y),
+            ),
+        ).background(LiveDesign.glass),
+    )
+
+    // Bottom system band: equal gaps around natural control sizes (iOS
+    // `PortraitSystemBar` uses equal spacers, not equal columns).
+    Row(
+        Modifier.zone(zones.systemCluster),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Spacer(Modifier.weight(1f))
+        LockButton(locked, Modifier.size(40.dp), onClick = onLock)
+        Spacer(Modifier.weight(1f))
+        DispButton(
+            activeIndex = dispIndex,
+            modeCount = 3,
+            modifier = Modifier.size(width = 74.dp, height = 44.dp),
+            onClick = onDisp,
+        )
+        Spacer(Modifier.weight(1f))
+        RecordButton(recording, Modifier.size(83.dp), onClick = onRecord)
+        Spacer(Modifier.weight(1f))
+        AuxCircleButton(Modifier.size(63.dp)) { glyphModifier, tint ->
+            MediaStackGlyph(tint, glyphModifier)
+        }
+        Spacer(Modifier.weight(1f))
+        AuxCircleButton(Modifier.size(63.dp)) { glyphModifier, tint ->
+            GearGlyph(tint, glyphModifier)
+        }
+        Spacer(Modifier.weight(1f))
+    }
+}
+
+/**
+ * The portrait top bar (iOS `MonitorInfoBar` `.infoBar`): accent-frames
+ * timecode leading, storage centered on the screen width, camera battery
+ * inline trailing, on the plain glass band.
+ */
+@Composable
+private fun PortraitInfoBar(frameCount: Long, modifier: Modifier = Modifier) {
+    Box(modifier.background(LiveDesign.glass).padding(horizontal = 16.dp)) {
+        Text(
+            DemoMonitorState.MEDIA,
+            style = chromeStyle(13f, FontWeight.Medium),
+            color = LiveDesign.muted,
+            maxLines = 1,
+            modifier = Modifier.align(Alignment.Center),
+        )
+        Row(Modifier.fillMaxSize(), verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                timecodeAnnotated(frameCount, DemoMonitorState.FRAME_RATE),
+                style = chromeStyle(15f, FontWeight.Normal, mono = true),
+                maxLines = 1,
+            )
+            Spacer(Modifier.weight(1f))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(5.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                BatteryGlyph(
+                    DemoMonitorState.CAMERA_BATTERY,
+                    LiveDesign.accent,
+                    Modifier.size(22.dp, 11.dp),
+                )
+                Text(
+                    "${DemoMonitorState.CAMERA_BATTERY}%",
+                    style = chromeStyle(10.5f, FontWeight.Medium, mono = true),
+                    color = LiveDesign.text.copy(alpha = 0.72f),
+                )
+                CameraGlyph(LiveDesign.muted, Modifier.size(15.dp, 12.dp))
+            }
+        }
     }
 }
 

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -28,6 +29,7 @@ import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -124,11 +126,37 @@ private tailrec fun android.content.Context.findActivity(): android.app.Activity
  * DISP / media / settings rail, DISP 1↔2 cycling. Deferred: the assist
  * toolbar zone (skipped — its capture-strip sibling renders at its own zone),
  * scopes, pickers/panels, portrait.
+ *
+ * Chrome glass runs the tiered GPU treatment (GlassChrome.kt) at this
+ * device's [resolveTier] ceiling; [glassTierOverride] (`zc.glass.tier`
+ * debug intent extra) forces a lower tier for testing.
  */
 @Composable
-fun MonitorScreen(session: CameraSession, frameSource: LiveFrameSource?) {
+fun MonitorScreen(
+    session: CameraSession,
+    frameSource: LiveFrameSource?,
+    glassTierOverride: String? = null,
+) {
     val sessionState by session.state.collectAsState()
     LaunchedEffect(session) { session.connect() }
+
+    // Shared glass state: the active tier plus the one blurred backdrop
+    // texture every glass pill samples. The frame-clock loop is the perf
+    // safety net — sustained overruns of the 48 ms p90 budget drop one tier
+    // (FULL → BLUR → FLAT) and stop the backdrop work with it.
+    val glass = remember {
+        MonitorGlass(resolveTier(android.os.Build.VERSION.SDK_INT, glassTierOverride))
+    }
+    LaunchedEffect(glass) {
+        val budget = FrameBudgetWindow()
+        var last = 0L
+        while (glass.tier != GlassTier.FLAT) {
+            withFrameNanos { now ->
+                if (last != 0L && budget.frame(now - last)) glass.demote()
+                last = now
+            }
+        }
+    }
 
     // Shell state, iOS-model-equivalent: DISP index (0 live, 1 clean), the
     // interface lock, the record toggle, and the fake-clock timecode tick.
@@ -289,10 +317,29 @@ fun MonitorScreen(session: CameraSession, frameSource: LiveFrameSource?) {
             }
         val isClean = dispIndex == 1
 
+        // Backdrop geometry for the glass pipeline: the viewport and the feed
+        // zone in root px. The blurred texture covers the whole viewport
+        // (black letterbox included), so pills over black sample the same
+        // map. setLayout is idempotent per geometry, so calling it on every
+        // recomposition is free.
+        with(density) {
+            glass.backdrop.setLayout(
+                rootWidthPx = constraints.maxWidth.toFloat(),
+                rootHeightPx = constraints.maxHeight.toFloat(),
+                feedRectPx =
+                    android.graphics.RectF(
+                        zones.feed.x.dp.toPx(),
+                        zones.feed.y.dp.toPx(),
+                        (zones.feed.x + zones.feed.width).dp.toPx(),
+                        (zones.feed.y + zones.feed.height).dp.toPx(),
+                    ),
+            )
+        }
+
         // Feed at the zone map's feed frame; LiveFeedView aspect-fits within it.
         Box(Modifier.zone(zones.feed), contentAlignment = Alignment.Center) {
             if (frameSource != null) {
-                LiveFeedView(frameSource, Modifier.fillMaxSize())
+                LiveFeedView(frameSource, Modifier.fillMaxSize(), onFrame = glass::submit)
             } else {
                 Text(
                     text =
@@ -307,60 +354,62 @@ fun MonitorScreen(session: CameraSession, frameSource: LiveFrameSource?) {
             }
         }
 
-        // Top info pill, centered in the deck band; compact in clean mode.
-        // The deck is feed-anchored and the synthesized island lane (see
-        // monitorLeadingInsetDp) starts the feed right of the lock, so the
-        // band always clears it — same as iPhone geometry.
-        Box(Modifier.zone(zones.infoBar), contentAlignment = Alignment.Center) {
-            FitScale(zones.infoBar.width.dp) {
-                InfoPill(compact = isClean, recording = recording, frameCount = frameCount)
-            }
-        }
-
-        // Bottom capture strip — live mode only, dimmed while locked; the
-        // glass hugs its readouts against the band's trailing edge like the
-        // iOS content-hugging strip. The assist toolbar zone to its left is
-        // deferred (v1 skips assists).
-        if (!isClean) {
-            zones.captureStrip?.let { strip ->
-                Box(
-                    Modifier.zone(strip).alpha(if (locked) 0.4f else 1f),
-                    contentAlignment = Alignment.CenterEnd,
-                ) {
-                    FitScale(strip.width.dp) { CaptureStrip() }
+        CompositionLocalProvider(LocalMonitorGlass provides glass) {
+            // Top info pill, centered in the deck band; compact in clean mode.
+            // The deck is feed-anchored and the synthesized island lane (see
+            // monitorLeadingInsetDp) starts the feed right of the lock, so the
+            // band always clears it — same as iPhone geometry.
+            Box(Modifier.zone(zones.infoBar), contentAlignment = Alignment.Center) {
+                FitScale(zones.infoBar.width.dp) {
+                    InfoPill(compact = isClean, recording = recording, frameCount = frameCount)
                 }
             }
-        }
 
-        // Side rails: lock + battery indicators + record / DISP / media / settings.
-        LockButton(locked, Modifier.zone(zones.lock)) { locked = !locked }
-        zones.batteryPhone?.let {
-            BatteryIndicatorColumn(
-                percent = DemoMonitorState.PHONE_BATTERY,
-                isCamera = false,
-                modifier = Modifier.zone(it),
-            )
-        }
-        zones.batteryCamera?.let {
-            BatteryIndicatorColumn(
-                percent = DemoMonitorState.CAMERA_BATTERY,
-                isCamera = true,
-                modifier = Modifier.zone(it),
-            )
-        }
-        AuxCircleButton(Modifier.zone(zones.settings)) { glyphModifier, tint ->
-            GearGlyph(tint, glyphModifier)
-        }
-        AuxCircleButton(Modifier.zone(zones.media)) { glyphModifier, tint ->
-            MediaStackGlyph(tint, glyphModifier)
-        }
-        RecordButton(recording, Modifier.zone(zones.record)) { recording = !recording }
-        DispButton(
-            activeIndex = dispIndex,
-            modeCount = 3, // Live / Clean / Command dashes, matching iOS; Command lands later.
-            modifier = Modifier.zone(zones.disp),
-        ) {
-            dispIndex = (dispIndex + 1) % 2
+            // Bottom capture strip — live mode only, dimmed while locked; the
+            // glass hugs its readouts against the band's trailing edge like the
+            // iOS content-hugging strip. The assist toolbar zone to its left is
+            // deferred (v1 skips assists).
+            if (!isClean) {
+                zones.captureStrip?.let { strip ->
+                    Box(
+                        Modifier.zone(strip).alpha(if (locked) 0.4f else 1f),
+                        contentAlignment = Alignment.CenterEnd,
+                    ) {
+                        FitScale(strip.width.dp) { CaptureStrip() }
+                    }
+                }
+            }
+
+            // Side rails: lock + battery indicators + record / DISP / media / settings.
+            LockButton(locked, Modifier.zone(zones.lock)) { locked = !locked }
+            zones.batteryPhone?.let {
+                BatteryIndicatorColumn(
+                    percent = DemoMonitorState.PHONE_BATTERY,
+                    isCamera = false,
+                    modifier = Modifier.zone(it),
+                )
+            }
+            zones.batteryCamera?.let {
+                BatteryIndicatorColumn(
+                    percent = DemoMonitorState.CAMERA_BATTERY,
+                    isCamera = true,
+                    modifier = Modifier.zone(it),
+                )
+            }
+            AuxCircleButton(Modifier.zone(zones.settings)) { glyphModifier, tint ->
+                GearGlyph(tint, glyphModifier)
+            }
+            AuxCircleButton(Modifier.zone(zones.media)) { glyphModifier, tint ->
+                MediaStackGlyph(tint, glyphModifier)
+            }
+            RecordButton(recording, Modifier.zone(zones.record)) { recording = !recording }
+            DispButton(
+                activeIndex = dispIndex,
+                modeCount = 3, // Live / Clean / Command dashes, matching iOS; Command lands later.
+                modifier = Modifier.zone(zones.disp),
+            ) {
+                dispIndex = (dispIndex + 1) % 2
+            }
         }
 
         // Recording tally border at the physical edge (iOS `RecordingBorderModule`).

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
@@ -126,7 +126,11 @@ private tailrec fun android.content.Context.findActivity(): android.app.Activity
  * scopes, pickers/panels, portrait.
  */
 @Composable
-fun MonitorScreen(session: CameraSession, frameSource: LiveFrameSource?) {
+fun MonitorScreen(
+    session: CameraSession,
+    frameSource: LiveFrameSource?,
+    scopeKind: ScopeKind? = null,
+) {
     val sessionState by session.state.collectAsState()
     LaunchedEffect(session) { session.connect() }
 
@@ -281,7 +285,7 @@ fun MonitorScreen(session: CameraSession, frameSource: LiveFrameSource?) {
                         mode = dispIndex,
                         isPortrait = false,
                         aspectFill = false,
-                        scopeCount = 0,
+                        scopeCount = if (scopeKind != null) 1 else 0,
                         mirrored = false,
                         bottomBarHeight = LiveDesign.CONTROL_HEIGHT_DP,
                     ),
@@ -361,6 +365,20 @@ fun MonitorScreen(session: CameraSession, frameSource: LiveFrameSource?) {
             modifier = Modifier.zone(zones.disp),
         ) {
             dispIndex = (dispIndex + 1) % 2
+        }
+
+        // Scopes v1: one debug-selected scope (`--es zc.scopes`), mounted at the
+        // zone map's scopes zone when the core emits one; the landscape map
+        // floats scopes over the feed (like iOS), so it falls back to the
+        // iOS-parity floating frame.
+        if (scopeKind != null && frameSource != null) {
+            ScopePanel(
+                scopeKind,
+                frameSource,
+                Modifier.zone(
+                    zones.scopes ?: floatingScopeFrame(scopeKind, zones.feed, zones.infoBar),
+                ),
+            )
         }
 
         // Recording tally border at the physical edge (iOS `RecordingBorderModule`).

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/ScopeView.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/ScopeView.kt
@@ -1,0 +1,701 @@
+package com.opencapture.openzcine
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.BlendMode
+import android.graphics.Paint
+import android.graphics.Typeface
+import android.util.Log
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import com.opencapture.openzcine.bridge.ScopeAnchors
+import com.opencapture.openzcine.bridge.ScopeTraces
+import com.opencapture.openzcine.bridge.SwiftCore
+import com.opencapture.openzcine.bridge.ZoneFrame
+import com.opencapture.openzcine.core.LiveFrame
+import java.nio.ByteBuffer
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.math.cos
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+import kotlin.math.sin
+import kotlin.math.sqrt
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+private const val TAG = "ZCScope"
+
+/** Wire ordinal for RED Log3G10 — the ZR live-view default and iOS fallback curve. */
+private const val CURVE_LOG3G10 = 0
+
+/** Scope refresh period — ~10 Hz, timer-driven on an absolute schedule. */
+private const val SCOPE_PERIOD_NANOS = 100_000_000L
+
+/** Widest reduction frame handed to the core sampler (1280→160, 1024→128). */
+private const val REDUCTION_MAX_WIDTH = 160
+
+/**
+ * The four v1 scopes, selectable through the debug intent
+ * `--es zc.scopes wave|parade|histo|vector` (the real scope picker is chrome
+ * work, out of scope here).
+ */
+enum class ScopeKind(val token: String, val title: String, val chip: String) {
+    WAVEFORM("wave", "WAVE", "LUMA"),
+    PARADE("parade", "PARADE", "RGB"),
+    HISTOGRAM("histo", "HISTO", "RGBL"),
+    VECTORSCOPE("vector", "VECTOR", "MON · 1X"),
+    ;
+
+    companion object {
+        /** Parses an intent token; null for absent/unknown values. */
+        fun fromToken(value: String?): ScopeKind? = entries.firstOrNull { it.token == value }
+    }
+}
+
+/**
+ * Default frame for the floating scope panel, mirroring the iOS landscape
+ * `MovablePanel` sizes anchored inside the feed's top-leading corner, below
+ * the info deck (the landscape zone map carries no scopes zone — scopes float
+ * over the feed on both platforms).
+ */
+// ponytail: fixed top-leading anchor for the single debug scope; per-kind iOS
+// default corners + dragging arrive with the real scope-picker chrome.
+fun floatingScopeFrame(kind: ScopeKind, feed: ZoneFrame, infoBar: ZoneFrame): ZoneFrame {
+    val (width, height) =
+        when (kind) {
+            ScopeKind.WAVEFORM, ScopeKind.PARADE -> 250f to 153f
+            ScopeKind.HISTOGRAM -> 250f to 77f
+            ScopeKind.VECTORSCOPE -> 190f to 190f
+        }
+    return ZoneFrame(feed.x + 12f, infoBar.y + infoBar.height + 8f, width, height)
+}
+
+// ── Scope palette (iOS MonitorOverlays.swift `ScopePalette`, values 1:1) ──
+
+private fun rgba(r: Int, g: Int, b: Int, a: Float) = Color(r / 255f, g / 255f, b / 255f, a)
+
+private object ScopePalette {
+    val lumaGhost = rgba(182, 190, 186, 0.08f)
+    val luma = rgba(222, 230, 224, 1.0f)
+    val lumaHot = rgba(255, 255, 255, 1.0f)
+    val paradeRed = rgba(255, 86, 78, 1.0f)
+    val paradeGreen = rgba(102, 232, 132, 1.0f)
+    val paradeBlue = rgba(92, 156, 255, 1.0f)
+    val boundary = rgba(220, 235, 225, 0.8f)
+    val clip = rgba(255, 150, 142, 0.8f)
+    val middle = rgba(246, 241, 226, 0.8f)
+    val graticule = rgba(220, 235, 225, 0.55f)
+    val graticuleFaint = rgba(220, 235, 225, 0.30f)
+    val histogramRedFill = rgba(255, 48, 44, 0.17f)
+    val histogramGreenFill = rgba(0, 238, 70, 0.15f)
+    val histogramBlueFill = rgba(45, 76, 255, 0.19f)
+    val histogramRedStroke = rgba(255, 48, 44, 0.96f)
+    val histogramGreenStroke = rgba(0, 238, 70, 0.92f)
+    val histogramBlueStroke = rgba(45, 76, 255, 0.94f)
+    val histogramLumaStroke = rgba(245, 242, 232, 0.58f)
+    val panelBackground = Color(0.025f, 0.036f, 0.03f, 0.72f)
+
+    /** Phosphor persistence: the previous tick draws first at this opacity. */
+    const val TRAIL_DECAY = 0.35f
+}
+
+// ── Tick payload ──
+
+/** One presented scope tick: the current payload plus the previous one (trail). */
+private class ScopeDrawData(
+    val traces: ScopeTraces? = null,
+    val trailTraces: ScopeTraces? = null,
+    /** Blended + smoothed display bins per channel (histogram kind only). */
+    val histogram: HistogramDisplay? = null,
+    val vector: ImageBitmap? = null,
+    val vectorTrail: ImageBitmap? = null,
+)
+
+private class HistogramDisplay(
+    val luma: FloatArray,
+    val red: FloatArray,
+    val green: FloatArray,
+    val blue: FloatArray,
+    val peak: Float,
+)
+
+// ── Panel ──
+
+/**
+ * One scope panel — waveform, RGB parade, histogram, or vectorscope — fed by
+ * the live JPEG stream at ~10 Hz. All axis/curve math comes from the Swift
+ * core over the facade ([SwiftCore.scopeTraces] / [SwiftCore.scopeVector] /
+ * [SwiftCore.scopeAnchors]); this composable only reduces the frame and draws.
+ */
+@Composable
+fun ScopePanel(kind: ScopeKind, source: com.opencapture.openzcine.core.LiveFrameSource, modifier: Modifier = Modifier) {
+    val anchors = remember { ScopeAnchors.parse(SwiftCore.scopeAnchors(CURVE_LOG3G10)) }
+    val data = remember { mutableStateOf<ScopeDrawData?>(null) }
+
+    LaunchedEffect(source, kind) {
+        withContext(Dispatchers.Default) {
+            pumpScope(source.frames, kind) { data.value = it }
+        }
+    }
+
+    Box(
+        modifier
+            .background(ScopePalette.panelBackground, ChromeShape)
+            .border(1.dp, LiveDesign.hairline, ChromeShape),
+    ) {
+        Canvas(Modifier.fillMaxSize()) { drawScope(kind, anchors, data.value) }
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 8.dp).padding(top = 4.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                kind.title,
+                style = chromeStyle(10.5f, FontWeight.Bold, mono = true),
+                color = LiveDesign.text.copy(alpha = 0.66f),
+                maxLines = 1,
+            )
+            Text(
+                kind.chip,
+                style = chromeStyle(9.5f, FontWeight.Bold, mono = true),
+                color = LiveDesign.text.copy(alpha = 0.58f),
+                maxLines = 1,
+            )
+        }
+    }
+}
+
+// ── Pump: absolute-schedule ~10 Hz reduction ──
+
+/**
+ * Decodes the live JPEG at 1/8-class resolution and drives one scope tick
+ * through the facade every [SCOPE_PERIOD_NANOS].
+ *
+ * Cadence is timer-driven against an absolute schedule (`start + n·period`) —
+ * NEVER an `elapsed >= interval` gate against the frame stream, which only
+ * ever locks onto integer divisions of the source rate (the repo's wall-clock
+ * aliasing scar, fixed 4ae1544 on iOS). A tick that finds no new frame skips
+ * the work and keeps the schedule.
+ */
+private suspend fun pumpScope(
+    frames: Flow<LiveFrame>,
+    kind: ScopeKind,
+    present: (ScopeDrawData) -> Unit,
+): Unit = coroutineScope {
+    val latest = AtomicReference<ByteArray?>(null)
+    launch { frames.collect { latest.set(it.jpegData) } }
+
+    val tap = ScopeFrameTap()
+    val stats = ScopeTickStats { if (BuildConfig.DEBUG) Log.d(TAG, it) }
+    val vectorBitmaps = VectorBitmapRing()
+    var lastProcessed: ByteArray? = null
+    var previousTraces: ScopeTraces? = null
+    var previousHistogram: ScopeTraces? = null
+    var previousVector: ImageBitmap? = null
+    val startNanos = System.nanoTime()
+    var tick = 0L
+    while (true) {
+        tick = max(tick + 1, (System.nanoTime() - startNanos) / SCOPE_PERIOD_NANOS)
+        val waitMillis = (startNanos + tick * SCOPE_PERIOD_NANOS - System.nanoTime()) / 1_000_000
+        if (waitMillis > 0) delay(waitMillis)
+
+        val jpeg = latest.get() ?: continue
+        if (jpeg === lastProcessed) continue // static feed — hold the trace
+        lastProcessed = jpeg
+
+        val tickStart = System.nanoTime()
+        val reduced = tap.reduce(jpeg) ?: continue
+        when (kind) {
+            ScopeKind.WAVEFORM, ScopeKind.PARADE -> {
+                val traces =
+                    ScopeTraces.parse(
+                        SwiftCore.scopeTraces(
+                            reduced.rgba, reduced.width, reduced.height,
+                            reduced.bytesPerRow, CURVE_LOG3G10,
+                        ),
+                    )
+                present(ScopeDrawData(traces = traces, trailTraces = previousTraces))
+                previousTraces = traces
+            }
+            ScopeKind.HISTOGRAM -> {
+                val traces =
+                    ScopeTraces.parse(
+                        SwiftCore.scopeTraces(
+                            reduced.rgba, reduced.width, reduced.height,
+                            reduced.bytesPerRow, CURVE_LOG3G10,
+                        ),
+                    )
+                present(ScopeDrawData(histogram = histogramDisplay(traces, previousHistogram)))
+                previousHistogram = traces
+            }
+            ScopeKind.VECTORSCOPE -> {
+                val pixels =
+                    SwiftCore.scopeVector(
+                        reduced.rgba, reduced.width, reduced.height,
+                        reduced.bytesPerRow, CURVE_LOG3G10,
+                    )
+                val image = vectorBitmaps.imageFrom(pixels)
+                present(ScopeDrawData(vector = image, vectorTrail = previousVector))
+                previousVector = image
+            }
+        }
+        stats.tickCompleted(System.nanoTime() - tickStart, System.nanoTime())
+    }
+}
+
+/** One reduced frame ready for the core sampler. */
+private class ReducedFrame(
+    val rgba: ByteArray,
+    val width: Int,
+    val height: Int,
+    val bytesPerRow: Int,
+)
+
+/**
+ * JPEG → small RGBA reduction, allocation-free in steady state: the JPEG is
+ * decoded straight at 1/2ⁿ scale (`inSampleSize` — the DCT-domain fast path,
+ * far cheaper than full decode + rescale, and independent of the feed
+ * renderer's bitmap ring, so a tick can never observe a torn frame) into one
+ * reused mutable bitmap, then copied into a reused RGBA byte array.
+ */
+private class ScopeFrameTap {
+    private val boundsOptions = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    private val options = BitmapFactory.Options().apply { inMutable = true }
+    private var bitmap: Bitmap? = null
+    private var rgba = ByteArray(0)
+
+    fun reduce(jpeg: ByteArray): ReducedFrame? {
+        BitmapFactory.decodeByteArray(jpeg, 0, jpeg.size, boundsOptions)
+        if (boundsOptions.outWidth <= 0) return null
+        var sample = 1
+        while (boundsOptions.outWidth / sample > REDUCTION_MAX_WIDTH) sample *= 2
+        options.inSampleSize = sample
+        options.inBitmap = bitmap
+        val decoded =
+            try {
+                BitmapFactory.decodeByteArray(jpeg, 0, jpeg.size, options)
+            } catch (_: IllegalArgumentException) {
+                // Pooled bitmap incompatible (feed size changed) — decode fresh.
+                options.inBitmap = null
+                BitmapFactory.decodeByteArray(jpeg, 0, jpeg.size, options)
+            } ?: return null
+        bitmap = decoded
+        val byteCount = decoded.rowBytes * decoded.height
+        if (rgba.size != byteCount) rgba = ByteArray(byteCount)
+        decoded.copyPixelsToBuffer(ByteBuffer.wrap(rgba))
+        return ReducedFrame(rgba, decoded.width, decoded.height, decoded.rowBytes)
+    }
+}
+
+/**
+ * Ring of reused 128×128 bitmaps for the vectorscope density image — 3 deep so
+ * the bitmap being written is never one the RenderThread may still read
+ * (current frame + trail), mirroring [JpegFrameDecoder]'s ring rationale.
+ */
+private class VectorBitmapRing {
+    private val pool = arrayOfNulls<Bitmap>(3)
+    private var next = 0
+
+    fun imageFrom(premultipliedRgba: ByteArray): ImageBitmap? {
+        if (premultipliedRgba.isEmpty()) return null
+        val side = sqrt(premultipliedRgba.size / 4.0).toInt()
+        var bitmap = pool[next]
+        if (bitmap == null || bitmap.width != side) {
+            bitmap = Bitmap.createBitmap(side, side, Bitmap.Config.ARGB_8888)
+            pool[next] = bitmap
+        }
+        bitmap.copyPixelsFromBuffer(ByteBuffer.wrap(premultipliedRgba))
+        next = (next + 1) % pool.size
+        return bitmap.asImageBitmap()
+    }
+}
+
+/** `0.65·current + 0.35·previous` display-bin blend, then a radius-2 box smooth (iOS parity). */
+private fun histogramDisplay(current: ScopeTraces, previous: ScopeTraces?): HistogramDisplay {
+    fun channel(now: FloatArray, before: FloatArray?): FloatArray {
+        val blended =
+            if (before == null || before.size != now.size) {
+                now
+            } else {
+                FloatArray(now.size) { now[it] * 0.65f + before[it] * 0.35f }
+            }
+        val smoothed = FloatArray(blended.size)
+        for (index in blended.indices) {
+            val lower = max(0, index - 2)
+            val upper = min(blended.size - 1, index + 2)
+            var sum = 0f
+            for (i in lower..upper) sum += blended[i]
+            smoothed[index] = sum / (upper - lower + 1)
+        }
+        return smoothed
+    }
+    val luma = channel(current.histogramLuma, previous?.histogramLuma)
+    val red = channel(current.histogramRed, previous?.histogramRed)
+    val green = channel(current.histogramGreen, previous?.histogramGreen)
+    val blue = channel(current.histogramBlue, previous?.histogramBlue)
+    val peak = max(max(luma.max(), red.max()), max(max(green.max(), blue.max()), 1f))
+    return HistogramDisplay(luma, red, green, blue, peak)
+}
+
+/** ~10 Hz cadence accounting: achieved rate plus per-tick cost every 5 s. */
+private class ScopeTickStats(private val log: (String) -> Unit) {
+    private var ticks = 0L
+    private var totalNanos = 0L
+    private var maxNanos = 0L
+    private var windowStart = 0L
+
+    fun tickCompleted(costNanos: Long, nowNanos: Long) {
+        if (windowStart == 0L) windowStart = nowNanos
+        ticks++
+        totalNanos += costNanos
+        maxNanos = max(maxNanos, costNanos)
+        val elapsed = nowNanos - windowStart
+        if (elapsed < 5_000_000_000L) return
+        log(
+            "scope pacing: %.1f Hz | tick avg %.1f ms max %.1f ms"
+                .format(ticks * 1e9 / elapsed, totalNanos / ticks / 1e6, maxNanos / 1e6),
+        )
+        ticks = 0
+        totalNanos = 0
+        maxNanos = 0
+        windowStart = nowNanos
+    }
+}
+
+// ── Drawing ──
+
+/** iOS `scopePlotRect`: 6pt side insets, 26pt title clearance, 8pt bottom. */
+private fun DrawScope.plotRect(): Rect =
+    Rect(
+        6.dp.toPx(),
+        26.dp.toPx(),
+        size.width - 6.dp.toPx(),
+        size.height - 8.dp.toPx(),
+    )
+
+/** iOS `scopeLevelY`: display level 0…1 to y, with the 4% top/bottom buffer. */
+private fun levelY(level: Float, plot: Rect): Float =
+    plot.bottom - (0.04f + level * 0.92f) * plot.height
+
+private fun DrawScope.drawScope(kind: ScopeKind, anchors: ScopeAnchors, data: ScopeDrawData?) {
+    val plot = plotRect()
+    when (kind) {
+        ScopeKind.WAVEFORM, ScopeKind.PARADE -> {
+            data?.trailTraces?.let { drawTrace(kind, it, plot, ScopePalette.TRAIL_DECAY) }
+            data?.traces?.let { drawTrace(kind, it, plot, 1f) }
+            drawAxisGuides(anchors, plot)
+        }
+        ScopeKind.HISTOGRAM -> {
+            data?.histogram?.let { drawHistogram(it, plot) }
+            drawHistogramGuides(anchors, plot)
+        }
+        ScopeKind.VECTORSCOPE -> {
+            val side = min(plot.width, plot.height)
+            val square =
+                Rect(
+                    plot.center.x - side / 2, plot.center.y - side / 2,
+                    plot.center.x + side / 2, plot.center.y + side / 2,
+                )
+            data?.vectorTrail?.let { drawVectorDensity(it, square, ScopePalette.TRAIL_DECAY) }
+            data?.vector?.let { drawVectorDensity(it, square, 1f) }
+            drawVectorGraticule(anchors, square)
+        }
+    }
+}
+
+// Waveform / parade points render through the native canvas: one batched
+// `drawPoints(FloatArray)` per pass over a reused scratch array — no per-point
+// object allocation (the Compose `drawPoints(List<Offset>)` overload boxes).
+private val pointScratch = ThreadLocal.withInitial { FloatArray(0) }
+
+private fun DrawScope.drawPointPass(
+    xy: FloatArray,
+    count: Int,
+    color: Color,
+    widthPx: Float,
+    opacity: Float,
+) {
+    if (count == 0) return
+    drawIntoCanvas { canvas ->
+        val paint = Paint()
+        paint.isAntiAlias = false
+        paint.strokeCap = Paint.Cap.SQUARE
+        paint.strokeWidth = widthPx
+        paint.blendMode = BlendMode.PLUS
+        paint.color =
+            android.graphics.Color.argb(
+                (color.alpha * opacity * 255).roundToInt(),
+                (color.red * 255).roundToInt(),
+                (color.green * 255).roundToInt(),
+                (color.blue * 255).roundToInt(),
+            )
+        canvas.nativeCanvas.drawPoints(xy, 0, count * 2, paint)
+    }
+}
+
+/** Fills the scratch array with plot-space positions for one channel. */
+private fun fillChannel(
+    traces: ScopeTraces,
+    channelOffset: Int,
+    plot: Rect,
+    laneOrigin: Float,
+    laneWidth: Float,
+    out: FloatArray,
+): Int {
+    val stride = ScopeTraces.POINT_STRIDE
+    for (index in 0 until traces.pointCount) {
+        val x = traces.points[index * stride]
+        val level = traces.points[index * stride + channelOffset]
+        out[index * 2] = laneOrigin + x * laneWidth
+        out[index * 2 + 1] = levelY(level, plot)
+    }
+    return traces.pointCount
+}
+
+private fun DrawScope.drawTrace(kind: ScopeKind, traces: ScopeTraces, plot: Rect, opacity: Float) {
+    if (traces.pointCount == 0) return
+    var scratch = pointScratch.get()
+    if (scratch.size < traces.pointCount * 2) {
+        scratch = FloatArray(traces.pointCount * 2)
+        pointScratch.set(scratch)
+    }
+    when (kind) {
+        ScopeKind.WAVEFORM -> {
+            // Luma trace: 2px additive ghost + 1px core, brighter every 4th dot.
+            val count = fillChannel(traces, 1, plot, plot.left, plot.width, scratch)
+            drawPointPass(scratch, count, ScopePalette.lumaGhost, 2.dp.toPx(), opacity)
+            drawPointPass(scratch, count, ScopePalette.luma, 1.dp.toPx(), opacity)
+            var hot = 0
+            for (index in 0 until count step 4) {
+                scratch[hot * 2] = scratch[index * 2]
+                scratch[hot * 2 + 1] = scratch[index * 2 + 1]
+                hot++
+            }
+            drawPointPass(scratch, hot, ScopePalette.lumaHot, 1.dp.toPx(), opacity)
+        }
+        ScopeKind.PARADE -> {
+            val laneWidth = plot.width / 3
+            val lanes =
+                listOf(
+                    Pair(2, ScopePalette.paradeRed),
+                    Pair(3, ScopePalette.paradeGreen),
+                    Pair(4, ScopePalette.paradeBlue),
+                )
+            for ((laneIndex, lane) in lanes.withIndex()) {
+                val origin = plot.left + laneIndex * laneWidth
+                val count = fillChannel(traces, lane.first, plot, origin, laneWidth - 1, scratch)
+                drawPointPass(scratch, count, lane.second, 1.dp.toPx(), opacity)
+            }
+        }
+        else -> Unit
+    }
+}
+
+/** Boundary lines (code 0/255) plus the three fixed anchor lines. */
+private fun DrawScope.drawAxisGuides(anchors: ScopeAnchors, plot: Rect) {
+    val dashed = PathEffect.dashPathEffect(floatArrayOf(4.dp.toPx(), 4.dp.toPx()))
+    fun line(level: Float, color: Color, width: Float, effect: PathEffect? = null) {
+        val y = levelY(level, plot)
+        drawLine(
+            color, Offset(plot.left, y), Offset(plot.right, y),
+            strokeWidth = width, pathEffect = effect,
+        )
+    }
+    line(0f, ScopePalette.boundary, 1.25.dp.toPx())
+    line(1f, ScopePalette.boundary, 1.25.dp.toPx())
+    line(anchors.clipLine, ScopePalette.clip, 1.dp.toPx(), dashed)
+    line(anchors.midGray, ScopePalette.middle, 1.dp.toPx())
+    line(anchors.crushLine, ScopePalette.clip, 1.dp.toPx(), dashed)
+}
+
+private fun DrawScope.drawHistogram(display: HistogramDisplay, plot: Rect) {
+    fun channel(bins: FloatArray, fill: Color, stroke: Color, strokeWidth: Float) {
+        val path = histogramPath(bins, plot, display.peak, closed = true)
+        drawPath(path, fill, alpha = 0.92f, blendMode = androidx.compose.ui.graphics.BlendMode.Plus)
+        val outline = histogramPath(bins, plot, display.peak, closed = false)
+        drawPath(
+            outline, stroke, alpha = 0.92f,
+            style = Stroke(strokeWidth, cap = androidx.compose.ui.graphics.StrokeCap.Round),
+            blendMode = androidx.compose.ui.graphics.BlendMode.Plus,
+        )
+    }
+    channel(display.red, ScopePalette.histogramRedFill, ScopePalette.histogramRedStroke, 1.8.dp.toPx())
+    channel(display.green, ScopePalette.histogramGreenFill, ScopePalette.histogramGreenStroke, 1.8.dp.toPx())
+    channel(display.blue, ScopePalette.histogramBlueFill, ScopePalette.histogramBlueStroke, 1.8.dp.toPx())
+    // Luma: dim outline only (a fill washed mid-tones white on iOS).
+    drawPath(
+        histogramPath(display.luma, plot, display.peak, closed = false),
+        ScopePalette.histogramLumaStroke,
+        alpha = 0.58f,
+        style = Stroke(1.4.dp.toPx(), cap = androidx.compose.ui.graphics.StrokeCap.Round),
+    )
+}
+
+/** Smoothed contour over the display bins (quadratic midpoints, iOS `histogramPaths`). */
+private fun histogramPath(bins: FloatArray, plot: Rect, peak: Float, closed: Boolean): Path {
+    val path = Path()
+    fun x(index: Int) = plot.left + index.toFloat() / (bins.size - 1) * plot.width
+    fun y(index: Int) = plot.bottom - bins[index] / peak * plot.height
+    if (closed) {
+        path.moveTo(plot.left, plot.bottom)
+        path.lineTo(x(0), y(0))
+    } else {
+        path.moveTo(x(0), y(0))
+    }
+    for (index in 1 until bins.size) {
+        val midX = (x(index - 1) + x(index)) / 2
+        val midY = (y(index - 1) + y(index)) / 2
+        path.quadraticTo(x(index - 1), y(index - 1), midX, midY)
+    }
+    path.quadraticTo(x(bins.size - 2), y(bins.size - 2), x(bins.size - 1), y(bins.size - 1))
+    if (closed) {
+        path.lineTo(plot.right, plot.bottom)
+        path.close()
+    }
+    return path
+}
+
+/** Quarter grid, 0/255 boundaries, and the three anchors as vertical lines. */
+private fun DrawScope.drawHistogramGuides(anchors: ScopeAnchors, plot: Rect) {
+    for (step in 1..3) {
+        val y = plot.top + plot.height * step / 4
+        drawLine(rgba(220, 235, 225, 0.06f), Offset(plot.left, y), Offset(plot.right, y), 1.dp.toPx())
+    }
+    fun vertical(fraction: Float, color: Color, width: Float, effect: PathEffect? = null) {
+        val x = plot.left + fraction * plot.width
+        drawLine(color, Offset(x, plot.top), Offset(x, plot.bottom), width, pathEffect = effect)
+    }
+    vertical(0f, ScopePalette.boundary, 1.25.dp.toPx())
+    vertical(1f, ScopePalette.boundary, 1.25.dp.toPx())
+    val dashed = PathEffect.dashPathEffect(floatArrayOf(4.dp.toPx(), 4.dp.toPx()))
+    vertical(anchors.crushLine, ScopePalette.clip, 1.dp.toPx(), dashed)
+    vertical(anchors.midGray, ScopePalette.middle, 1.dp.toPx())
+    vertical(anchors.clipLine, ScopePalette.clip, 1.dp.toPx(), dashed)
+}
+
+/**
+ * Blits the 128×128 density image into the square trace rect. The bilinear
+ * upscale melts bins into soft blobs (approximating the iOS Gaussian pass);
+ * a second crisp low-alpha draw keeps small saturated features locatable.
+ */
+private fun DrawScope.drawVectorDensity(image: ImageBitmap, square: Rect, opacity: Float) {
+    val dstOffset = IntOffset(square.left.roundToInt(), square.top.roundToInt())
+    val dstSize = IntSize(square.width.roundToInt(), square.height.roundToInt())
+    drawImage(
+        image,
+        srcOffset = IntOffset.Zero,
+        srcSize = IntSize(image.width, image.height),
+        dstOffset = dstOffset,
+        dstSize = dstSize,
+        alpha = opacity,
+        blendMode = androidx.compose.ui.graphics.BlendMode.Plus,
+    )
+    drawImage(
+        image,
+        srcOffset = IntOffset.Zero,
+        srcSize = IntSize(image.width, image.height),
+        dstOffset = dstOffset,
+        dstSize = dstSize,
+        alpha = 0.35f * opacity,
+        blendMode = androidx.compose.ui.graphics.BlendMode.Plus,
+    )
+}
+
+/**
+ * Vectorscope graticule: outer ring, centre crosshair, the dashed I-phase
+ * skin-tone line at 123°, and the six 75% targets at the core-supplied CbCr
+ * positions ([ScopeAnchors.vectorTargets] — trace and graticule can never
+ * disagree about the matrix).
+ */
+private fun DrawScope.drawVectorGraticule(anchors: ScopeAnchors, square: Rect) {
+    val centre = square.center
+    val radius = square.width / 2
+    drawCircle(ScopePalette.graticule, radius, centre, style = Stroke(1.25.dp.toPx()))
+    val cross = 8.dp.toPx()
+    drawLine(
+        ScopePalette.graticuleFaint,
+        Offset(centre.x - cross, centre.y), Offset(centre.x + cross, centre.y), 1.dp.toPx(),
+    )
+    drawLine(
+        ScopePalette.graticuleFaint,
+        Offset(centre.x, centre.y - cross), Offset(centre.x, centre.y + cross), 1.dp.toPx(),
+    )
+    val skinAngle = Math.toRadians(123.0)
+    drawLine(
+        ScopePalette.middle,
+        centre,
+        Offset(
+            centre.x + (cos(skinAngle) * radius * 0.92).toFloat(),
+            centre.y - (sin(skinAngle) * radius * 0.92).toFloat(),
+        ),
+        1.dp.toPx(),
+        pathEffect = PathEffect.dashPathEffect(floatArrayOf(4.dp.toPx(), 4.dp.toPx())),
+    )
+    val labels = listOf("R", "Mg", "B", "Cy", "G", "Yl")
+    val boxSide = 7.dp.toPx()
+    drawIntoCanvas { canvas ->
+        val textPaint = Paint(Paint.ANTI_ALIAS_FLAG)
+        textPaint.typeface = Typeface.create(Typeface.MONOSPACE, Typeface.BOLD)
+        textPaint.textSize = 6.5.dp.toPx()
+        textPaint.textAlign = Paint.Align.CENTER
+        textPaint.color = android.graphics.Color.argb(140, 220, 235, 225)
+        for ((index, target) in anchors.vectorTargets.withIndex()) {
+            val point =
+                Offset(
+                    centre.x + target.first * square.width,
+                    centre.y - target.second * square.height,
+                )
+            drawRect(
+                ScopePalette.graticule.copy(alpha = 0.6f),
+                topLeft = Offset(point.x - boxSide / 2, point.y - boxSide / 2),
+                size = Size(boxSide, boxSide),
+                style = Stroke(1.dp.toPx()),
+            )
+            val dx = point.x - centre.x
+            val dy = point.y - centre.y
+            val length = max(1f, sqrt(dx * dx + dy * dy))
+            val push = 10.dp.toPx()
+            canvas.nativeCanvas.drawText(
+                labels[index],
+                point.x + dx / length * push,
+                point.y + dy / length * push + textPaint.textSize / 3,
+                textPaint,
+            )
+        }
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/ScopeWire.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/ScopeWire.kt
@@ -1,0 +1,76 @@
+package com.opencapture.openzcine.bridge
+
+/**
+ * Fixed scope-axis anchors decoded from [SwiftCore.scopeAnchors] — the Kotlin
+ * view of the Swift `ScopeFrameWire.anchors` payload. Levels are display
+ * fractions 0…1 from the plot bottom; the mid-grey anchor is per-curve and
+ * NEVER moves with ISO/exposure (the core pins it — Erik's hard rule).
+ */
+data class ScopeAnchors(
+    val crushLine: Float,
+    val midGray: Float,
+    val clipLine: Float,
+    /** Six 75% colour-bar targets as `(cb, cr)` pairs, each in −0.5…+0.5. */
+    val vectorTargets: List<Pair<Float, Float>>,
+) {
+    companion object {
+        private const val TARGET_COUNT = 6
+
+        /** Decodes the wire array; throws when malformed. */
+        fun parse(flat: FloatArray): ScopeAnchors {
+            require(flat.size == 3 + TARGET_COUNT * 2) { "anchor array length ${flat.size}" }
+            return ScopeAnchors(
+                crushLine = flat[0],
+                midGray = flat[1],
+                clipLine = flat[2],
+                vectorTargets = (0 until TARGET_COUNT).map { Pair(flat[3 + it * 2], flat[4 + it * 2]) },
+            )
+        }
+    }
+}
+
+/**
+ * One scope tick decoded from [SwiftCore.scopeTraces] — the Kotlin view of the
+ * Swift `ScopeFrameWire.traces` payload. Per-point levels and histogram
+ * buckets are already on the anchored display axis; drawing needs no curve
+ * math.
+ */
+class ScopeTraces(
+    val pointCount: Int,
+    /** `pointCount × 5` floats: `x, luma, red, green, blue` per point. */
+    val points: FloatArray,
+    val histogramLuma: FloatArray,
+    val histogramRed: FloatArray,
+    val histogramGreen: FloatArray,
+    val histogramBlue: FloatArray,
+) {
+    companion object {
+        /** Floats per point record — mirrors `ScopeFrameWire.pointStride`. */
+        const val POINT_STRIDE = 5
+
+        /** Display bins per histogram channel — mirrors `ScopeFrameWire.histogramBins`. */
+        const val HISTOGRAM_BINS = 256
+
+        /** Decodes the wire array; throws when malformed. */
+        fun parse(flat: FloatArray): ScopeTraces {
+            require(flat.isNotEmpty()) { "empty scope payload" }
+            val count = flat[0].toInt()
+            val pointsEnd = 1 + count * POINT_STRIDE
+            require(flat.size == pointsEnd + 4 * HISTOGRAM_BINS) {
+                "scope payload length ${flat.size} for $count points"
+            }
+            fun histogram(channel: Int): FloatArray {
+                val start = pointsEnd + channel * HISTOGRAM_BINS
+                return flat.copyOfRange(start, start + HISTOGRAM_BINS)
+            }
+            return ScopeTraces(
+                pointCount = count,
+                points = flat.copyOfRange(1, pointsEnd),
+                histogramLuma = histogram(0),
+                histogramRed = histogram(1),
+                histogramGreen = histogram(2),
+                histogramBlue = histogram(3),
+            )
+        }
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCore.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCore.kt
@@ -73,6 +73,40 @@ object SwiftCore {
      */
     external fun startConnectionDemo(listener: ConnectionPhaseListener)
 
+    // ── Feed effects (colour math baked in the core, uploaded by Kotlin) ──
+
+    /**
+     * A built-in monitor look baked by the core into a packed-2D RGBA8 grid
+     * (`size³ × 4` bytes) for a `width = size²`, `height = size` texture:
+     * pixel `(x = b·size + r, y = g)` — slice tiles along x, so a shader
+     * trilinearly samples with two bilinear taps. Null for an unknown
+     * [lookOrdinal] (`FeedLut.wireOrdinal`) or size outside 2–64. Bake once
+     * per selection (the cube generation is ~10⁵ transcendental calls), never
+     * per frame.
+     */
+    external fun bakeLut(lookOrdinal: Int, size: Int): ByteArray?
+
+    /**
+     * The core's false-colour cube (64³) in the same packed-2D RGBA8 grid.
+     * [scaleOrdinal] is `FeedFalseColorScale.wireOrdinal`; [curveOrdinal]
+     * selects the signal curve (0 = Log3G10, 1 = N-Log). Null for unknown
+     * ordinals.
+     */
+    external fun bakeFalseColorCube(scaleOrdinal: Int, curveOrdinal: Int): ByteArray?
+
+    /**
+     * Assist thresholds on the normalized 0–1 code axis:
+     * `[deLogBlack, deLogClip, zebraHighlight, zebraMidtoneCentre]` — the
+     * peaking de-log anchors and zebra comparison codes, computed by the
+     * core's `ExposureSignalMapping` for [curveOrdinal] and the given
+     * monitor-percent thresholds. Null for an unknown curve ordinal.
+     */
+    external fun feedEffectsScalars(
+        curveOrdinal: Int,
+        zebraHighlightIre: Float,
+        zebraMidtoneIre: Float,
+    ): FloatArray?
+
     // ── Camera session (PTP-IP protocol/session layer in the Swift core) ──
 
     /** Receives session lifecycle callbacks pushed from Swift (non-main thread). */

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCore.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCore.kt
@@ -73,6 +73,47 @@ object SwiftCore {
      */
     external fun startConnectionDemo(listener: ConnectionPhaseListener)
 
+    // ── Scopes (anchored axis math + sampling in the Swift core) ──
+
+    /**
+     * Fixed scope-axis anchors and vectorscope graticule targets for a tone
+     * curve ([curve]: 0 = RED Log3G10, 1 = Nikon N-Log):
+     * `[crushLine, midGrayLevel, clipLine, (cb, cr) × 6 targets]` — see
+     * [ScopeAnchors.parse] and the Swift mirror `ScopeFrameWire.anchors`.
+     * Static per curve; call once.
+     */
+    external fun scopeAnchors(curve: Int): FloatArray
+
+    /**
+     * Samples one downsampled RGBA frame for the waveform / parade /
+     * histogram scopes: `[N, (x, luma, r, g, b) × N, 4 × 256 display bins]`
+     * with all levels already on the core's 3-anchor display axis — see
+     * [ScopeTraces.parse] and the Swift mirror `ScopeFrameWire.traces`.
+     * Blocking (one CPU sampling pass); call from a background dispatcher.
+     */
+    external fun scopeTraces(
+        rgba: ByteArray,
+        width: Int,
+        height: Int,
+        bytesPerRow: Int,
+        curve: Int,
+    ): FloatArray
+
+    /**
+     * Samples one downsampled RGBA frame for the vectorscope: a 128×128
+     * premultiplied-RGBA density image of the BT.709 chroma plane, computed
+     * from the clean points pushed through the core's built-in display tone
+     * map (`ScopeFrameWire.vectorPixels`). Empty when the frame yields no
+     * samples. Blocking; call from a background dispatcher.
+     */
+    external fun scopeVector(
+        rgba: ByteArray,
+        width: Int,
+        height: Int,
+        bytesPerRow: Int,
+        curve: Int,
+    ): ByteArray
+
     // ── Camera session (PTP-IP protocol/session layer in the Swift core) ──
 
     /** Receives session lifecycle callbacks pushed from Swift (non-main thread). */

--- a/Apps/Android/app/src/release/kotlin/com/opencapture/openzcine/DemoHarness.kt
+++ b/Apps/Android/app/src/release/kotlin/com/opencapture/openzcine/DemoHarness.kt
@@ -13,7 +13,14 @@ object DemoHarness {
     /** Never matched in release: the extra is read only by the debug harness. */
     const val EXTRA_DEMO_FEED = "zc.demo.feed"
 
+    /** Never matched in release: the extra is read only by the debug harness. */
+    const val EXTRA_SCOPES = "zc.scopes"
+
     /** Always null: release builds carry no demo frame source. */
     @Suppress("UNUSED_PARAMETER")
     fun demoLiveFeed(intent: Intent): Pair<CameraSession, LiveFrameSource>? = null
+
+    /** Always null: the debug scope toggle does not exist in release builds. */
+    @Suppress("UNUSED_PARAMETER")
+    fun scopeKind(intent: Intent): ScopeKind? = null
 }

--- a/Apps/Android/app/src/release/kotlin/com/opencapture/openzcine/DemoHarness.kt
+++ b/Apps/Android/app/src/release/kotlin/com/opencapture/openzcine/DemoHarness.kt
@@ -16,4 +16,8 @@ object DemoHarness {
     /** Always null: release builds carry no demo frame source. */
     @Suppress("UNUSED_PARAMETER")
     fun demoLiveFeed(intent: Intent): Pair<CameraSession, LiveFrameSource>? = null
+
+    /** Always null: release builds always run the platform-resolved glass tier. */
+    @Suppress("UNUSED_PARAMETER")
+    fun glassTierOverride(intent: Intent): String? = null
 }

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/AssistStateTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/AssistStateTest.kt
@@ -1,0 +1,74 @@
+package com.opencapture.openzcine
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AssistStateTest {
+    @Test
+    fun `lut toggles on with the default look and off again`() {
+        val state = AssistState(FeedEffects.NONE, null)
+        state.toggle(AssistTool.LUT)
+        assertEquals(FeedLut.LOG3G10_709, state.effects.lut)
+        assertTrue(state.isOn(AssistTool.LUT))
+        state.toggle(AssistTool.LUT)
+        assertNull(state.effects.lut)
+        assertTrue(state.effects.isIdentity)
+    }
+
+    @Test
+    fun `false colour replaces the lut and vice versa`() {
+        val state = AssistState(FeedEffects(lut = FeedLut.MONO), null)
+        state.toggle(AssistTool.FALSE)
+        assertNull(state.effects.lut)
+        assertEquals(FeedFalseColorScale.STOPS, state.effects.falseColor)
+        state.toggle(AssistTool.LUT)
+        assertNull(state.effects.falseColor)
+        assertEquals(FeedLut.LOG3G10_709, state.effects.lut)
+    }
+
+    @Test
+    fun `scopes are single-active - another scope switches, same scope clears`() {
+        val state = AssistState(FeedEffects.NONE, null)
+        state.toggle(AssistTool.WAVE)
+        assertEquals(ScopeKind.WAVEFORM, state.scope)
+        state.toggle(AssistTool.VECTOR)
+        assertEquals(ScopeKind.VECTORSCOPE, state.scope)
+        assertFalse(state.isOn(AssistTool.WAVE))
+        state.toggle(AssistTool.VECTOR)
+        assertNull(state.scope)
+    }
+
+    @Test
+    fun `effects state feeds the engine input`() {
+        val state = AssistState(FeedEffects.NONE, null)
+        state.toggle(AssistTool.PEAK)
+        state.toggle(AssistTool.ZEBRA)
+        assertEquals(state.effects, FeedEffectsState.current)
+        assertTrue(FeedEffectsState.current.peaking)
+        assertTrue(FeedEffectsState.current.zebra)
+    }
+
+    @Test
+    fun `every toggle persists, and the token grammar round-trips`() {
+        var savedEffects: FeedEffects? = null
+        var savedScope: ScopeKind? = null
+        val state =
+            AssistState(FeedEffects.NONE, null) { effects, scope ->
+                savedEffects = effects
+                savedScope = scope
+            }
+        state.toggle(AssistTool.LUT)
+        state.toggle(AssistTool.PEAK)
+        state.toggle(AssistTool.HISTO)
+        assertEquals(state.effects, savedEffects)
+        assertEquals(ScopeKind.HISTOGRAM, savedScope)
+
+        // The persisted form is the zc.assist token grammar — parse restores it.
+        val effects = savedEffects!!
+        val restored = AssistState.tokens(effects).let { FeedEffects.parse(it, effects.lut?.id, effects.falseColor?.id) }
+        assertEquals(effects, restored)
+    }
+}

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/FeedEffectsTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/FeedEffectsTest.kt
@@ -1,0 +1,65 @@
+package com.opencapture.openzcine
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class FeedEffectsTest {
+    @Test
+    fun `no extras means the identity feed`() {
+        val effects = FeedEffects.parse(null, null, null)
+        assertEquals(FeedEffects.NONE, effects)
+        assertTrue(effects.isIdentity)
+    }
+
+    @Test
+    fun `parses a combined assist list`() {
+        val effects = FeedEffects.parse("lut,zebra,peaking", null, null)
+        assertEquals(FeedLut.LOG3G10_709, effects.lut)
+        assertNull(effects.falseColor)
+        assertTrue(effects.peaking)
+        assertTrue(effects.zebra)
+        assertFalse(effects.isIdentity)
+    }
+
+    @Test
+    fun `false colour replaces the lut like iOS`() {
+        val effects = FeedEffects.parse("lut,falsecolor", "mono", "ire")
+        assertNull(effects.lut)
+        assertEquals(FeedFalseColorScale.IRE, effects.falseColor)
+    }
+
+    @Test
+    fun `variant ids select looks and scales`() {
+        assertEquals(FeedLut.MONO, FeedEffects.parse("lut", "mono", null).lut)
+        assertEquals(FeedLut.NLOG_709, FeedEffects.parse("lut", "nlog", null).lut)
+        assertEquals(
+            FeedFalseColorScale.STOPS,
+            FeedEffects.parse("falsecolor", null, null).falseColor,
+        )
+    }
+
+    @Test
+    fun `unknown tokens and ids fall back to defaults`() {
+        val effects = FeedEffects.parse("sparkle, LUT , zebra", "not-a-look", null)
+        assertEquals(FeedLut.LOG3G10_709, effects.lut)
+        assertTrue(effects.zebra)
+        assertFalse(effects.peaking)
+        assertEquals(
+            FeedFalseColorScale.STOPS,
+            FeedEffects.parse("falsecolor", null, "bogus").falseColor,
+        )
+    }
+
+    @Test
+    fun `wire ordinals stay pinned to the Swift facade contract`() {
+        // FeedEffectsWire.look / .curve / .bakedFalseColor in the Swift facade.
+        assertEquals(0, FeedLut.LOG3G10_709.wireOrdinal)
+        assertEquals(1, FeedLut.NLOG_709.wireOrdinal)
+        assertEquals(2, FeedLut.MONO.wireOrdinal)
+        assertEquals(0, FeedFalseColorScale.STOPS.wireOrdinal)
+        assertEquals(1, FeedFalseColorScale.IRE.wireOrdinal)
+    }
+}

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/GlassTierTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/GlassTierTest.kt
@@ -1,0 +1,61 @@
+package com.opencapture.openzcine
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/** Pure-JVM checks of the glass tier resolution and the auto-degrade counter. */
+class GlassTierTest {
+    @Test
+    fun platformCeilingPicksTheTier() {
+        assertEquals(GlassTier.FULL, resolveTier(33))
+        assertEquals(GlassTier.FULL, resolveTier(36))
+        assertEquals(GlassTier.BLUR, resolveTier(31))
+        assertEquals(GlassTier.BLUR, resolveTier(32))
+        assertEquals(GlassTier.FLAT, resolveTier(29))
+    }
+
+    @Test
+    fun overrideLowersButNeverRaises() {
+        assertEquals(GlassTier.BLUR, resolveTier(33, "blur"))
+        assertEquals(GlassTier.FLAT, resolveTier(33, "flat"))
+        // FULL needs RuntimeShader — an API 31 device stays at its BLUR ceiling.
+        assertEquals(GlassTier.BLUR, resolveTier(31, "full"))
+        assertEquals(GlassTier.FLAT, resolveTier(29, "full"))
+    }
+
+    @Test
+    fun unknownOverrideFallsBackToTheCeiling() {
+        assertEquals(GlassTier.FULL, resolveTier(33, "chrome"))
+        assertEquals(GlassTier.FULL, resolveTier(33, null))
+    }
+
+    private fun window() =
+        FrameBudgetWindow(budgetNanos = 48, window = 10, maxOverBudget = 1, warmup = 2)
+
+    @Test
+    fun healthyWindowNeverDemotes() {
+        val budget = window()
+        repeat(50) { assertFalse(budget.frame(16)) }
+    }
+
+    @Test
+    fun sustainedOverrunDemotesAfterAFullWindow() {
+        val budget = window()
+        repeat(2) { budget.frame(999) } // warmup: ignored, however bad
+        repeat(9) { assertFalse(budget.frame(999)) }
+        assertTrue(budget.frame(999)) // 10th frame closes the window
+    }
+
+    @Test
+    fun windowResetsAfterEachDecision() {
+        val budget = window()
+        repeat(2) { budget.frame(16) }
+        // One bad frame per window is within maxOverBudget — never demotes.
+        repeat(4) {
+            repeat(9) { assertFalse(budget.frame(16)) }
+            assertFalse(budget.frame(999))
+        }
+    }
+}

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/ScopeWireTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/ScopeWireTest.kt
@@ -1,0 +1,50 @@
+package com.opencapture.openzcine.bridge
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/** Pure-JVM check of the scope wire decoding against hand-built payloads. */
+class ScopeWireTest {
+    @Test
+    fun parsesAnchors() {
+        val flat =
+            floatArrayOf(0.05f, 0.47f, 0.95f) +
+                FloatArray(12) { (it - 6) / 24f } // 6 (cb, cr) pairs
+        val anchors = ScopeAnchors.parse(flat)
+        assertEquals(0.05f, anchors.crushLine)
+        assertEquals(0.47f, anchors.midGray)
+        assertEquals(0.95f, anchors.clipLine)
+        assertEquals(6, anchors.vectorTargets.size)
+        assertEquals(Pair(-6 / 24f, -5 / 24f), anchors.vectorTargets[0])
+    }
+
+    @Test
+    fun rejectsTornAnchors() {
+        assertFailsWith<IllegalArgumentException> { ScopeAnchors.parse(FloatArray(4)) }
+    }
+
+    @Test
+    fun parsesTraces() {
+        // Two points, then 4 × 256 histogram bins tagged by channel.
+        val points =
+            floatArrayOf(
+                0.0f, 0.1f, 0.2f, 0.3f, 0.4f,
+                1.0f, 0.5f, 0.6f, 0.7f, 0.8f,
+            )
+        val histograms = FloatArray(4 * 256) { (it / 256).toFloat() }
+        val traces = ScopeTraces.parse(floatArrayOf(2f) + points + histograms)
+        assertEquals(2, traces.pointCount)
+        assertEquals(0.5f, traces.points[1 * ScopeTraces.POINT_STRIDE + 1]) // point 1 luma
+        assertEquals(0f, traces.histogramLuma[0])
+        assertEquals(1f, traces.histogramRed[0])
+        assertEquals(2f, traces.histogramGreen[255])
+        assertEquals(3f, traces.histogramBlue[128])
+    }
+
+    @Test
+    fun rejectsTornTraces() {
+        assertFailsWith<IllegalArgumentException> { ScopeTraces.parse(floatArrayOf(3f, 0f)) }
+        assertFailsWith<IllegalArgumentException> { ScopeTraces.parse(FloatArray(0)) }
+    }
+}

--- a/Sources/OpenZCineAndroidFacade/FeedEffectsWire.swift
+++ b/Sources/OpenZCineAndroidFacade/FeedEffectsWire.swift
@@ -1,0 +1,116 @@
+// Baked feed-effect payloads crossing the JNI seam.
+//
+// Like `MonitorZoneMapWire`, this file compiles on every platform so the baking
+// is exercised by `just native-check` on macOS against the exact colour math
+// the iOS shell renders with. The Kotlin consumer is
+// `Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/FeedEffectsRenderer.kt`.
+//
+// Single source of truth rule: the CORE bakes every curve and cube
+// (`MonitorLUT`, `FalseColorMap`, `ExposureSignalMapping`); Android only uploads
+// the result as textures/uniforms and interpolates. No colour math is re-derived
+// in Kotlin or AGSL.
+
+import OpenZCineCore
+
+/// Bakes monitor looks, false-colour cubes, and assist thresholds into flat
+/// byte/float payloads for the Android GPU effect chain.
+///
+/// Cube payloads use a packed-2D RGBA8 layout ready for a `width = size²`,
+/// `height = size` bitmap: pixel `(x = b·size + r, y = g)` carries the
+/// red-fastest cube entry `r + g·size + b·size²`, so a shader samples slice `b`
+/// as a `size × size` tile at x-offset `b·size` (bilinear in-tile, two taps +
+/// mix across slices = trilinear).
+public enum FeedEffectsWire {
+    /// Built-in look ordinals, mirroring `FeedLut` in Kotlin:
+    /// 0 = Log3G10→709, 1 = N-Log→709, 2 = Mono.
+    static func look(_ ordinal: Int) -> MonitorLUT? {
+        switch ordinal {
+        case 0: .log3G10Rec709
+        case 1: .nLogRec709
+        case 2: .monochrome
+        default: nil
+        }
+    }
+
+    /// Signal-curve ordinals, mirroring the Kotlin constants:
+    /// 0 = RED Log3G10, 1 = Nikon N-Log.
+    static func curve(_ ordinal: Int) -> ExposureToneCurve? {
+        switch ordinal {
+        case 0: .redLog3G10
+        case 1: .nikonNLog
+        default: nil
+        }
+    }
+
+    /// A built-in monitor look as a packed-2D RGBA8 grid (`size³ × 4` bytes),
+    /// or `nil` for an unknown ordinal / unsupported size. 33³ matches the iOS
+    /// built-ins (`MonitorLUT.cube`'s professional-`.cube` default).
+    public static func bakedLUT(lookOrdinal: Int, size: Int = 33) -> [UInt8]? {
+        guard let look = look(lookOrdinal), CubeLUT.supportedSizeRange.contains(size)
+        else { return nil }
+        return packedRGBA(cube: look.cube(size: size))
+    }
+
+    /// A false-colour cube (scale ordinal 0 = Stops, 1 = IRE) for the default
+    /// camera mapping of the selected curve, as a packed-2D RGBA8 grid at the
+    /// core's 64³ false-colour resolution. `nil` for unknown ordinals.
+    /// (The Limits scale composites two cubes over the graded feed and ships
+    /// with the assist-toolbar work, not this debug surface.)
+    public static func bakedFalseColor(scaleOrdinal: Int, curveOrdinal: Int) -> [UInt8]? {
+        guard let curve = curve(curveOrdinal) else { return nil }
+        let scale: FalseColorScale? =
+            switch scaleOrdinal {
+            case 0: .stops
+            case 1: .ire
+            default: nil
+            }
+        guard let scale else { return nil }
+        return packedRGBA(
+            cube: FalseColorMap.cube(scale: scale, mapping: ExposureSignalMapping(curve: curve)))
+    }
+
+    /// Assist thresholds on the normalized 0–1 code axis, for shader uniforms:
+    /// `[deLogBlack, deLogClip, zebraHighlight, zebraMidtoneCentre]`.
+    ///
+    /// The first pair anchors focus peaking's de-log stretch (the same
+    /// `ExposureScale.referenceIRE(signalNative:)` remap the iOS peaking path
+    /// applies before edge detection); the second pair converts the operator's
+    /// monitor-percent zebra thresholds to native code exactly like
+    /// `ImageEffectsCompositor.applyZebra`. `nil` for an unknown curve ordinal.
+    public static func scalars(
+        curveOrdinal: Int, zebraHighlightIRE: Double, zebraMidtoneIRE: Double
+    ) -> [Float]? {
+        guard let curve = curve(curveOrdinal) else { return nil }
+        let mapping = ExposureSignalMapping(curve: curve)
+        return [
+            Float(mapping.blackNative / 255),
+            Float(mapping.clipNative / 255),
+            Float(mapping.signalNative(monitorPercent: zebraHighlightIRE) / 255),
+            Float(mapping.signalNative(monitorPercent: zebraMidtoneIRE) / 255),
+        ]
+    }
+
+    /// Reorders a red-fastest cube into the packed-2D bitmap layout and
+    /// quantizes to RGBA8 (alpha 255).
+    static func packedRGBA(cube: CubeLUT) -> [UInt8] {
+        let size = cube.size
+        var out = [UInt8](repeating: 255, count: size * size * size * 4)
+        for g in 0..<size {
+            for b in 0..<size {
+                for r in 0..<size {
+                    let src = (r + g * size + b * size * size) * 3
+                    let dst = (g * size * size + b * size + r) * 4
+                    out[dst] = quantized(cube.rgb[src])
+                    out[dst + 1] = quantized(cube.rgb[src + 1])
+                    out[dst + 2] = quantized(cube.rgb[src + 2])
+                }
+            }
+        }
+        return out
+    }
+
+    /// `[0, 1]` float component to an 8-bit code, round-to-nearest.
+    static func quantized(_ value: Float) -> UInt8 {
+        UInt8((min(max(value, 0), 1) * 255).rounded())
+    }
+}

--- a/Sources/OpenZCineAndroidFacade/ScopeFrameWire.swift
+++ b/Sources/OpenZCineAndroidFacade/ScopeFrameWire.swift
@@ -1,0 +1,162 @@
+// Flat wire format for one scope tick crossing the JNI seam.
+//
+// Like `MonitorZoneMapWire`, this file compiles on every platform so the
+// payloads are exercised by `just native-check` on macOS against the exact
+// core scope math the iOS shell consumes (`ScopeSampler`, `ScopeDisplayScale`,
+// `VectorscopeSampler`). The Kotlin mirror lives in
+// `Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/ScopeWire.kt`.
+
+import Foundation
+import OpenZCineCore
+
+/// Core-driven scope payloads for the Compose shell: the MATH (anchor axis
+/// placement, curve mapping, chroma binning, tone-mapped vectorscope) runs in
+/// the shared Swift core; Kotlin only draws the returned records.
+///
+/// All display levels use the 3-anchor axis (`ScopeDisplayScale.waveformLevel`):
+/// the curve's log-black floor lands on the crush line 5% up, mid grey sits at
+/// its FIXED per-curve level (never moved by ISO/exposure), and the ISO
+/// clip-warning code lands on the clip line 5% down from the top.
+public enum ScopeFrameWire {
+    /// Floats per point record in ``traces``: `x, luma, red, green, blue`
+    /// (x is 0…1 across the frame; the rest are anchored display levels 0…1).
+    public static let pointStride = 5
+
+    /// Bins per remapped histogram channel (display-axis buckets).
+    public static let histogramBins = 256
+
+    /// Vectorscope density grid axis (matches the iOS panels).
+    public static let vectorBinCount = 128
+
+    /// Sampling step in pixels — the iOS live tap's `ScopeAssistSampling.pointStride`.
+    public static let sampleStride = 2
+
+    /// `ExposureToneCurve` for a wire ordinal: 0 = RED Log3G10 (the ZR live-view
+    /// default and the iOS fallback), 1 = Nikon N-Log.
+    static func curve(ordinal: Int) -> ExposureToneCurve {
+        ordinal == 1 ? .nikonNLog : .redLog3G10
+    }
+
+    /// Fixed axis anchors and graticule constants for one curve:
+    /// `[crushLine, middleGrayLevel, clipLine]` followed by six `(cb, cr)`
+    /// pairs — the 75% R/Mg/B/Cy/G/Yl vectorscope targets from the core's
+    /// BT.709 chroma matrix, each component in −0.5…+0.5.
+    ///
+    /// Mid grey is per-curve and deliberately independent of ISO/exposure:
+    /// `ScopeDisplayScale.middleGrayLevel(curve:)` pins it where 18% grey sits
+    /// at the curve's published base-ISO clip. Only the highlight segment
+    /// re-stretches when the camera's clip warning moves.
+    public static func anchors(curveOrdinal: Int) -> [Float] {
+        let curve = curve(ordinal: curveOrdinal)
+        var out: [Float] = [
+            Float(ScopeDisplayScale.crushLineLevel),
+            Float(ScopeDisplayScale.middleGrayLevel(curve: curve)),
+            Float(ScopeDisplayScale.clipLineLevel),
+        ]
+        // 75% colour-bar targets (191 = 0.75 × 255) — same values the iOS
+        // graticule feeds through `VectorscopeSampler.chroma`.
+        let targets: [(red: UInt8, green: UInt8, blue: UInt8)] = [
+            (191, 0, 0), (191, 0, 191), (0, 0, 191),
+            (0, 191, 191), (0, 191, 0), (191, 191, 0),
+        ]
+        for target in targets {
+            let (cb, cr) = VectorscopeSampler.chroma(
+                red: target.red, green: target.green, blue: target.blue)
+            out.append(Float(cb))
+            out.append(Float(cr))
+        }
+        return out
+    }
+
+    /// Samples one downsampled RGBA frame for the waveform / parade / histogram
+    /// scopes and returns the flattened payload:
+    ///
+    /// `[N, (x, luma, red, green, blue) × N, 256 luma bins, 256 red, 256 green, 256 blue]`
+    ///
+    /// Point levels and histogram buckets are already on the anchored display
+    /// axis, so the shell places pixels without re-deriving any curve math.
+    /// Invalid buffer geometry yields `[0]` plus four empty histograms.
+    public static func traces(
+        rgba: [UInt8], width: Int, height: Int, bytesPerRow: Int, curveOrdinal: Int
+    ) -> [Float] {
+        let mapping = ExposureSignalMapping(curve: curve(ordinal: curveOrdinal))
+        let samples = ScopeSampler.sample(
+            rgba: rgba, width: width, height: height, bytesPerRow: bytesPerRow,
+            stride: sampleStride)
+        var out = [Float]()
+        out.reserveCapacity(1 + samples.points.count * pointStride + 4 * histogramBins)
+        out.append(Float(samples.points.count))
+        func level(_ native: UInt8) -> Float {
+            Float(
+                ScopeDisplayScale.waveformLevel(
+                    signalNative: Double(native), mapping: mapping))
+        }
+        for point in samples.points {
+            out.append(Float(point.xRatio))
+            out.append(level(point.luma))
+            out.append(level(point.red))
+            out.append(level(point.green))
+            out.append(level(point.blue))
+        }
+        let histograms = [
+            samples.histogramLuma, samples.histogramRed,
+            samples.histogramGreen, samples.histogramBlue,
+        ]
+        for histogram in histograms {
+            let remapped = ScopeDisplayScale.remapHistogram(histogram, mapping: mapping)
+            for bin in remapped {
+                out.append(Float(bin))
+            }
+        }
+        return out
+    }
+
+    /// Built-in monitor looks for the vectorscope's tone-mapped domain, built
+    /// once — the same `MonitorLUT` cubes the iOS shell falls back to when no
+    /// operator LUT is active.
+    private static let log3G10MonitorCube = MonitorLUT.log3G10Rec709.cube()
+    private static let nLogMonitorCube = MonitorLUT.nLogRec709.cube()
+
+    /// Samples one downsampled RGBA frame for the vectorscope and returns the
+    /// 128×128 premultiplied-RGBA density image (row 0 at +Cr, ready to blit).
+    ///
+    /// The clean log points are pushed through the built-in display tone map
+    /// (`MonitorLUT` — v1 has no operator LUTs on Android, matching the iOS
+    /// no-LUT fallback), binned by BT.709 CbCr, then rasterized with the same
+    /// log-density ramp and trace tint as the iOS shell's
+    /// `VectorscopeDensityRasterizer` at default brightness. Empty when the
+    /// frame yields no samples.
+    public static func vectorPixels(
+        rgba: [UInt8], width: Int, height: Int, bytesPerRow: Int, curveOrdinal: Int
+    ) -> [UInt8] {
+        let samples = ScopeSampler.sample(
+            rgba: rgba, width: width, height: height, bytesPerRow: bytesPerRow,
+            stride: sampleStride)
+        let cube = curveOrdinal == 1 ? nLogMonitorCube : log3G10MonitorCube
+        let monitorPoints = VectorscopeSampler.monitorPoints(samples.points, through: cube)
+        let bins = VectorscopeSampler.accumulate(
+            points: monitorPoints, binCount: vectorBinCount, gain: 1)
+        let n = bins.binCount
+        guard n > 0, bins.peak > 0 else { return [] }
+        let peak = Double(bins.peak)
+        var pixels = [UInt8](repeating: 0, count: n * n * 4)
+        for index in 0..<bins.counts.count {
+            let count = bins.counts[index]
+            guard count > 0 else { continue }
+            // Logarithmic density ramp (phosphor-style) — keeps single-pixel
+            // chroma readable while dense regions still glow.
+            let density = log(1 + Double(count)) / log(1 + peak)
+            let alpha = min(1, max(0, 0.4 + 0.6 * density))
+            let tint = bins.averageColor(at: index).traceTint
+            // Flip rows so +Cr renders upward (bins store row 0 at −Cr).
+            let row = n - 1 - index / n
+            let column = index % n
+            let offset = (row * n + column) * 4
+            pixels[offset] = UInt8(255 * tint.red * alpha)
+            pixels[offset + 1] = UInt8(255 * tint.green * alpha)
+            pixels[offset + 2] = UInt8(255 * tint.blue * alpha)
+            pixels[offset + 3] = UInt8(255 * alpha)
+        }
+        return pixels
+    }
+}

--- a/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
+++ b/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
@@ -42,6 +42,32 @@
         return String(cString: chars)
     }
 
+    /// Copies a Swift byte buffer into a new JVM `byte[]` local reference.
+    private func javaByteArray(
+        _ env: UnsafeMutablePointer<JNIEnv?>, _ bytes: [UInt8]
+    ) -> jbyteArray? {
+        let fns = table(env)
+        guard let array = fns.NewByteArray!(env, jsize(bytes.count)) else { return nil }
+        bytes.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress else { return }
+            fns.SetByteArrayRegion!(
+                env, array, 0, jsize(bytes.count), base.assumingMemoryBound(to: jbyte.self))
+        }
+        return array
+    }
+
+    /// Copies a Swift float buffer into a new JVM `float[]` local reference.
+    private func javaFloatArray(
+        _ env: UnsafeMutablePointer<JNIEnv?>, _ values: [Float]
+    ) -> jfloatArray? {
+        let fns = table(env)
+        guard let array = fns.NewFloatArray!(env, jsize(values.count)) else { return nil }
+        values.withUnsafeBufferPointer { buffer in
+            fns.SetFloatArrayRegion!(env, array, 0, jsize(values.count), buffer.baseAddress)
+        }
+        return array
+    }
+
     // MARK: - Info
 
     /// `SwiftCore.coreVersion(): String` — proves the Swift core is alive in-process.
@@ -119,6 +145,53 @@
             fns.SetFloatArrayRegion!(env, array, 0, jsize(flat.count), buffer.baseAddress)
         }
         return array
+    }
+
+    // MARK: - Feed effects (baked in the core, uploaded by Kotlin)
+
+    /// `SwiftCore.bakeLut(lookOrdinal, size): ByteArray?` — a built-in monitor
+    /// look baked by the core into the packed-2D RGBA8 grid described in
+    /// `FeedEffectsWire`. Null for unknown ordinals/sizes.
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_bakeLut")
+    public func swiftCoreBakeLut(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?, lookOrdinal: jint, size: jint
+    ) -> jbyteArray? {
+        guard
+            let bytes = FeedEffectsWire.bakedLUT(
+                lookOrdinal: Int(lookOrdinal), size: Int(size))
+        else { return nil }
+        return javaByteArray(env, bytes)
+    }
+
+    /// `SwiftCore.bakeFalseColorCube(scaleOrdinal, curveOrdinal): ByteArray?` —
+    /// the core's false-colour cube (64³) in the same packed-2D RGBA8 grid.
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_bakeFalseColorCube")
+    public func swiftCoreBakeFalseColorCube(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?, scaleOrdinal: jint,
+        curveOrdinal: jint
+    ) -> jbyteArray? {
+        guard
+            let bytes = FeedEffectsWire.bakedFalseColor(
+                scaleOrdinal: Int(scaleOrdinal), curveOrdinal: Int(curveOrdinal))
+        else { return nil }
+        return javaByteArray(env, bytes)
+    }
+
+    /// `SwiftCore.feedEffectsScalars(curveOrdinal, zebraHighlightIre, zebraMidtoneIre):
+    /// FloatArray?` — `[deLogBlack, deLogClip, zebraHighlight, zebraMidtoneCentre]`
+    /// on the normalized 0–1 code axis (see `FeedEffectsWire.scalars`).
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_feedEffectsScalars")
+    public func swiftCoreFeedEffectsScalars(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?, curveOrdinal: jint,
+        zebraHighlightIre: jfloat, zebraMidtoneIre: jfloat
+    ) -> jfloatArray? {
+        guard
+            let values = FeedEffectsWire.scalars(
+                curveOrdinal: Int(curveOrdinal),
+                zebraHighlightIRE: Double(zebraHighlightIre),
+                zebraMidtoneIRE: Double(zebraMidtoneIre))
+        else { return nil }
+        return javaFloatArray(env, values)
     }
 
     // MARK: - Callback / streaming shape

--- a/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
+++ b/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
@@ -42,6 +42,49 @@
         return String(cString: chars)
     }
 
+    /// Copies a `jbyteArray` into a Swift `[UInt8]`.
+    private func swiftBytes(
+        _ env: UnsafeMutablePointer<JNIEnv?>, _ value: jbyteArray?
+    ) -> [UInt8]? {
+        guard let value else { return nil }
+        let fns = table(env)
+        let length = Int(fns.GetArrayLength!(env, value))
+        guard length > 0 else { return [] }
+        var out = [UInt8](repeating: 0, count: length)
+        out.withUnsafeMutableBytes { raw in
+            fns.GetByteArrayRegion!(
+                env, value, 0, jsize(length),
+                raw.baseAddress?.assumingMemoryBound(to: jbyte.self))
+        }
+        return out
+    }
+
+    /// Copies a Swift `[Float]` into a new JVM-owned `jfloatArray`.
+    private func javaFloatArray(
+        _ env: UnsafeMutablePointer<JNIEnv?>, _ values: [Float]
+    ) -> jfloatArray? {
+        let fns = table(env)
+        guard let array = fns.NewFloatArray!(env, jsize(values.count)) else { return nil }
+        values.withUnsafeBufferPointer { buffer in
+            fns.SetFloatArrayRegion!(env, array, 0, jsize(values.count), buffer.baseAddress)
+        }
+        return array
+    }
+
+    /// Copies a Swift `[UInt8]` into a new JVM-owned `jbyteArray`.
+    private func javaByteArray(
+        _ env: UnsafeMutablePointer<JNIEnv?>, _ values: [UInt8]
+    ) -> jbyteArray? {
+        let fns = table(env)
+        guard let array = fns.NewByteArray!(env, jsize(values.count)) else { return nil }
+        values.withUnsafeBufferPointer { buffer in
+            buffer.baseAddress?.withMemoryRebound(to: jbyte.self, capacity: values.count) {
+                fns.SetByteArrayRegion!(env, array, 0, jsize(values.count), $0)
+            }
+        }
+        return array
+    }
+
     // MARK: - Info
 
     /// `SwiftCore.coreVersion(): String` — proves the Swift core is alive in-process.
@@ -119,6 +162,49 @@
             fns.SetFloatArrayRegion!(env, array, 0, jsize(flat.count), buffer.baseAddress)
         }
         return array
+    }
+
+    // MARK: - Scopes
+
+    /// `SwiftCore.scopeAnchors(curve): FloatArray` — fixed axis anchors and
+    /// vectorscope graticule targets per `ScopeFrameWire.anchors`.
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_scopeAnchors")
+    public func swiftCoreScopeAnchors(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?, curve: jint
+    ) -> jfloatArray? {
+        javaFloatArray(env, ScopeFrameWire.anchors(curveOrdinal: Int(curve)))
+    }
+
+    /// `SwiftCore.scopeTraces(rgba, width, height, bytesPerRow, curve): FloatArray`
+    /// — one scope tick's waveform/parade/histogram payload per
+    /// `ScopeFrameWire.traces`. Blocking; Kotlin calls it off the main thread.
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_scopeTraces")
+    public func swiftCoreScopeTraces(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?, rgba: jbyteArray?,
+        width: jint, height: jint, bytesPerRow: jint, curve: jint
+    ) -> jfloatArray? {
+        guard let buffer = swiftBytes(env, rgba) else { return nil }
+        return javaFloatArray(
+            env,
+            ScopeFrameWire.traces(
+                rgba: buffer, width: Int(width), height: Int(height),
+                bytesPerRow: Int(bytesPerRow), curveOrdinal: Int(curve)))
+    }
+
+    /// `SwiftCore.scopeVector(rgba, width, height, bytesPerRow, curve): ByteArray`
+    /// — one scope tick's 128×128 premultiplied-RGBA vectorscope density image
+    /// per `ScopeFrameWire.vectorPixels`. Empty for a frame with no samples.
+    @_cdecl("Java_com_opencapture_openzcine_bridge_SwiftCore_scopeVector")
+    public func swiftCoreScopeVector(
+        env: UnsafeMutablePointer<JNIEnv?>, this _: jobject?, rgba: jbyteArray?,
+        width: jint, height: jint, bytesPerRow: jint, curve: jint
+    ) -> jbyteArray? {
+        guard let buffer = swiftBytes(env, rgba) else { return nil }
+        return javaByteArray(
+            env,
+            ScopeFrameWire.vectorPixels(
+                rgba: buffer, width: Int(width), height: Int(height),
+                bytesPerRow: Int(bytesPerRow), curveOrdinal: Int(curve)))
     }
 
     // MARK: - Callback / streaming shape

--- a/Tests/OpenZCineAndroidFacadeTests/FeedEffectsWireTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/FeedEffectsWireTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import OpenZCineCore
+import Testing
+
+@testable import OpenZCineAndroidFacade
+
+/// The packed-2D payloads Compose uploads as effect textures must carry the
+/// core's cube values exactly — pixel `(x = b·size + r, y = g)` ↔ red-fastest
+/// cube index — and the scalar thresholds must be the core's, not re-derived.
+struct FeedEffectsWireTests {
+    /// RGBA of the packed pixel for cube lattice coordinates `(r, g, b)`.
+    private func packedPixel(
+        _ bytes: [UInt8], size: Int, r: Int, g: Int, b: Int
+    ) -> (red: UInt8, green: UInt8, blue: UInt8, alpha: UInt8) {
+        let offset = (g * size * size + b * size + r) * 4
+        return (bytes[offset], bytes[offset + 1], bytes[offset + 2], bytes[offset + 3])
+    }
+
+    /// The wire's own quantization, so expectations share the exact rounding.
+    private func byte(_ value: Float) -> UInt8 {
+        FeedEffectsWire.quantized(value)
+    }
+
+    @Test("Packed LUT grid carries MonitorLUT cube values byte-for-value")
+    func packedLutMatchesCoreCube() throws {
+        let size = 33
+        let bytes = try #require(FeedEffectsWire.bakedLUT(lookOrdinal: 0, size: size))
+        #expect(bytes.count == size * size * size * 4)
+        let cube = MonitorLUT.log3G10Rec709.cube(size: size)
+        for (r, g, b) in [(0, 0, 0), (32, 32, 32), (16, 8, 24), (32, 0, 0), (5, 21, 13)] {
+            let index = (r + g * size + b * size * size) * 3
+            let pixel = packedPixel(bytes, size: size, r: r, g: g, b: b)
+            #expect(pixel.red == byte(cube.rgb[index]))
+            #expect(pixel.green == byte(cube.rgb[index + 1]))
+            #expect(pixel.blue == byte(cube.rgb[index + 2]))
+            #expect(pixel.alpha == 255)
+        }
+    }
+
+    @Test("Mono look bakes achromatic and neutral input maps near-identity greys")
+    func monoLookIsAchromatic() throws {
+        let size = 17
+        let bytes = try #require(FeedEffectsWire.bakedLUT(lookOrdinal: 2, size: size))
+        for (r, g, b) in [(0, 16, 8), (16, 0, 0), (4, 4, 4), (12, 3, 9)] {
+            let pixel = packedPixel(bytes, size: size, r: r, g: g, b: b)
+            #expect(pixel.red == pixel.green)
+            #expect(pixel.green == pixel.blue)
+        }
+        // Neutral axis: Rec.709 luma of an achromatic input is the input itself
+        // (±1 code for float rounding).
+        let mid = packedPixel(bytes, size: size, r: 8, g: 8, b: 8)
+        #expect(abs(Int(mid.red) - Int(byte(8.0 / 16.0))) <= 1)
+    }
+
+    @Test("False-colour grid matches the core cube and paints the documented clip zone")
+    func falseColorCubeMatchesCore() throws {
+        let bytes = try #require(FeedEffectsWire.bakedFalseColor(scaleOrdinal: 1, curveOrdinal: 0))
+        let cube = FalseColorMap.cube(
+            scale: .ire, mapping: ExposureSignalMapping(curve: .redLog3G10))
+        let size = cube.size
+        #expect(bytes.count == size * size * size * 4)
+        for (r, g, b) in [(0, 0, 0), (63, 63, 63), (40, 20, 10), (10, 40, 55)] {
+            let index = (r + g * size + b * size * size) * 3
+            let pixel = packedPixel(bytes, size: size, r: r, g: g, b: b)
+            #expect(pixel.red == byte(cube.rgb[index]))
+            #expect(pixel.green == byte(cube.rgb[index + 1]))
+            #expect(pixel.blue == byte(cube.rgb[index + 2]))
+        }
+        // Encoded 1.0 sits past the clip warning → the documented 99+ IRE red zone.
+        let clip = packedPixel(bytes, size: size, r: 63, g: 63, b: 63)
+        #expect(clip.red == byte(0.78))
+        #expect(clip.green == byte(0.28))
+        #expect(clip.blue == byte(0.18))
+    }
+
+    @Test("Scalars are the core's black/clip anchors and zebra thresholds")
+    func scalarsCarryCoreThresholds() throws {
+        let scalars = try #require(
+            FeedEffectsWire.scalars(curveOrdinal: 0, zebraHighlightIRE: 100, zebraMidtoneIRE: 55))
+        #expect(scalars.count == 4)
+        let mapping = ExposureSignalMapping(curve: .redLog3G10)
+        #expect(scalars[0] == Float(mapping.blackNative / 255))
+        #expect(scalars[1] == Float(mapping.clipNative / 255))
+        // Log3G10's default clip warning is native 180; monitor 100% maps onto it.
+        #expect(scalars[1] == Float(180.0 / 255.0))
+        #expect(scalars[2] == Float(mapping.signalNative(monitorPercent: 100) / 255))
+        #expect(scalars[3] == Float(mapping.signalNative(monitorPercent: 55) / 255))
+        #expect(scalars[2] > scalars[3])
+        #expect(scalars[3] > scalars[0])
+    }
+
+    @Test("Unknown ordinals and unsupported sizes are rejected")
+    func unknownOrdinalsAreRejected() {
+        #expect(FeedEffectsWire.bakedLUT(lookOrdinal: 3, size: 33) == nil)
+        #expect(FeedEffectsWire.bakedLUT(lookOrdinal: 0, size: 65) == nil)
+        #expect(FeedEffectsWire.bakedFalseColor(scaleOrdinal: 2, curveOrdinal: 0) == nil)
+        #expect(FeedEffectsWire.bakedFalseColor(scaleOrdinal: 0, curveOrdinal: 5) == nil)
+        #expect(
+            FeedEffectsWire.scalars(curveOrdinal: 9, zebraHighlightIRE: 100, zebraMidtoneIRE: 55)
+                == nil)
+    }
+}

--- a/Tests/OpenZCineAndroidFacadeTests/ScopeFrameWireTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/ScopeFrameWireTests.swift
@@ -1,0 +1,150 @@
+import OpenZCineCore
+import Testing
+
+@testable import OpenZCineAndroidFacade
+
+/// The scope wire must carry the core's anchored axis math value-for-value —
+/// the Compose shell draws straight off these payloads with no curve math of
+/// its own.
+struct ScopeFrameWireTests {
+    // MARK: - Anchors
+
+    @Test func anchorsCarryFixedSafeBorderLines() {
+        for ordinal in [0, 1] {
+            let anchors = ScopeFrameWire.anchors(curveOrdinal: ordinal)
+            #expect(anchors.count == 3 + 6 * 2)
+            #expect(anchors[0] == Float(ScopeDisplayScale.crushLineLevel))
+            #expect(anchors[2] == Float(ScopeDisplayScale.clipLineLevel))
+            #expect(anchors[0] < anchors[1] && anchors[1] < anchors[2])
+        }
+    }
+
+    @Test func midGrayAnchorMatchesCoreAndIgnoresISO() {
+        let anchors = ScopeFrameWire.anchors(curveOrdinal: 0)
+        // The wire's mid-grey anchor is the per-curve fixed level — the same
+        // value regardless of any ISO-driven clip shift, by construction: it
+        // derives from the curve's PUBLISHED default clip, never the live one.
+        #expect(anchors[1] == Float(ScopeDisplayScale.middleGrayLevel(curve: .redLog3G10)))
+        let shiftedISO = ExposureSignalMapping(curve: .redLog3G10, clipNative: 215)
+        #expect(
+            Float(ScopeDisplayScale.middleGrayLevel(mapping: shiftedISO)) == anchors[1])
+    }
+
+    @Test func vectorTargetsMatchCoreChromaMatrix() {
+        let anchors = ScopeFrameWire.anchors(curveOrdinal: 0)
+        // First target is 75% red: positive Cr, negative Cb, inside ±0.5.
+        let (cb, cr) = VectorscopeSampler.chroma(red: 191, green: 0, blue: 0)
+        #expect(anchors[3] == Float(cb))
+        #expect(anchors[4] == Float(cr))
+        for value in anchors[3...] {
+            #expect(value >= -0.5 && value <= 0.5)
+        }
+    }
+
+    // MARK: - Traces
+
+    /// A 2×8 buffer whose stride-2 sweep samples exactly one pixel per value
+    /// band: black, mid grey (Log3G10 18% grey code), clip warning, white.
+    private func syntheticBuffer() -> ([UInt8], Int, Int) {
+        let mid = UInt8(ExposureToneCurve.redLog3G10.middleGrayNativeCode.rounded())
+        let clip = UInt8(ExposureToneCurve.redLog3G10.defaultClipNative.rounded())
+        var rgba = [UInt8]()
+        for value in [UInt8(0), mid, clip, 255] {
+            // Two rows per band, two pixels per row — stride 2 hits row 0, col 0.
+            for _ in 0..<4 {
+                rgba.append(contentsOf: [value, value, value, 255])
+            }
+        }
+        return (rgba, 2, 8)
+    }
+
+    @Test func tracesPayloadIsWellFormed() {
+        let (rgba, width, height) = syntheticBuffer()
+        let flat = ScopeFrameWire.traces(
+            rgba: rgba, width: width, height: height, bytesPerRow: width * 4,
+            curveOrdinal: 0)
+        let count = Int(flat[0])
+        // stride-2 sweep over 4×4 → 2×2 points.
+        #expect(count == 4)
+        #expect(
+            flat.count
+                == 1 + count * ScopeFrameWire.pointStride + 4 * ScopeFrameWire.histogramBins)
+        let allFinite = flat.allSatisfy { $0.isFinite }
+        #expect(allFinite)
+    }
+
+    @Test func pointLevelsSitOnTheAnchoredAxis() {
+        let (rgba, width, height) = syntheticBuffer()
+        let flat = ScopeFrameWire.traces(
+            rgba: rgba, width: width, height: height, bytesPerRow: width * 4,
+            curveOrdinal: 0)
+        let count = Int(flat[0])
+        let anchors = ScopeFrameWire.anchors(curveOrdinal: 0)
+        var levels = [Float]()
+        for index in 0..<count {
+            levels.append(flat[1 + index * ScopeFrameWire.pointStride + 1])  // luma level
+        }
+        levels.sort()
+        // Black row (native 0) sits below the crush line; the mid-grey row sits
+        // exactly on the fixed mid-grey anchor; the clip-warning row lands on
+        // the clip line (±1 code of quantisation).
+        #expect(levels[0] < anchors[0])
+        #expect(abs(levels[1] - anchors[1]) < 0.01)
+        #expect(abs(levels[2] - anchors[2]) < 0.01)
+        #expect(levels[3] > anchors[2])
+    }
+
+    @Test func histogramsCarryEverySampledPixel() {
+        let (rgba, width, height) = syntheticBuffer()
+        let flat = ScopeFrameWire.traces(
+            rgba: rgba, width: width, height: height, bytesPerRow: width * 4,
+            curveOrdinal: 0)
+        let count = Int(flat[0])
+        let start = 1 + count * ScopeFrameWire.pointStride
+        for channel in 0..<4 {
+            let bins = flat[
+                (start + channel * ScopeFrameWire.histogramBins)..<(start + (channel + 1)
+                    * ScopeFrameWire.histogramBins)
+            ]
+            #expect(Int(bins.reduce(0, +).rounded()) == count)
+        }
+    }
+
+    @Test func invalidBufferYieldsEmptyPayload() {
+        let flat = ScopeFrameWire.traces(
+            rgba: [0, 0, 0], width: 4, height: 4, bytesPerRow: 16, curveOrdinal: 0)
+        #expect(flat[0] == 0)
+        #expect(flat.count == 1 + 4 * ScopeFrameWire.histogramBins)
+    }
+
+    // MARK: - Vectorscope
+
+    @Test func vectorPixelsArePremultipliedRGBA() {
+        // A saturated two-colour frame so the tone-mapped chroma spreads into
+        // more than one bin.
+        var rgba = [UInt8]()
+        for index in 0..<16 {
+            rgba.append(contentsOf: index % 2 == 0 ? [200, 40, 40, 255] : [40, 40, 200, 255])
+        }
+        let pixels = ScopeFrameWire.vectorPixels(
+            rgba: rgba, width: 4, height: 4, bytesPerRow: 16, curveOrdinal: 0)
+        let n = ScopeFrameWire.vectorBinCount
+        #expect(pixels.count == n * n * 4)
+        var occupied = 0
+        for offset in Swift.stride(from: 0, to: pixels.count, by: 4) {
+            let alpha = pixels[offset + 3]
+            if alpha > 0 { occupied += 1 }
+            // Premultiplied: no channel may exceed its alpha.
+            #expect(pixels[offset] <= alpha)
+            #expect(pixels[offset + 1] <= alpha)
+            #expect(pixels[offset + 2] <= alpha)
+        }
+        #expect(occupied > 0)
+    }
+
+    @Test func emptyFrameYieldsEmptyVectorImage() {
+        let pixels = ScopeFrameWire.vectorPixels(
+            rgba: [], width: 0, height: 0, bytesPerRow: 0, curveOrdinal: 0)
+        #expect(pixels.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- wires the real assist toolbar to the shared-core scope and feed-effects paths
- adds the third DISP command dashboard with the iOS-equivalent health strip, hero timecode, and control grid
- unlocks portrait rotation and consumes the shared zone map for the portrait-fit shell
- preserves the tiered custom GPU glass pipeline across live, clean, command, landscape, and portrait states

## Stack / merge order

This branch **contains the commits from #117, #119, and #120**. Merge those three PRs first; this PR's diff will then shrink to the chrome-completion work.

Recommended order: #117 → #119 → #120 → this PR.

## Verification

- `just check`
- `just native-check`
- `just android-check`
- `just android-core`
- `just android-install R58R92BL76K`
- Samsung SM-A127F / API 33 screenshots: landscape live with vector + LUT/peaking/zebra, landscape command, portrait live with vector + LUT/peaking/zebra, and portrait command
- inspected all four edges in every captured state: no chrome clipping, overflow, or truncation

Closes #72
