### PR TITLE
ci: resume Dependabot action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,4 @@ updates:
       interval: weekly
     commit-message:
       prefix: ci
-    # Paused for the pre-launch phase; raise the limit to re-enable update PRs.
-    open-pull-requests-limit: 0
   # Add production native ecosystems here once Swift/iOS/Android package manifests settle.


### PR DESCRIPTION
## Summary

- drop `open-pull-requests-limit: 0`, which paused every Dependabot update PR for the pre-launch phase; the limit returns to the default of 5

Doing this before the repository goes public means the catch-up PRs land while it is still private, rather than being the first thing visitors see. It also returns the SHA-pinned actions in `ci.yml` to a maintained update cadence, which matters more once that workflow serves fork pull requests.

Dependabot *alerts* and security updates are a separate mechanism — they require the repository to be public and get enabled after the visibility flip.

## Verification

- `just hygiene` and `just secrets` clean
- config-only change; Dependabot validates `.github/dependabot.yml` against the default branch on merge

## Kaneo

- OPE-82

🤖 Generated with [Claude Code](https://claude.com/claude-code)