### PR TITLE
feat(site): show repo and Android as coming soon

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -127,6 +127,8 @@ Feature work tracked as its own tasks on the Kaneo board, outside the Phase 0–
   where 100% matches the former 25% appearance and saved iOS settings migrate without a visual jump.
 - **Android beta-readiness parity** (planned) — port the diagnostics, support links, and live-view
   guide after the iOS behavior is validated with external testers.
+- **Public launch landing actions** (in progress): keep TestFlight available while Android and the
+  public repository are presented as clearly unavailable until their launches.
 
 ## Milestone Success Criteria
 

--- a/scripts/check-site.sh
+++ b/scripts/check-site.sh
@@ -19,6 +19,18 @@ if grep -q 'REPO_URL' "${html_files[@]}"; then
   exit 1
 fi
 
+if grep -q 'href="https://github.com/erik-sutton95/OpenZCine"' site/index.html; then
+  echo "Landing page must not link visitors to the private repository." >&2
+  exit 1
+fi
+
+android_soon_count=$(grep -c 'data-coming-soon="android" aria-disabled="true"' site/index.html || true)
+repo_soon_count=$(grep -c 'data-coming-soon="public-repo" aria-disabled="true"' site/index.html || true)
+if (( android_soon_count != 2 || repo_soon_count != 4 )); then
+  echo "Landing page must expose disabled coming-soon states for Android and the public repo." >&2
+  exit 1
+fi
+
 if [[ "$mode" == "deployed" ]] && grep -q 'TESTFLIGHT_URL' "${html_files[@]}"; then
   echo "Deployed site still contains TESTFLIGHT_URL." >&2
   exit 1

--- a/scripts/check-site.sh
+++ b/scripts/check-site.sh
@@ -19,18 +19,6 @@ if grep -q 'REPO_URL' "${html_files[@]}"; then
   exit 1
 fi
 
-if grep -q 'href="https://github.com/erik-sutton95/OpenZCine"' site/index.html; then
-  echo "Landing page must not link visitors to the private repository." >&2
-  exit 1
-fi
-
-android_soon_count=$(grep -c 'data-coming-soon="android" aria-disabled="true"' site/index.html || true)
-repo_soon_count=$(grep -c 'data-coming-soon="public-repo" aria-disabled="true"' site/index.html || true)
-if (( android_soon_count != 2 || repo_soon_count != 4 )); then
-  echo "Landing page must expose disabled coming-soon states for Android and the public repo." >&2
-  exit 1
-fi
-
 if [[ "$mode" == "deployed" ]] && grep -q 'TESTFLIGHT_URL' "${html_files[@]}"; then
   echo "Deployed site still contains TESTFLIGHT_URL." >&2
   exit 1

--- a/site/assets/app.css
+++ b/site/assets/app.css
@@ -231,6 +231,31 @@ h3 { font-size: clamp(20px, 2.4vw, 26px); line-height: 1.2; letter-spacing: -0.0
   opacity: 1; transform: translateX(0);
 }
 
+/* Unavailable actions keep the pill silhouette while making their release
+  status unmistakable. They are spans, so they cannot receive focus or clicks. */
+.btn--disabled {
+  background: rgba(247,239,225,0.035);
+  color: var(--faint);
+  border: 1px solid var(--hairline);
+  cursor: not-allowed;
+  transform: none;
+  will-change: auto;
+}
+.btn--disabled:hover { background: rgba(247,239,225,0.035); border-color: var(--hairline); }
+.btn__status {
+  padding: 3px 7px;
+  border: 1px solid var(--hairline);
+  border-radius: 999px;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: .08em;
+  line-height: 1.2;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .btn, .btn__rec, .btn__arrow { transition: none; }
   .btn--primary:hover .btn__rec { animation: none; }
@@ -287,11 +312,17 @@ h3 { font-size: clamp(20px, 2.4vw, 26px); line-height: 1.2; letter-spacing: -0.0
 .nav__links a:hover { color: var(--ink); }
 .nav__links a:hover::after { right: 0; }
 .nav__cta { display: flex; align-items: center; gap: 10px; }
-.nav__github { font-size: 14px; color: var(--muted); }
-.nav__github:hover { color: var(--ink); }
+.nav__repo-status {
+  display: inline-flex; align-items: center; gap: 6px;
+  color: var(--faint); font-size: 14px; cursor: not-allowed;
+}
+.nav__status {
+  color: var(--faint); font-family: var(--mono); font-size: 8px;
+  letter-spacing: .08em; text-transform: uppercase;
+}
 .nav__cta .btn { padding: 9px 16px; font-size: 14px; }
 @media (min-width: 860px) { .nav__links { display: flex; } }
-@media (max-width: 560px) { .nav__github { display: none; } }
+@media (max-width: 560px) { .nav__repo-status { display: none; } }
 
 /* ---- Footer ---- */
 .footer { background: var(--bg-deep); border-top: 1px solid var(--hairline); padding: 48px 0; }

--- a/site/index.html
+++ b/site/index.html
@@ -58,7 +58,9 @@
         <a href="#open-source">Open Source</a>
       </nav>
       <div class="nav__cta">
-        <a class="nav__github" href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener" aria-label="OpenZCine on GitHub">★ GitHub</a>
+        <span class="nav__repo-status" data-coming-soon="public-repo" aria-disabled="true">
+          Public repo <span class="nav__status">soon</span>
+        </span>
         <a class="btn btn--primary btn--magnetic" href="TESTFLIGHT_URL"><span class="btn__rec" aria-hidden="true"></span>Join the beta</a>
       </div>
     </div>
@@ -81,7 +83,12 @@
           built-in, RED, or custom LUT baking. Free and open source.</p>
         <div class="hero__cta" data-intro>
           <a class="btn btn--primary btn--magnetic" href="TESTFLIGHT_URL"><span class="btn__rec" aria-hidden="true"></span>Join the TestFlight beta</a>
-          <a class="btn btn--ghost btn--magnetic" href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">★ Star on GitHub<span class="btn__arrow" aria-hidden="true">→</span></a>
+          <span class="btn btn--disabled" data-coming-soon="android" aria-disabled="true">
+            Android <span class="btn__status">Coming soon</span>
+          </span>
+          <span class="btn btn--disabled" data-coming-soon="public-repo" aria-disabled="true">
+            Public repo <span class="btn__status">Coming soon</span>
+          </span>
         </div>
 
         <div class="hero__mock" data-intro>
@@ -273,8 +280,9 @@
         <p class="lead">No subscriptions, no paywalls, no telemetry. OpenZCine is Apache-2.0
           licensed and built in the open by a community of filmmakers and developers.</p>
         <div class="hero__cta">
-          <a class="btn btn--primary btn--magnetic" href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener"><span class="btn__rec" aria-hidden="true"></span>★ Star on GitHub</a>
-          <a class="btn btn--ghost btn--magnetic" href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">Contribute<span class="btn__arrow" aria-hidden="true">→</span></a>
+          <span class="btn btn--disabled" data-coming-soon="public-repo" aria-disabled="true">
+            Public repo <span class="btn__status">Coming soon</span>
+          </span>
         </div>
       </div>
     </section>
@@ -306,7 +314,12 @@
         <p class="lead">Join the TestFlight beta and help shape OpenZCine.</p>
         <div class="hero__cta">
           <a class="btn btn--primary btn--magnetic" href="TESTFLIGHT_URL"><span class="btn__rec" aria-hidden="true"></span>Join the TestFlight beta</a>
-          <a class="btn btn--ghost btn--magnetic" href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">★ Star on GitHub<span class="btn__arrow" aria-hidden="true">→</span></a>
+          <span class="btn btn--disabled" data-coming-soon="android" aria-disabled="true">
+            Android <span class="btn__status">Coming soon</span>
+          </span>
+          <span class="btn btn--disabled" data-coming-soon="public-repo" aria-disabled="true">
+            Public repo <span class="btn__status">Coming soon</span>
+          </span>
         </div>
       </div>
     </section>
@@ -323,7 +336,7 @@
         <a href="/support/">Support</a> ·
         <a href="/privacy/">Privacy</a> ·
         <a href="/terms/">Terms</a> ·
-        Free &amp; open source · <a href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">Apache-2.0</a>
+        Free &amp; open source · Apache-2.0
       </p>
       <p class="footer__disclaimer">
         Not affiliated with or endorsed by Nikon Corporation. &ldquo;Nikon&rdquo;,


### PR DESCRIPTION
## Summary

- keep TestFlight as the only active landing-page release action
- show Android and the public repository as consistent disabled Coming soon pills
- remove homepage links that currently send public visitors to the private repository

## Verification

- `just check`
- visual QA at 1280 x 800, 768 x 1024, and 375 x 812
- verified disabled pills have no link target, keyboard focus, or magnetic hover behavior

Closes #169