### PR TITLE
ci: run native checks on hosted macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,34 @@ jobs:
       - name: Run native checks
         run: just native-check
 
+  gate:
+    name: CI gate
+    # The single required status check. `native` and `android` are conditional, and a required
+    # check that never reports leaves a pull request blocked forever — so this job always runs and
+    # collapses every other job's result into one verdict. Requiring it is also fail-closed: a pull
+    # request that edits this workflow to drop a job stops reporting `CI gate` and cannot merge.
+    if: always()
+    needs: [meta, secrets, changes, native, android]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every job to have passed or been deliberately skipped
+        env:
+          # success | failure | cancelled | skipped, one per job in `needs`.
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          set -euo pipefail
+          for result in $RESULTS; do
+            case "$result" in
+              # `skipped` is legitimate: the paths filter proved the job had nothing to do.
+              success | skipped) ;;
+              *)
+                echo "::error::a CI job reported '$result'"
+                exit 1
+                ;;
+            esac
+          done
+          echo "All CI jobs passed or were skipped: $RESULTS"
+
   android:
     name: Android
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,8 @@ jobs:
               - 'scripts/add-*.rb'
               - 'scripts/ios-*.sh'
               - 'justfile'
+              # Changing how the native job builds must re-run the native job.
+              - '.github/workflows/ci.yml'
             android:
               - 'Apps/Android/**'
 
@@ -120,15 +122,17 @@ jobs:
     needs: changes
     # Skip the slow macOS build for docs-only changes; Meta checks still lint the docs.
     if: ${{ needs.changes.outputs.code == 'true' }}
-    # Self-hosted Mac while the repo is private (hosted macOS minutes bill at 10x). The machine's
-    # default toolchain is Xcode 26.2, so no setup-xcode step. IMPORTANT: switch back to
-    # macos-latest before the repository goes public — self-hosted runners must never serve
-    # fork PRs.
-    runs-on: [self-hosted, macOS]
+    # Hosted macOS: free and unlimited on public repositories, and a fresh VM per job. Never move
+    # this job to a self-hosted runner — it runs `just native-check` from the pull request, so a
+    # fork PR would execute attacker-controlled code on a persistent machine.
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+      - uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+        with:
+          xcode-version: latest-stable
       - name: Install native tooling
         run: brew install just swift-format || true
       - name: Run native checks


### PR DESCRIPTION
## Summary

- move the `Native Swift/iOS` job from the self-hosted Mac to `macos-latest` ahead of the repository going public — the job runs `just native-check` from the pull request, so a fork PR would execute attacker-controlled code on a persistent personal machine
- add `setup-xcode`, since the self-hosted Mac supplied Xcode 26.2 as its default toolchain and hosted runners do not; mirrors `testflight.yml`, which already builds on `macos-latest`
- add `.github/workflows/ci.yml` to the `code` paths filter so a change to the native job re-runs the native job — without it this switch would merge untested
- add an always-run `CI gate` job that collapses every job's result into a single verdict, so the native build can become a *required* status check instead of advisory

The job was self-hosted because hosted macOS bills at 10x on a **private** repository. Standard macOS runners are free and unlimited on public repositories, so the cost rationale disappears at the same moment the security risk appears.

## Verification

- `just check` (669 tests, 24 suites)
- `actionlint` clean
- `Native Swift/iOS` runs on this PR by way of the paths-filter change — that green run **is** the verification that hosted macOS can build the project

## Follow-up (not this PR)

Deregister runner id 2 and stop the service on the machine once the hosted job is confirmed green.

## Follow-up: make `CI gate` required

`native` and `android` are conditional on the paths filter, so neither can be a required status check — a required check that never reports blocks the pull request forever, which is why branch protection currently requires only `Meta checks` and `Secret scan`. That leaves the Swift build advisory: a pull request could break it and still satisfy every required check.

`CI gate` always runs, so it can be required. It accepts `skipped` as well as `success`, because a skip means the paths filter proved the job had nothing to do. Requiring it is fail-closed — a pull request that edits this workflow to drop a job stops reporting `CI gate` and cannot merge.

**Order matters:** merge this first, *then* add `CI gate` to branch protection. Requiring it before it exists on `main` blocks every open pull request on a check nothing reports.

## Kaneo

- OPE-81

🤖 Generated with [Claude Code](https://claude.com/claude-code)