### PR TITLE
fix(ios): repair hotspot pairing after GUID migration

### DIFF
--- a/Sources/OpenZCineCore/PTPIPHandshake.swift
+++ b/Sources/OpenZCineCore/PTPIPHandshake.swift
@@ -16,6 +16,14 @@ public enum PTPIPInitiator {
         ])
     }
 
+    /// Preserves a valid installed identity, seeding ``appGUID`` only for a fresh or corrupt store.
+    /// Camera pairing profiles are keyed to these 16 bytes, so branding changes must never replace
+    /// an identity that has already been persisted on the device.
+    public static func resolvedAppGUID(persistedGUID: Data?) -> Data {
+        guard let persistedGUID, persistedGUID.count == 16 else { return appGUID }
+        return persistedGUID
+    }
+
     /// This string is part of the paired initiator identity; keep it stable.
     public static let friendlyName = "WTU-iPhone"
 }

--- a/Sources/OpenZCineCore/PTPIPSavedCameraRecords.swift
+++ b/Sources/OpenZCineCore/PTPIPSavedCameraRecords.swift
@@ -351,16 +351,26 @@ public enum CameraStartupPolicy {
         PTPIPSavedCameraRecords.canonicalized(savedCameras).isEmpty ? .addCamera : .savedCameras
     }
 
+    /// Returns cameras that have not already been saved by this app.
+    ///
+    /// When `allowSavedCameraRecovery` is true and discovery found no new cameras, the discovered
+    /// saved cameras are returned as a repair fallback. This lets an explicit pairing flow recover
+    /// a stale camera-side profile without allowing known cameras to crowd out a genuinely new one.
     public static func pairingDiscoveryCandidates(
         discoveredCameras: [DiscoveredCamera],
-        savedCameras: [PTPIPSavedCameraRecord]
+        savedCameras: [PTPIPSavedCameraRecord],
+        allowSavedCameraRecovery: Bool = false
     ) -> [DiscoveredCamera] {
         let savedCameras = PTPIPSavedCameraRecords.canonicalized(savedCameras)
-        return discoveredCameras.filter { discoveredCamera in
+        let newCameras = discoveredCameras.filter { discoveredCamera in
             !savedCameras.contains { savedCamera in
                 discoveryCamera(discoveredCamera, matchesSavedCamera: savedCamera)
             }
         }
+        if allowSavedCameraRecovery, newCameras.isEmpty {
+            return discoveredCameras
+        }
+        return newCameras
     }
 
     /// Resolves the connection strategy. A camera with a local saved profile is trusted and

--- a/Tests/OpenZCineCoreTests/CameraStartupPolicyTests.swift
+++ b/Tests/OpenZCineCoreTests/CameraStartupPolicyTests.swift
@@ -195,3 +195,56 @@ import Testing
 
     #expect(candidates.isEmpty)
 }
+
+@Test func startupPolicySurfacesSavedHotspotCameraForExplicitRepair() {
+    let saved = [
+        PTPIPSavedCameraRecord(
+            host: "172.20.10.8",
+            displayName: "ZR_6001234",
+            transport: "iPhone hotspot",
+            lastSeenAt: nil
+        )
+    ]
+    let rediscovered = DiscoveredCamera(
+        ip: "172.20.10.15",
+        name: "ZR_6001234",
+        source: .bonjour
+    )
+
+    let candidates = CameraStartupPolicy.pairingDiscoveryCandidates(
+        discoveredCameras: [rediscovered],
+        savedCameras: saved,
+        allowSavedCameraRecovery: true
+    )
+
+    #expect(candidates == [rediscovered])
+}
+
+@Test func startupPolicyKeepsNewCamerasAheadOfSavedRepairFallback() {
+    let saved = [
+        PTPIPSavedCameraRecord(
+            host: "172.20.10.8",
+            displayName: "ZR_6001234",
+            transport: "iPhone hotspot",
+            lastSeenAt: nil
+        )
+    ]
+    let rediscoveredSavedCamera = DiscoveredCamera(
+        ip: "172.20.10.15",
+        name: "ZR_6001234",
+        source: .bonjour
+    )
+    let newCamera = DiscoveredCamera(
+        ip: "172.20.10.16",
+        name: "ZR_7000000",
+        source: .bonjour
+    )
+
+    let candidates = CameraStartupPolicy.pairingDiscoveryCandidates(
+        discoveredCameras: [rediscoveredSavedCamera, newCamera],
+        savedCameras: saved,
+        allowSavedCameraRecovery: true
+    )
+
+    #expect(candidates == [newCamera])
+}

--- a/Tests/OpenZCineCoreTests/PTPIPHandshakeTests.swift
+++ b/Tests/OpenZCineCoreTests/PTPIPHandshakeTests.swift
@@ -25,6 +25,22 @@ import Testing
     #expect(PTPIPInitiator.friendlyName == "WTU-iPhone")
 }
 
+@Test func initiatorIdentityPreservesAValidPersistedGUID() {
+    let legacyGUID = Data([
+        0x5A, 0x43, 0x69, 0x6E, 0x65, 0x43, 0x74, 0x72,
+        0x6C, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
+    ])
+
+    #expect(PTPIPInitiator.resolvedAppGUID(persistedGUID: legacyGUID) == legacyGUID)
+}
+
+@Test func initiatorIdentitySeedsFreshOrInvalidStores() {
+    #expect(PTPIPInitiator.resolvedAppGUID(persistedGUID: nil) == PTPIPInitiator.appGUID)
+    #expect(
+        PTPIPInitiator.resolvedAppGUID(persistedGUID: Data(repeating: 0, count: 8))
+            == PTPIPInitiator.appGUID)
+}
+
 @Test func pairingChallengeExtractsAsciiPinAndRawHex() {
     let challenge = PTPIPPairingChallenge(
         data: Data([0x5A, 0x52, 0x20, 0x31, 0x32, 0x33, 0x34]),

--- a/docs/investigations/debug/ios-hotspot-pairing-guid-migration.md
+++ b/docs/investigations/debug/ios-hotspot-pairing-guid-migration.md
@@ -1,0 +1,36 @@
+---
+status: awaiting_human_verify
+trigger: "Phone Hotspot first-pair wizard reaches Find and pair but remains on Looking for cameras after the camera joins"
+created: 2026-07-15T08:00:00Z
+updated: 2026-07-15T08:09:00Z
+---
+
+## Current Focus
+
+hypothesis: CONFIRMED - the PTP-IP initiator GUID changed while the saved-camera record did not
+next_action: Verify an upgraded TestFlight install with the saved hotspot camera and a Nikon ZR
+
+## Resolution
+
+root_cause: PR #25 changed the PTP-IP initiator GUID from the previously paired `ZCineCtrl` bytes
+to `OpenZCine`. `NativeCameraConnectionStore.guid()` then replaced the persisted identity while
+retaining the saved camera. Hotspot discovery still found the camera, but the explicit pairing
+screen filtered it by saved host or camera name and rendered the empty "Looking for cameras" state.
+
+fix: Preserve every valid persisted 16-byte initiator GUID. For installs that already received the
+broken migration, let the explicit pairing wizard surface a saved camera as a repair fallback when
+no new camera is present. The existing saved-profile connection path can then retry first-time
+pairing when the camera rejects the replaced identity. New cameras still take priority over repair
+candidates, and fresh installs continue to seed the `OpenZCine` identity.
+
+verification: `just test` and `just check` passed with 666 tests, including initiator persistence
+and hotspot repair policy coverage. The focused `FirstPairWizardStepTests` suite passed, and
+`just native-check` passed the Swift package, iOS, and watchOS build gates. Physical-camera
+confirmation remains.
+
+files_changed: [Sources/OpenZCineCore/PTPIPHandshake.swift,
+  Sources/OpenZCineCore/PTPIPSavedCameraRecords.swift,
+  Tests/OpenZCineCoreTests/PTPIPHandshakeTests.swift,
+  Tests/OpenZCineCoreTests/CameraStartupPolicyTests.swift,
+  ios/Runner/NativeCameraSession.swift, ios/Runner/NativeAppRoot.swift,
+  ios/RunnerTests/FirstPairWizardStepTests.swift]

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -790,11 +790,17 @@ final class NativeAppModel {
     }
 
     var pairingDiscoveryCandidates: [DiscoveredCamera] {
-        CameraStartupPolicy.pairingDiscoveryCandidates(
-            discoveredCameras: discoveredCameras,
-            savedCameras: savedCameras
+        let transportCandidates = discoveredCameras.filter {
+            discoveryTransportFilter == .usbC ? $0.isUSB : !$0.isUSB
+        }
+        return CameraStartupPolicy.pairingDiscoveryCandidates(
+            discoveredCameras: transportCandidates,
+            savedCameras: savedCameras,
+            // A wire-identity migration can leave the app record present while the camera-side
+            // profile needs pairing again. In the explicit Pair new flow, surface that known
+            // camera only when no genuinely new camera was found so the screen cannot look stuck.
+            allowSavedCameraRecovery: isPairingNewCamera
         )
-        .filter { discoveryTransportFilter == .usbC ? $0.isUSB : !$0.isUSB }
     }
 
     /// True when discovery found no Wi‑Fi cameras and the phone is not on a camera AP.

--- a/ios/Runner/NativeCameraSession.swift
+++ b/ios/Runner/NativeCameraSession.swift
@@ -120,11 +120,13 @@ final class NativeCameraConnectionStore {
     }
 
     func guid() -> Data {
-        let appGUID = PTPIPInitiator.appGUID
-        if UserDefaults.standard.data(forKey: guidKey) != appGUID {
-            UserDefaults.standard.set(appGUID, forKey: guidKey)
+        let defaults = UserDefaults.standard
+        let persistedGUID = defaults.data(forKey: guidKey)
+        let resolvedGUID = PTPIPInitiator.resolvedAppGUID(persistedGUID: persistedGUID)
+        if persistedGUID != resolvedGUID {
+            defaults.set(resolvedGUID, forKey: guidKey)
         }
-        return appGUID
+        return resolvedGUID
     }
 
     func pairedHosts() -> [String] {

--- a/ios/RunnerTests/FirstPairWizardStepTests.swift
+++ b/ios/RunnerTests/FirstPairWizardStepTests.swift
@@ -69,4 +69,34 @@ struct FirstPairWizardStepTests {
                     skipsPermissions: true) == 4)
         }
     }
+
+    @MainActor
+    @Test("Phone Hotspot pairing surfaces a saved camera when it is the only repair candidate")
+    func phoneHotspotSavedCameraRepairFallback() {
+        let model = NativeAppModel()
+        model.isPairingNewCamera = true
+        model.firstPairTransportMethod = .phoneHotspot
+        model.discoveryTransportFilter = .wiFi
+        model.savedCameras = [
+            PTPIPSavedCameraRecord(
+                host: "172.20.10.8",
+                displayName: "ZR_6001234",
+                transport: "iPhone hotspot",
+                lastSeenAt: nil
+            )
+        ]
+        let rediscovered = DiscoveredCamera(
+            ip: "172.20.10.15",
+            name: "ZR_6001234",
+            source: .bonjour
+        )
+        let unrelatedUSB = DiscoveredCamera(
+            ip: "usb:TEST",
+            name: "ZR_7000000",
+            source: .usb
+        )
+        model.discoveredCameras = [rediscovered, unrelatedUSB]
+
+        #expect(model.pairingDiscoveryCandidates == [rediscovered])
+    }
 }


### PR DESCRIPTION
## Summary

- preserve an installed 16-byte PTP-IP initiator identity instead of replacing it during branding changes
- surface a rediscovered saved hotspot camera as an explicit pairing repair fallback when no new camera is present
- add core and iOS model regression coverage and document the migration failure

## Root cause

PR #25 changed the initiator GUID bytes, but the connection store replaced the persisted identity while retaining saved camera records. Discovery still found the Nikon ZR, then the pairing screen filtered it out as already saved and remained on Looking for cameras.

## Verification

- `just test` (666 tests)
- focused `FirstPairWizardStepTests` suite
- `just native-check`
- `just check`

Physical Nikon ZR hotspot confirmation is still required.

Closes #151