### PR TITLE
fix(ios): scope monitor layout to classic notches

### DIFF
--- a/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
+++ b/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
@@ -518,10 +518,11 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
                 width: max(0, deckRight - deckLeft),
                 height: topInfoDeckHeight
             ),
-            bottomAssistTools: bottomRegion.place(
+            bottomAssistTools: Self.bottomAssistFrame(
+                in: bottomRegion,
                 width: bottomModuleWidth,
-                height: bottomRegion.height,
-                anchor: .leading
+                batteryRail: batteryRail,
+                safeArea: feedSafeArea
             ),
             bottomCaptureSettings: bottomCaptureRegion.place(
                 width: bottomModuleWidth,
@@ -543,6 +544,32 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
 
     private static func rightRailWidth(for chromeWidth: Double) -> Double {
         min(max(0, chromeWidth), MonitorSideRailControlLayout.recordButtonSize)
+    }
+
+    private static func bottomAssistFrame(
+        in region: MonitorLayoutRegion,
+        width: Double,
+        batteryRail: MonitorModuleFrame,
+        safeArea: MonitorEdgeInsets
+    ) -> MonitorModuleFrame {
+        let defaultFrame = region.place(
+            width: width,
+            height: region.height,
+            anchor: .leading
+        )
+        guard MonitorBatteryRailLayout.usesClassicSideNotch(safeArea: safeArea) else {
+            return defaultFrame
+        }
+
+        let defaultRight = defaultFrame.x + defaultFrame.width
+        let clearLeft = batteryRail.x + batteryRail.width + bottomModuleSpacing
+        let adjustedLeft = min(defaultRight, max(defaultFrame.x, clearLeft))
+        return MonitorModuleFrame(
+            x: adjustedLeft,
+            y: defaultFrame.y,
+            width: defaultRight - adjustedLeft,
+            height: defaultFrame.height
+        )
     }
 
     private static func rightRailFrame(
@@ -716,12 +743,14 @@ public struct MonitorBatteryRailLayout: Equatable, Sendable {
     }
 
     private static func sideNotchHeight(for safeArea: MonitorEdgeInsets) -> Double {
+        usesClassicSideNotch(safeArea: safeArea) ? classicSideNotchHeight : sideNotchHeight
+    }
+
+    /// Whether symmetric landscape safe areas identify the wider pre-Dynamic-Island notch.
+    public static func usesClassicSideNotch(safeArea: MonitorEdgeInsets) -> Bool {
         let leading = max(0, safeArea.leading)
         let trailing = max(0, safeArea.trailing)
-        let hasSymmetricClassicNotch =
-            min(leading, trailing) >= 40 && abs(leading - trailing) < 4
-
-        return hasSymmetricClassicNotch ? classicSideNotchHeight : sideNotchHeight
+        return min(leading, trailing) >= 40 && abs(leading - trailing) < 4
     }
 }
 

--- a/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
+++ b/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
@@ -212,7 +212,8 @@ public enum MonitorFeedLayout {
     public static func frame(
         viewportWidth: Double,
         viewportHeight: Double,
-        safeArea: MonitorEdgeInsets
+        safeArea: MonitorEdgeInsets,
+        horizontalDirection: MonitorHorizontalLayoutDirection = .standard
     ) -> MonitorFeedFrame {
         let leadingInset = leadingInset(for: safeArea)
         let viewportWidth = max(0, viewportWidth)
@@ -244,12 +245,18 @@ public enum MonitorFeedLayout {
         }
 
         let remainingWidth = max(0, viewportWidth - width)
-        // A classic landscape notch reports equal horizontal safe areas, so keep the image
-        // centered between the two side margins instead of anchoring it beneath either side.
-        let x =
-            MonitorBatteryRailLayout.usesClassicSideNotch(safeArea: safeArea)
-            ? remainingWidth / 2
-            : min(remainingWidth, leadingInset)
+        let x: Double
+        if MonitorBatteryRailLayout.usesClassicSideNotch(safeArea: safeArea) {
+            // Classic iPhones report equal horizontal safe areas even though only one side has
+            // the notch. Use the physical orientation to spend the full notch-side safe lane
+            // without wasting an additional centered margin beside it.
+            x =
+                horizontalDirection == .mirrored
+                ? max(0, remainingWidth - safeArea.trailing)
+                : min(remainingWidth, safeArea.leading)
+        } else {
+            x = min(remainingWidth, leadingInset)
+        }
 
         return MonitorFeedFrame(x: x, y: 0, width: width, height: viewportHeight)
     }
@@ -258,12 +265,14 @@ public enum MonitorFeedLayout {
     public static func fullBleedFrame(
         viewportWidth: Double,
         viewportHeight: Double,
-        safeArea: MonitorEdgeInsets
+        safeArea: MonitorEdgeInsets,
+        horizontalDirection: MonitorHorizontalLayoutDirection = .standard
     ) -> MonitorFeedFrame {
         frame(
             viewportWidth: viewportWidth,
             viewportHeight: viewportHeight,
-            safeArea: safeArea
+            safeArea: safeArea,
+            horizontalDirection: horizontalDirection
         )
     }
 }
@@ -472,7 +481,8 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
         let feed = MonitorFeedLayout.fullBleedFrame(
             viewportWidth: viewportWidth,
             viewportHeight: viewportHeight,
-            safeArea: feedSafeArea
+            safeArea: feedSafeArea,
+            horizontalDirection: horizontalDirection
         )
         let rightRailLane = screen.trailingLane(after: feed)
         let rightRailControls = Self.rightRailFrame(
@@ -490,13 +500,19 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
             height: lockButtonSize
         )
 
-        // Keep the deck centered over the feed while clearing the lock on compact classic-notch
-        // phones. Their symmetric 44pt landscape safe areas put the feed's usual 10pt inset just
-        // inside the lock frame; modern asymmetric cutouts already have enough feed clearance.
+        // Keep the deck centered over the feed while clearing the lock only on compact
+        // classic-notch phones. Every other device retains the established deck inset.
         let minimumDeckInset =
             lockButton.x + lockButton.width + topInfoDeckControlGap - feed.x
+        let usesClassicSideNotch = MonitorBatteryRailLayout.usesClassicSideNotch(
+            safeArea: feedSafeArea
+        )
         let deckInset =
-            constrained ? topInfoDeckSideInset : max(topInfoDeckSideInset, minimumDeckInset)
+            constrained
+            ? topInfoDeckSideInset
+            : usesClassicSideNotch
+                ? max(topInfoDeckSideInset, minimumDeckInset)
+                : topInfoDeckSideInset
         let deckLeft = feed.x + deckInset
         let deckRight = feed.x + feed.width - deckInset
 
@@ -679,6 +695,12 @@ public struct MonitorBatteryRailLayout: Equatable, Sendable {
     /// Battery indicator height in points (battery glyph + percentage + device icon).
     public static let indicatorHeight = 70.0
 
+    /// Compact phone-battery height used between the lock button and a classic side notch.
+    public static let compactPhoneIndicatorHeight = 26.0
+
+    /// Visual separation between the lock button and compact phone-battery readout.
+    public static let lockButtonGap = 4.0
+
     /// Reserved vertical span for the landscape Dynamic Island. Sized just over the physical
     /// island (~126pt black core on the Pro Max) so the indicators sit snug above and below it.
     public static let sideNotchHeight = 135.0
@@ -706,6 +728,7 @@ public struct MonitorBatteryRailLayout: Equatable, Sendable {
     // Indicator centers.
     public let phoneCenterX: Double
     public let phoneCenterY: Double
+    public let phoneIndicatorHeight: Double
     public let cameraCenterX: Double
     public let cameraCenterY: Double
 
@@ -713,27 +736,36 @@ public struct MonitorBatteryRailLayout: Equatable, Sendable {
     public let notchTop: Double
     public let notchBottom: Double
 
-    public var phoneBottom: Double { phoneCenterY + Self.indicatorHeight / 2 }
+    public var phoneTop: Double { phoneCenterY - phoneIndicatorHeight / 2 }
+    public var phoneBottom: Double { phoneCenterY + phoneIndicatorHeight / 2 }
     public var cameraTop: Double { cameraCenterY - Self.indicatorHeight / 2 }
 
     /// Fits the battery indicators to the side rail.
     public static func fit(
         railHeight: Double,
-        safeArea: MonitorEdgeInsets = .zero
+        safeArea: MonitorEdgeInsets = .zero,
+        phoneTopClearance: Double = 0
     ) -> MonitorBatteryRailLayout {
+        let usesCompactPhoneIndicator = usesClassicSideNotch(safeArea: safeArea)
+        let phoneIndicatorHeight =
+            usesCompactPhoneIndicator ? compactPhoneIndicatorHeight : indicatorHeight
         let requestedNotchHeight = sideNotchHeight(for: safeArea)
         let maximumNotchHeight = max(
-            0, railHeight - 2 * (indicatorHeight + notchPadding))
+            0,
+            railHeight - phoneIndicatorHeight - indicatorHeight - 2 * notchPadding
+        )
         let notchHeight = min(requestedNotchHeight, maximumNotchHeight)
         let notchCenterY = railHeight / 2
         let notchTop = notchCenterY - notchHeight / 2
         let notchBottom = notchCenterY + notchHeight / 2
         let indicatorCenterX = indicatorWidth / 2 - notchAlignmentInsetX
-        let minimumCenterY = indicatorHeight / 2
-        let maximumCenterY = max(minimumCenterY, railHeight - indicatorHeight / 2)
+        let minimumPhoneCenterY =
+            max(0, phoneTopClearance) + phoneIndicatorHeight / 2
+        let minimumCameraCenterY = indicatorHeight / 2
+        let maximumCenterY = max(minimumCameraCenterY, railHeight - indicatorHeight / 2)
         let phoneCenterY = max(
-            minimumCenterY,
-            notchTop - notchPadding - indicatorHeight / 2
+            minimumPhoneCenterY,
+            notchTop - notchPadding - phoneIndicatorHeight / 2
         )
         let cameraCenterY = min(
             maximumCenterY,
@@ -743,6 +775,7 @@ public struct MonitorBatteryRailLayout: Equatable, Sendable {
         return MonitorBatteryRailLayout(
             phoneCenterX: indicatorCenterX,
             phoneCenterY: phoneCenterY,
+            phoneIndicatorHeight: phoneIndicatorHeight,
             cameraCenterX: indicatorCenterX,
             cameraCenterY: cameraCenterY,
             notchTop: notchTop,
@@ -754,11 +787,15 @@ public struct MonitorBatteryRailLayout: Equatable, Sendable {
         usesClassicSideNotch(safeArea: safeArea) ? classicSideNotchHeight : sideNotchHeight
     }
 
-    /// Whether symmetric landscape safe areas identify the wider pre-Dynamic-Island notch.
+    /// Whether landscape safe-area geometry identifies a wider pre-Dynamic-Island notch.
+    /// Apple exposes no public notch-type API, so keep this deliberately narrow: classic-notch
+    /// phones occupy the 44–50pt band while Dynamic Island phones use larger side insets.
     public static func usesClassicSideNotch(safeArea: MonitorEdgeInsets) -> Bool {
         let leading = max(0, safeArea.leading)
         let trailing = max(0, safeArea.trailing)
-        return min(leading, trailing) >= 40 && abs(leading - trailing) < 4
+        let minimumInset = min(leading, trailing)
+        let maximumInset = max(leading, trailing)
+        return minimumInset >= 40 && maximumInset <= 50 && abs(leading - trailing) < 4
     }
 }
 

--- a/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
+++ b/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
@@ -184,6 +184,9 @@ public enum MonitorFeedLayout {
     /// Native monitor preview aspect ratio.
     public static let aspectRatio = 16.0 / 9.0
 
+    /// Classic-notch feed translation toward the opposite-side control rail.
+    public static let classicNotchRailwardShift = 10.0
+
     /// True for landscape viewports narrower than 16:9 (4:3-ish iPads), where the full-height
     /// feed would overflow the width. On these screens the side-rail chrome moves into the
     /// corners (battery inline beside the lock, settings/media top-trailing, record/DISP
@@ -248,12 +251,17 @@ public enum MonitorFeedLayout {
         let x: Double
         if MonitorBatteryRailLayout.usesClassicSideNotch(safeArea: safeArea) {
             // Classic iPhones report equal horizontal safe areas even though only one side has
-            // the notch. Use the physical orientation to spend the full notch-side safe lane
-            // without wasting an additional centered margin beside it.
+            // the notch. Use physical orientation to clear that side, then bias the feed slightly
+            // toward the opposite control rail to close its oversized black gap.
+            let availableShift = max(
+                0,
+                remainingWidth - max(0, safeArea.leading) - max(0, safeArea.trailing)
+            )
+            let railwardShift = min(classicNotchRailwardShift, availableShift)
             x =
                 horizontalDirection == .mirrored
-                ? max(0, remainingWidth - safeArea.trailing)
-                : min(remainingWidth, safeArea.leading)
+                ? max(0, remainingWidth - safeArea.trailing - railwardShift)
+                : min(remainingWidth, safeArea.leading + railwardShift)
         } else {
             x = min(remainingWidth, leadingInset)
         }
@@ -484,7 +492,28 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
             safeArea: feedSafeArea,
             horizontalDirection: horizontalDirection
         )
-        let rightRailLane = screen.trailingLane(after: feed)
+        let usesClassicSideNotch = MonitorBatteryRailLayout.usesClassicSideNotch(
+            safeArea: feedSafeArea
+        )
+        // The classic-notch feed moves toward the rail, but the rail itself stays on its
+        // established center line. Recover the pre-translation feed edge for lane placement.
+        let availableClassicShift = max(
+            0,
+            viewportWidth - feed.width - max(0, feedSafeArea.leading)
+                - max(0, feedSafeArea.trailing)
+        )
+        let classicShift =
+            usesClassicSideNotch
+            ? min(MonitorFeedLayout.classicNotchRailwardShift, availableClassicShift)
+            : 0
+        let railReferenceFeed = MonitorFeedFrame(
+            x: feed.x
+                + (horizontalDirection == .mirrored ? classicShift : -classicShift),
+            y: feed.y,
+            width: feed.width,
+            height: feed.height
+        )
+        let rightRailLane = screen.trailingLane(after: railReferenceFeed)
         let rightRailControls = Self.rightRailFrame(
             lane: rightRailLane,
             chrome: chrome,
@@ -504,9 +533,6 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
         // classic-notch phones. Every other device retains the established deck inset.
         let minimumDeckInset =
             lockButton.x + lockButton.width + topInfoDeckControlGap - feed.x
-        let usesClassicSideNotch = MonitorBatteryRailLayout.usesClassicSideNotch(
-            safeArea: feedSafeArea
-        )
         let deckInset =
             constrained
             ? topInfoDeckSideInset

--- a/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
+++ b/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
@@ -243,7 +243,15 @@ public enum MonitorFeedLayout {
             )
         }
 
-        return MonitorFeedFrame(x: leadingInset, y: 0, width: width, height: viewportHeight)
+        let remainingWidth = max(0, viewportWidth - width)
+        // A classic landscape notch reports equal horizontal safe areas, so keep the image
+        // centered between the two side margins instead of anchoring it beneath either side.
+        let x =
+            MonitorBatteryRailLayout.usesClassicSideNotch(safeArea: safeArea)
+            ? remainingWidth / 2
+            : min(remainingWidth, leadingInset)
+
+        return MonitorFeedFrame(x: x, y: 0, width: width, height: viewportHeight)
     }
 
     /// Fits the feed to the visible viewport without expanding the native 16:9 source frame.

--- a/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
+++ b/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
@@ -727,17 +727,19 @@ public struct MonitorBatteryRailLayout: Equatable, Sendable {
     /// Visual separation between the lock button and compact phone-battery readout.
     public static let lockButtonGap = 4.0
 
-    /// Reserved vertical span for the landscape Dynamic Island. Sized just over the physical
-    /// island (~126pt black core on the Pro Max) so the indicators sit snug above and below it.
-    public static let sideNotchHeight = 135.0
+    /// Reserved vertical span for the landscape Dynamic Island. The physical black core is about
+    /// 126pt tall, so this leaves a narrow safety edge while keeping both battery groups clear of
+    /// the neighboring lock and LUT controls.
+    public static let sideNotchHeight = 127.0
 
     /// Reserved vertical span for the wider classic notch used by iPhone 11-era displays.
     public static let classicSideNotchHeight = 232.0
 
-    /// Clearance between the battery indicators and the side notch reservation. Kept small so the
-    /// indicators tuck in close to the Dynamic Island (the reservation already clears the physical
-    /// island by a few points, so this stays off it).
+    /// Clearance between the battery indicators and the classic-notch reservation.
     public static let notchPadding = 3.0
+
+    /// Tighter clearance around the Dynamic Island reservation on newer iPhones.
+    public static let dynamicIslandPadding = 1.0
 
     /// Horizontal nudge that aligns the indicators with the Dynamic Island, which sits slightly
     /// inboard of the chrome's leading inset.
@@ -776,9 +778,10 @@ public struct MonitorBatteryRailLayout: Equatable, Sendable {
         let phoneIndicatorHeight =
             usesCompactPhoneIndicator ? compactPhoneIndicatorHeight : indicatorHeight
         let requestedNotchHeight = sideNotchHeight(for: safeArea)
+        let padding = notchPadding(for: safeArea)
         let maximumNotchHeight = max(
             0,
-            railHeight - phoneIndicatorHeight - indicatorHeight - 2 * notchPadding
+            railHeight - phoneIndicatorHeight - indicatorHeight - 2 * padding
         )
         let notchHeight = min(requestedNotchHeight, maximumNotchHeight)
         let notchCenterY = railHeight / 2
@@ -791,11 +794,11 @@ public struct MonitorBatteryRailLayout: Equatable, Sendable {
         let maximumCenterY = max(minimumCameraCenterY, railHeight - indicatorHeight / 2)
         let phoneCenterY = max(
             minimumPhoneCenterY,
-            notchTop - notchPadding - phoneIndicatorHeight / 2
+            notchTop - padding - phoneIndicatorHeight / 2
         )
         let cameraCenterY = min(
             maximumCenterY,
-            notchBottom + notchPadding + indicatorHeight / 2
+            notchBottom + padding + indicatorHeight / 2
         )
 
         return MonitorBatteryRailLayout(
@@ -811,6 +814,10 @@ public struct MonitorBatteryRailLayout: Equatable, Sendable {
 
     private static func sideNotchHeight(for safeArea: MonitorEdgeInsets) -> Double {
         usesClassicSideNotch(safeArea: safeArea) ? classicSideNotchHeight : sideNotchHeight
+    }
+
+    private static func notchPadding(for safeArea: MonitorEdgeInsets) -> Double {
+        usesClassicSideNotch(safeArea: safeArea) ? notchPadding : dynamicIslandPadding
     }
 
     /// Whether landscape safe-area geometry identifies a wider pre-Dynamic-Island notch.

--- a/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
+++ b/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
@@ -353,6 +353,9 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
     /// Horizontal inset that floats the top information deck over the feed, clear of the side lanes.
     public static let topInfoDeckSideInset = 10.0
 
+    /// Horizontal breathing room between the lock control and the information deck.
+    public static let topInfoDeckControlGap = 12.0
+
     /// Diameter of the top-leading lock button.
     public static let lockButtonSize = 40.0
 
@@ -470,10 +473,24 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
             railWidth: rightRailWidth
         )
 
-        // The deck spans the feed (minus symmetric insets) so its center is the feed center.
-        // The rail offset is tuned to keep the controls clear of the centered deck.
-        let deckLeft = feed.x + topInfoDeckSideInset
-        let deckRight = feed.x + feed.width - topInfoDeckSideInset
+        let lockButton = MonitorModuleFrame(
+            // Vertically centered in the top deck's band so its top edge lines up with the
+            // top bar pill (which is centered in that same band), rather than the chrome top.
+            x: chrome.x,
+            y: chrome.y + (topInfoDeckHeight - lockButtonSize) / 2,
+            width: lockButtonSize,
+            height: lockButtonSize
+        )
+
+        // Keep the deck centered over the feed while clearing the lock on compact classic-notch
+        // phones. Their symmetric 44pt landscape safe areas put the feed's usual 10pt inset just
+        // inside the lock frame; modern asymmetric cutouts already have enough feed clearance.
+        let minimumDeckInset =
+            lockButton.x + lockButton.width + topInfoDeckControlGap - feed.x
+        let deckInset =
+            constrained ? topInfoDeckSideInset : max(topInfoDeckSideInset, minimumDeckInset)
+        let deckLeft = feed.x + deckInset
+        let deckRight = feed.x + feed.width - deckInset
 
         // Width-constrained landscape also inlines the battery indicators beside the lock button
         // in the top chrome band instead of stacking them in a leading rail (no side lanes exist).
@@ -516,14 +533,7 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
                 lane: rightRailLane,
                 viewportHeight: viewportHeight
             ),
-            lockButton: MonitorModuleFrame(
-                // Vertically centered in the top deck's band so its top edge lines up with the
-                // top bar pill (which is centered in that same band), rather than the chrome top.
-                x: chrome.x,
-                y: chrome.y + (topInfoDeckHeight - lockButtonSize) / 2,
-                width: lockButtonSize,
-                height: lockButtonSize
-            )
+            lockButton: lockButton
         )
 
         return horizontalDirection == .mirrored
@@ -638,6 +648,9 @@ public struct MonitorBatteryRailLayout: Equatable, Sendable {
     /// island (~126pt black core on the Pro Max) so the indicators sit snug above and below it.
     public static let sideNotchHeight = 135.0
 
+    /// Reserved vertical span for the wider classic notch used by iPhone 11-era displays.
+    public static let classicSideNotchHeight = 232.0
+
     /// Clearance between the battery indicators and the side notch reservation. Kept small so the
     /// indicators tuck in close to the Dynamic Island (the reservation already clears the physical
     /// island by a few points, so this stays off it).
@@ -669,10 +682,17 @@ public struct MonitorBatteryRailLayout: Equatable, Sendable {
     public var cameraTop: Double { cameraCenterY - Self.indicatorHeight / 2 }
 
     /// Fits the battery indicators to the side rail.
-    public static func fit(railHeight: Double) -> MonitorBatteryRailLayout {
+    public static func fit(
+        railHeight: Double,
+        safeArea: MonitorEdgeInsets = .zero
+    ) -> MonitorBatteryRailLayout {
+        let requestedNotchHeight = sideNotchHeight(for: safeArea)
+        let maximumNotchHeight = max(
+            0, railHeight - 2 * (indicatorHeight + notchPadding))
+        let notchHeight = min(requestedNotchHeight, maximumNotchHeight)
         let notchCenterY = railHeight / 2
-        let notchTop = notchCenterY - sideNotchHeight / 2
-        let notchBottom = notchCenterY + sideNotchHeight / 2
+        let notchTop = notchCenterY - notchHeight / 2
+        let notchBottom = notchCenterY + notchHeight / 2
         let indicatorCenterX = indicatorWidth / 2 - notchAlignmentInsetX
         let minimumCenterY = indicatorHeight / 2
         let maximumCenterY = max(minimumCenterY, railHeight - indicatorHeight / 2)
@@ -693,6 +713,15 @@ public struct MonitorBatteryRailLayout: Equatable, Sendable {
             notchTop: notchTop,
             notchBottom: notchBottom
         )
+    }
+
+    private static func sideNotchHeight(for safeArea: MonitorEdgeInsets) -> Double {
+        let leading = max(0, safeArea.leading)
+        let trailing = max(0, safeArea.trailing)
+        let hasSymmetricClassicNotch =
+            min(leading, trailing) >= 40 && abs(leading - trailing) < 4
+
+        return hasSymmetricClassicNotch ? classicSideNotchHeight : sideNotchHeight
     }
 }
 

--- a/Tests/OpenZCineCoreTests/MonitorLayoutPolicyTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorLayoutPolicyTests.swift
@@ -580,8 +580,12 @@ import Testing
 @Test func batteryRailPlacesIndicatorsAroundSideNotch() {
     let layout = MonitorBatteryRailLayout.fit(railHeight: 390)
 
-    #expect(layout.phoneBottom == layout.notchTop - MonitorBatteryRailLayout.notchPadding)
-    #expect(layout.cameraTop == layout.notchBottom + MonitorBatteryRailLayout.notchPadding)
+    #expect(
+        layout.phoneBottom
+            == layout.notchTop - MonitorBatteryRailLayout.dynamicIslandPadding)
+    #expect(
+        layout.cameraTop
+            == layout.notchBottom + MonitorBatteryRailLayout.dynamicIslandPadding)
 }
 
 @Test func batteryRailKeepsIndicatorsCloserThanCornerAnchors() {
@@ -617,6 +621,12 @@ import Testing
         !MonitorBatteryRailLayout.usesClassicSideNotch(safeArea: symmetricDynamicIslandSafeArea))
     #expect(classic.phoneBottom == classic.notchTop - MonitorBatteryRailLayout.notchPadding)
     #expect(classic.cameraTop == classic.notchBottom + MonitorBatteryRailLayout.notchPadding)
+    #expect(
+        dynamicIsland.phoneBottom
+            == dynamicIsland.notchTop - MonitorBatteryRailLayout.dynamicIslandPadding)
+    #expect(
+        dynamicIsland.cameraTop
+            == dynamicIsland.notchBottom + MonitorBatteryRailLayout.dynamicIslandPadding)
 }
 
 @Test func dynamicIslandGeometryKeepsTheEstablishedMonitorLayout() {

--- a/Tests/OpenZCineCoreTests/MonitorLayoutPolicyTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorLayoutPolicyTests.swift
@@ -39,7 +39,7 @@ import Testing
     #expect(MonitorFeedLayout.leadingInset(for: safeArea) == 0)
 }
 
-@Test func feedLayoutCentersInsideClassicNotchLandscapeViewport() {
+@Test func feedLayoutUsesTheFullClassicNotchSafeLane() {
     let safeArea = MonitorEdgeInsets(top: 0, leading: 44, bottom: 21, trailing: 44)
     let frame = MonitorFeedLayout.fullBleedFrame(
         viewportWidth: 896,
@@ -47,10 +47,18 @@ import Testing
         safeArea: safeArea
     )
 
-    #expect(frame.x == 80)
+    #expect(frame.x == 44)
     #expect(frame.x >= safeArea.leading)
     #expect(frame.x + frame.width <= 896 - safeArea.trailing)
-    #expect(abs(frame.x + frame.width / 2 - 896 / 2) < 0.001)
+
+    let mirrored = MonitorFeedLayout.fullBleedFrame(
+        viewportWidth: 896,
+        viewportHeight: 414,
+        safeArea: safeArea,
+        horizontalDirection: .mirrored
+    )
+    #expect(mirrored.x == 116)
+    #expect(mirrored.x + mirrored.width == 896 - safeArea.trailing)
 }
 
 @Test func horizontalLayoutDirectionUsesDeviceOrientationBeforeSafeAreaFallback() {
@@ -329,14 +337,14 @@ import Testing
     #expect(landscapeRight.feed.x == 0)
     #expect(landscapeLeft.feed.height == 390)
     #expect(landscapeLeft.batteryRail == landscapeRight.batteryRail)
-    // The top deck floats over the feed, so it tracks the feed's leading edge per orientation.
+    // Dynamic Island layouts retain the established fixed inset from the feed in either
+    // orientation. Only classic-notch geometry receives the lock-clearance adjustment.
     #expect(
         landscapeLeft.topInfoDeck.x
             == landscapeLeft.feed.x + MonitorLiveViewModuleLayout.topInfoDeckSideInset)
     #expect(
         landscapeRight.topInfoDeck.x
-            >= landscapeRight.lockButton.x + landscapeRight.lockButton.width
-            + MonitorLiveViewModuleLayout.topInfoDeckControlGap)
+            == landscapeRight.feed.x + MonitorLiveViewModuleLayout.topInfoDeckSideInset)
     #expect(landscapeLeft.bottomAssistTools == landscapeRight.bottomAssistTools)
     #expect(landscapeLeft.bottomCaptureSettings == landscapeRight.bottomCaptureSettings)
     #expect(landscapeLeft.rightRailControls.x > landscapeLeft.feed.x + landscapeLeft.feed.width)
@@ -471,8 +479,7 @@ import Testing
     let deckCenter = layout.topInfoDeck.x + layout.topInfoDeck.width / 2
     let feedCenter = layout.feed.x + layout.feed.width / 2
 
-    #expect(layout.feed.x == 80)
-    #expect(abs(layout.feed.x + layout.feed.width / 2 - 896 / 2) < 0.001)
+    #expect(layout.feed.x == 44)
     #expect(
         lockRight + MonitorLiveViewModuleLayout.topInfoDeckControlGap
             <= layout.topInfoDeck.x)
@@ -580,6 +587,8 @@ import Testing
 @Test func batteryRailReservesTheFullClassicIPhoneNotch() {
     let classicSafeArea = MonitorEdgeInsets(top: 0, leading: 44, bottom: 21, trailing: 44)
     let dynamicIslandSafeArea = MonitorEdgeInsets(top: 0, leading: 59, bottom: 21, trailing: 44)
+    let symmetricDynamicIslandSafeArea = MonitorEdgeInsets(
+        top: 0, leading: 59, bottom: 21, trailing: 59)
     let classic = MonitorBatteryRailLayout.fit(
         railHeight: 414,
         safeArea: classicSafeArea
@@ -597,8 +606,48 @@ import Testing
             == MonitorBatteryRailLayout.sideNotchHeight)
     #expect(MonitorBatteryRailLayout.usesClassicSideNotch(safeArea: classicSafeArea))
     #expect(!MonitorBatteryRailLayout.usesClassicSideNotch(safeArea: dynamicIslandSafeArea))
+    #expect(
+        !MonitorBatteryRailLayout.usesClassicSideNotch(safeArea: symmetricDynamicIslandSafeArea))
     #expect(classic.phoneBottom == classic.notchTop - MonitorBatteryRailLayout.notchPadding)
     #expect(classic.cameraTop == classic.notchBottom + MonitorBatteryRailLayout.notchPadding)
+}
+
+@Test func dynamicIslandGeometryKeepsTheEstablishedMonitorLayout() {
+    let safeArea = MonitorEdgeInsets(top: 0, leading: 59, bottom: 21, trailing: 59)
+    let layout = MonitorLiveViewModuleLayout.fit(
+        viewportWidth: 874,
+        viewportHeight: 402,
+        feedSafeArea: safeArea,
+        chromeInsets: MonitorChromeLayout.insets(feedSafeArea: safeArea),
+        bottomBarHeight: 58,
+        horizontalDirection: .standard
+    )
+    let battery = MonitorBatteryRailLayout.fit(
+        railHeight: layout.batteryRail.height,
+        safeArea: safeArea,
+        phoneTopClearance: 47
+    )
+
+    #expect(layout.feed.x == safeArea.leading)
+    #expect(
+        layout.topInfoDeck.x
+            == layout.feed.x + MonitorLiveViewModuleLayout.topInfoDeckSideInset)
+    #expect(layout.bottomAssistTools.x == 16)
+    #expect(battery.phoneIndicatorHeight == MonitorBatteryRailLayout.indicatorHeight)
+}
+
+@Test func classicNotchPhoneBatterySeatsBelowTheLockCluster() {
+    let safeArea = MonitorEdgeInsets(top: 0, leading: 44, bottom: 21, trailing: 44)
+    let lockBottomWithGap = 47.0
+    let layout = MonitorBatteryRailLayout.fit(
+        railHeight: 386,
+        safeArea: safeArea,
+        phoneTopClearance: lockBottomWithGap
+    )
+
+    #expect(layout.phoneIndicatorHeight == MonitorBatteryRailLayout.compactPhoneIndicatorHeight)
+    #expect(layout.phoneTop >= lockBottomWithGap)
+    #expect(layout.phoneBottom <= layout.notchTop - MonitorBatteryRailLayout.notchPadding)
 }
 
 @Test func startupContentMarginsDoNotAddHorizontalSafeAreaGutters() {

--- a/Tests/OpenZCineCoreTests/MonitorLayoutPolicyTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorLayoutPolicyTests.swift
@@ -39,7 +39,7 @@ import Testing
     #expect(MonitorFeedLayout.leadingInset(for: safeArea) == 0)
 }
 
-@Test func feedLayoutUsesTheFullClassicNotchSafeLane() {
+@Test func feedLayoutTranslatesClassicNotchFeedTowardTheControlRail() {
     let safeArea = MonitorEdgeInsets(top: 0, leading: 44, bottom: 21, trailing: 44)
     let frame = MonitorFeedLayout.fullBleedFrame(
         viewportWidth: 896,
@@ -47,7 +47,7 @@ import Testing
         safeArea: safeArea
     )
 
-    #expect(frame.x == 44)
+    #expect(frame.x == 54)
     #expect(frame.x >= safeArea.leading)
     #expect(frame.x + frame.width <= 896 - safeArea.trailing)
 
@@ -57,8 +57,10 @@ import Testing
         safeArea: safeArea,
         horizontalDirection: .mirrored
     )
-    #expect(mirrored.x == 116)
-    #expect(mirrored.x + mirrored.width == 896 - safeArea.trailing)
+    #expect(mirrored.x == 106)
+    #expect(
+        mirrored.x + mirrored.width
+            == 896 - safeArea.trailing - MonitorFeedLayout.classicNotchRailwardShift)
 }
 
 @Test func horizontalLayoutDirectionUsesDeviceOrientationBeforeSafeAreaFallback() {
@@ -479,12 +481,17 @@ import Testing
     let deckCenter = layout.topInfoDeck.x + layout.topInfoDeck.width / 2
     let feedCenter = layout.feed.x + layout.feed.width / 2
 
-    #expect(layout.feed.x == 44)
+    #expect(layout.feed.x == 54)
     #expect(
         lockRight + MonitorLiveViewModuleLayout.topInfoDeckControlGap
             <= layout.topInfoDeck.x)
     #expect(abs(deckCenter - feedCenter) < 0.001)
     #expect(layout.topInfoDeck.x + layout.topInfoDeck.width <= 896)
+    let originalRailX =
+        safeArea.leading + layout.feed.width
+        + (896 - (safeArea.leading + layout.feed.width) - layout.rightRailControls.width) / 2
+    #expect(abs(layout.rightRailControls.x - originalRailX) < 0.001)
+    #expect(layout.rightRailControls.x - (layout.feed.x + layout.feed.width) < 10)
 
     let battery = MonitorBatteryRailLayout.fit(
         railHeight: layout.batteryRail.height,

--- a/Tests/OpenZCineCoreTests/MonitorLayoutPolicyTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorLayoutPolicyTests.swift
@@ -463,6 +463,17 @@ import Testing
             <= layout.topInfoDeck.x)
     #expect(abs(deckCenter - feedCenter) < 0.001)
     #expect(layout.topInfoDeck.x + layout.topInfoDeck.width <= 896)
+
+    let battery = MonitorBatteryRailLayout.fit(
+        railHeight: layout.batteryRail.height,
+        safeArea: safeArea
+    )
+    let cameraRight =
+        layout.batteryRail.x + battery.cameraCenterX
+        + MonitorBatteryRailLayout.indicatorWidth / 2
+    #expect(
+        cameraRight + MonitorLiveViewModuleLayout.bottomModuleSpacing
+            <= layout.bottomAssistTools.x)
 }
 
 @Test func liveViewLockButtonAlignsWithTopDeckBand() {
@@ -569,6 +580,8 @@ import Testing
     #expect(
         dynamicIsland.notchBottom - dynamicIsland.notchTop
             == MonitorBatteryRailLayout.sideNotchHeight)
+    #expect(MonitorBatteryRailLayout.usesClassicSideNotch(safeArea: classicSafeArea))
+    #expect(!MonitorBatteryRailLayout.usesClassicSideNotch(safeArea: dynamicIslandSafeArea))
     #expect(classic.phoneBottom == classic.notchTop - MonitorBatteryRailLayout.notchPadding)
     #expect(classic.cameraTop == classic.notchBottom + MonitorBatteryRailLayout.notchPadding)
 }

--- a/Tests/OpenZCineCoreTests/MonitorLayoutPolicyTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorLayoutPolicyTests.swift
@@ -39,6 +39,20 @@ import Testing
     #expect(MonitorFeedLayout.leadingInset(for: safeArea) == 0)
 }
 
+@Test func feedLayoutCentersInsideClassicNotchLandscapeViewport() {
+    let safeArea = MonitorEdgeInsets(top: 0, leading: 44, bottom: 21, trailing: 44)
+    let frame = MonitorFeedLayout.fullBleedFrame(
+        viewportWidth: 896,
+        viewportHeight: 414,
+        safeArea: safeArea
+    )
+
+    #expect(frame.x == 80)
+    #expect(frame.x >= safeArea.leading)
+    #expect(frame.x + frame.width <= 896 - safeArea.trailing)
+    #expect(abs(frame.x + frame.width / 2 - 896 / 2) < 0.001)
+}
+
 @Test func horizontalLayoutDirectionUsesDeviceOrientationBeforeSafeAreaFallback() {
     let ambiguousSafeArea = MonitorEdgeInsets(top: 0, leading: 44, bottom: 21, trailing: 44)
 
@@ -457,7 +471,8 @@ import Testing
     let deckCenter = layout.topInfoDeck.x + layout.topInfoDeck.width / 2
     let feedCenter = layout.feed.x + layout.feed.width / 2
 
-    #expect(layout.feed.x == 0)
+    #expect(layout.feed.x == 80)
+    #expect(abs(layout.feed.x + layout.feed.width / 2 - 896 / 2) < 0.001)
     #expect(
         lockRight + MonitorLiveViewModuleLayout.topInfoDeckControlGap
             <= layout.topInfoDeck.x)

--- a/Tests/OpenZCineCoreTests/MonitorLayoutPolicyTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorLayoutPolicyTests.swift
@@ -321,7 +321,8 @@ import Testing
             == landscapeLeft.feed.x + MonitorLiveViewModuleLayout.topInfoDeckSideInset)
     #expect(
         landscapeRight.topInfoDeck.x
-            == landscapeRight.feed.x + MonitorLiveViewModuleLayout.topInfoDeckSideInset)
+            >= landscapeRight.lockButton.x + landscapeRight.lockButton.width
+            + MonitorLiveViewModuleLayout.topInfoDeckControlGap)
     #expect(landscapeLeft.bottomAssistTools == landscapeRight.bottomAssistTools)
     #expect(landscapeLeft.bottomCaptureSettings == landscapeRight.bottomCaptureSettings)
     #expect(landscapeLeft.rightRailControls.x > landscapeLeft.feed.x + landscapeLeft.feed.width)
@@ -442,6 +443,28 @@ import Testing
     #expect(abs(deckCenter - feedCenter) < 0.001)
 }
 
+@Test func iphone11LandscapeInfoDeckClearsLockButtonAndStaysCentered() {
+    let safeArea = MonitorEdgeInsets(top: 0, leading: 44, bottom: 21, trailing: 44)
+    let layout = MonitorLiveViewModuleLayout.fit(
+        viewportWidth: 896,
+        viewportHeight: 414,
+        feedSafeArea: safeArea,
+        chromeInsets: MonitorChromeLayout.insets(feedSafeArea: safeArea),
+        bottomBarHeight: 58
+    )
+
+    let lockRight = layout.lockButton.x + layout.lockButton.width
+    let deckCenter = layout.topInfoDeck.x + layout.topInfoDeck.width / 2
+    let feedCenter = layout.feed.x + layout.feed.width / 2
+
+    #expect(layout.feed.x == 0)
+    #expect(
+        lockRight + MonitorLiveViewModuleLayout.topInfoDeckControlGap
+            <= layout.topInfoDeck.x)
+    #expect(abs(deckCenter - feedCenter) < 0.001)
+    #expect(layout.topInfoDeck.x + layout.topInfoDeck.width <= 896)
+}
+
 @Test func liveViewLockButtonAlignsWithTopDeckBand() {
     let chromeInsets = MonitorChromeLayout.insets(feedSafeArea: .zero)
     let layout = MonitorLiveViewModuleLayout.fit(
@@ -526,6 +549,28 @@ import Testing
 
     #expect(layout.phoneCenterY > MonitorBatteryRailLayout.indicatorHeight / 2)
     #expect(layout.cameraCenterY < 390 - MonitorBatteryRailLayout.indicatorHeight / 2)
+}
+
+@Test func batteryRailReservesTheFullClassicIPhoneNotch() {
+    let classicSafeArea = MonitorEdgeInsets(top: 0, leading: 44, bottom: 21, trailing: 44)
+    let dynamicIslandSafeArea = MonitorEdgeInsets(top: 0, leading: 59, bottom: 21, trailing: 44)
+    let classic = MonitorBatteryRailLayout.fit(
+        railHeight: 414,
+        safeArea: classicSafeArea
+    )
+    let dynamicIsland = MonitorBatteryRailLayout.fit(
+        railHeight: 414,
+        safeArea: dynamicIslandSafeArea
+    )
+
+    #expect(
+        classic.notchBottom - classic.notchTop
+            == MonitorBatteryRailLayout.classicSideNotchHeight)
+    #expect(
+        dynamicIsland.notchBottom - dynamicIsland.notchTop
+            == MonitorBatteryRailLayout.sideNotchHeight)
+    #expect(classic.phoneBottom == classic.notchTop - MonitorBatteryRailLayout.notchPadding)
+    #expect(classic.cameraTop == classic.notchBottom + MonitorBatteryRailLayout.notchPadding)
 }
 
 @Test func startupContentMarginsDoNotAddHorizontalSafeAreaGutters() {

--- a/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
@@ -564,7 +564,7 @@ private enum PadMiniViewport {
 
     let lockRight = map.systemSlots.lock.x + map.systemSlots.lock.width
 
-    #expect(map.feed.x == 44)
+    #expect(map.feed.x == 54)
     #expect(
         lockRight + MonitorLiveViewModuleLayout.topInfoDeckControlGap
             <= map.infoBar.frame.x)

--- a/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
@@ -564,8 +564,7 @@ private enum PadMiniViewport {
 
     let lockRight = map.systemSlots.lock.x + map.systemSlots.lock.width
 
-    #expect(map.feed.x == 80)
-    #expect(abs(map.feed.x + map.feed.width / 2 - 448) < 0.001)
+    #expect(map.feed.x == 44)
     #expect(
         lockRight + MonitorLiveViewModuleLayout.topInfoDeckControlGap
             <= map.infoBar.frame.x)

--- a/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
@@ -564,6 +564,8 @@ private enum PadMiniViewport {
 
     let lockRight = map.systemSlots.lock.x + map.systemSlots.lock.width
 
+    #expect(map.feed.x == 80)
+    #expect(abs(map.feed.x + map.feed.width / 2 - 448) < 0.001)
     #expect(
         lockRight + MonitorLiveViewModuleLayout.topInfoDeckControlGap
             <= map.infoBar.frame.x)

--- a/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
@@ -548,6 +548,28 @@ private enum PadMiniViewport {
     #expect(map.batteryCluster?.frame.width == MonitorBatteryRailLayout.indicatorWidth)
 }
 
+@Test func iphone11LandscapeZoneMapKeepsInfoBarClearOfLock() {
+    let safeArea = MonitorEdgeInsets(top: 0, leading: 44, bottom: 21, trailing: 44)
+    let map = MonitorZoneLayout.map(
+        viewportWidth: 896,
+        viewportHeight: 414,
+        safeArea: safeArea,
+        mode: .live,
+        isPortrait: false,
+        aspect: .fill,
+        scopeCount: 0,
+        horizontalDirection: .standard,
+        bottomBarHeight: 58
+    )
+
+    let lockRight = map.systemSlots.lock.x + map.systemSlots.lock.width
+
+    #expect(
+        lockRight + MonitorLiveViewModuleLayout.topInfoDeckControlGap
+            <= map.infoBar.frame.x)
+    #expect(map.infoBar.frame.x + map.infoBar.frame.width <= 896)
+}
+
 @Test func landscapeSystemSlotsCenterOnLegacyRailCenters() {
     let viewportWidth = 874.0
     let viewportHeight = 402.0

--- a/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
@@ -548,7 +548,7 @@ private enum PadMiniViewport {
     #expect(map.batteryCluster?.frame.width == MonitorBatteryRailLayout.indicatorWidth)
 }
 
-@Test func iphone11LandscapeZoneMapKeepsInfoBarClearOfLock() {
+@Test func iphone11LandscapeZoneMapKeepsInfoAndAssistBarsClear() throws {
     let safeArea = MonitorEdgeInsets(top: 0, leading: 44, bottom: 21, trailing: 44)
     let map = MonitorZoneLayout.map(
         viewportWidth: 896,
@@ -568,6 +568,18 @@ private enum PadMiniViewport {
         lockRight + MonitorLiveViewModuleLayout.topInfoDeckControlGap
             <= map.infoBar.frame.x)
     #expect(map.infoBar.frame.x + map.infoBar.frame.width <= 896)
+
+    let batteryCluster = try #require(map.batteryCluster?.frame)
+    let battery = MonitorBatteryRailLayout.fit(
+        railHeight: batteryCluster.height,
+        safeArea: safeArea
+    )
+    let cameraRight =
+        batteryCluster.x + battery.cameraCenterX
+        + MonitorBatteryRailLayout.indicatorWidth / 2
+    #expect(
+        cameraRight + MonitorLiveViewModuleLayout.bottomModuleSpacing
+            <= (map.assistStrip?.frame.x ?? 0))
 }
 
 @Test func landscapeSystemSlotsCenterOnLegacyRailCenters() {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -125,8 +125,8 @@ Feature work tracked as its own tasks on the Kaneo board, outside the Phase 0–
   and downloaded RED LUTs, with built-in looks protected and active selections reconciled safely.
 - **Waveform/parade brightness calibration** (in progress) — a useful 0–200% trace-intensity range
   where 100% matches the former 25% appearance and saved iOS settings migrate without a visual jump.
-- **Classic-notch iPhone layout hardening** (in progress) — keep live-view chrome collision-free on
-  compact landscape devices such as iPhone 11 while preserving full-bleed monitoring.
+- **Classic-notch iPhone layout hardening** (in progress) — center the 16:9 feed clear of the notch
+  and keep live-view chrome collision-free on compact landscape devices such as iPhone 11.
 - **Android beta-readiness parity** (planned) — port the diagnostics, support links, and live-view
   guide after the iOS behavior is validated with external testers.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -125,6 +125,8 @@ Feature work tracked as its own tasks on the Kaneo board, outside the Phase 0–
   and downloaded RED LUTs, with built-in looks protected and active selections reconciled safely.
 - **Waveform/parade brightness calibration** (in progress) — a useful 0–200% trace-intensity range
   where 100% matches the former 25% appearance and saved iOS settings migrate without a visual jump.
+- **Classic-notch iPhone layout hardening** (in progress) — keep live-view chrome collision-free on
+  compact landscape devices such as iPhone 11 while preserving full-bleed monitoring.
 - **Android beta-readiness parity** (planned) — port the diagnostics, support links, and live-view
   guide after the iOS behavior is validated with external testers.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -127,6 +127,8 @@ Feature work tracked as its own tasks on the Kaneo board, outside the Phase 0–
   where 100% matches the former 25% appearance and saved iOS settings migrate without a visual jump.
 - **Classic-notch iPhone layout hardening** (in progress) — fit the 16:9 feed tightly beside the
   notch and keep live-view chrome collision-free on compact landscape devices such as iPhone 11.
+- **Compact-Pro guide panel hardening** (in progress) — keep cinema aspect-ratio choices on one
+  line in the five-column Guides grid on non-Max iPhone 15 Pro, 16 Pro, and 17 Pro displays.
 - **Android beta-readiness parity** (planned) — port the diagnostics, support links, and live-view
   guide after the iOS behavior is validated with external testers.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -125,8 +125,8 @@ Feature work tracked as its own tasks on the Kaneo board, outside the Phase 0–
   and downloaded RED LUTs, with built-in looks protected and active selections reconciled safely.
 - **Waveform/parade brightness calibration** (in progress) — a useful 0–200% trace-intensity range
   where 100% matches the former 25% appearance and saved iOS settings migrate without a visual jump.
-- **Classic-notch iPhone layout hardening** (in progress) — center the 16:9 feed clear of the notch
-  and keep live-view chrome collision-free on compact landscape devices such as iPhone 11.
+- **Classic-notch iPhone layout hardening** (in progress) — fit the 16:9 feed tightly beside the
+  notch and keep live-view chrome collision-free on compact landscape devices such as iPhone 11.
 - **Android beta-readiness parity** (planned) — port the diagnostics, support links, and live-view
   guide after the iOS behavior is validated with external testers.
 

--- a/ios/Runner/MonitorControls.swift
+++ b/ios/Runner/MonitorControls.swift
@@ -198,7 +198,11 @@ struct GlassChoice: View {
     var body: some View {
         Text(title)
             .font(.system(size: 14, weight: .medium, design: .monospaced))
+            .lineLimit(1)
+            .minimumScaleFactor(0.8)
+            .allowsTightening(true)
             .foregroundStyle(isSelected ? LiveDesign.accent : LiveDesign.text)
+            .padding(.horizontal, 2)
             .frame(maxWidth: .infinity)
             .padding(.vertical, 16)
             .background(

--- a/ios/Runner/MonitorExperience.swift
+++ b/ios/Runner/MonitorExperience.swift
@@ -211,6 +211,7 @@ struct LiveFeedModule: View {
     let safeArea: MonitorEdgeInsets
     let viewportWidth: Double
     let canvasOffsetX: Double
+    var horizontalDirection: MonitorHorizontalLayoutDirection = .standard
     /// Portrait mounts hand the module an exact zone-frame height. The measured height is only
     /// trustworthy in the landscape full-bleed canvas: inside a safe-area-inset context the
     /// module's own `.ignoresSafeArea()` re-expands the proposal, the reader reports the grown
@@ -231,7 +232,8 @@ struct LiveFeedModule: View {
                 let feedFrame = MonitorFeedLayout.fullBleedFrame(
                     viewportWidth: viewportWidth,
                     viewportHeight: fixedContentHeight ?? Double(proxy.size.height),
-                    safeArea: safeArea
+                    safeArea: safeArea,
+                    horizontalDirection: horizontalDirection
                 )
                 let imageWidth = CGFloat(feedFrame.width)
                 let imageHeight = CGFloat(feedFrame.height)
@@ -741,16 +743,18 @@ extension View {
 struct BatteryRailModule: View {
     @Environment(NativeAppModel.self) private var model
     let safeArea: MonitorEdgeInsets
+    let phoneTopClearance: Double
 
     var body: some View {
         GeometryReader { proxy in
             let layout = MonitorBatteryRailLayout.fit(
                 railHeight: Double(proxy.size.height),
-                safeArea: safeArea
+                safeArea: safeArea,
+                phoneTopClearance: phoneTopClearance
             )
 
             ZStack {
-                phoneBatteryIndicator
+                phoneBatteryIndicator(compact: layout.phoneIndicatorHeight < 40)
                     .position(x: CGFloat(layout.phoneCenterX), y: CGFloat(layout.phoneCenterY))
                 cameraBatteryIndicator
                     .position(x: CGFloat(layout.cameraCenterX), y: CGFloat(layout.cameraCenterY))
@@ -759,12 +763,13 @@ struct BatteryRailModule: View {
         }
     }
 
-    private var phoneBatteryIndicator: some View {
+    private func phoneBatteryIndicator(compact: Bool) -> some View {
         BatteryIndicator(
             percent: model.cameraState.phoneBatteryPercent,
             deviceSystemName: "iphone",
             isCamera: false,
-            isCharging: model.phoneBatteryCharging
+            isCharging: model.phoneBatteryCharging,
+            layout: compact ? .compactRail : .rail
         )
     }
 
@@ -1214,10 +1219,10 @@ struct RecordButton: View {
 }
 
 struct BatteryIndicator: View {
-    /// `.rail`: 3-row VStack for the landscape battery rail (default). `.inline`: single-row
-    /// HStack for the portrait top bar (R2).
+    /// `.rail`: 3-row landscape rail. `.compactRail`: battery + percentage between a classic
+    /// notch and lock button. `.inline`: single-row portrait/iPad presentation.
     enum Layout {
-        case rail, inline
+        case rail, compactRail, inline
     }
 
     let percent: Int
@@ -1257,6 +1262,7 @@ struct BatteryIndicator: View {
     var body: some View {
         switch layout {
         case .rail: railBody
+        case .compactRail: compactRailBody
         case .inline: inlineBody
         }
     }
@@ -1292,6 +1298,24 @@ struct BatteryIndicator: View {
             width: CGFloat(MonitorBatteryRailLayout.indicatorWidth),
             height: CGFloat(MonitorBatteryRailLayout.indicatorHeight)
         )
+    }
+
+    private var compactRailBody: some View {
+        VStack(spacing: 1) {
+            Image(systemName: batterySymbol)
+                .font(.system(size: 15, weight: .regular))
+                .foregroundStyle(batteryTint)
+                .overlay { chargingOverlay }
+            Text(readout)
+                .font(.system(size: 9, weight: .medium, design: .monospaced))
+                .foregroundStyle(LiveDesign.text.opacity(0.72))
+        }
+        .frame(
+            width: CGFloat(MonitorBatteryRailLayout.indicatorWidth),
+            height: CGFloat(MonitorBatteryRailLayout.compactPhoneIndicatorHeight)
+        )
+        .accessibilityLabel("iPhone battery")
+        .accessibilityValue(readout)
     }
 
     /// Portrait top-bar presentation (R2): one row, battery glyph / percent / device glyph,

--- a/ios/Runner/MonitorExperience.swift
+++ b/ios/Runner/MonitorExperience.swift
@@ -989,13 +989,16 @@ struct AssistToolButtonRow: View {
     @Environment(NativeAppModel.self) private var model
     let tool: MonitorAssistTool
     var context: ViewAssistContext = .liveView
+    var compact = false
     /// When set, long-press routes here instead of the live-monitor assist popup (e.g. media playback).
     var onConfigure: ((MonitorAssistTool) -> Void)? = nil
     @State private var buildup: Task<Void, Never>?
 
     var body: some View {
         AssistToolButton(
-            tool: tool, isOn: model.preferences.visibleAssistTools(for: context).contains(tool)
+            tool: tool,
+            isOn: model.preferences.visibleAssistTools(for: context).contains(tool),
+            compact: compact
         )
         // Fit-mode scope cap (R7): a scope that can't activate renders grayed but stays tappable —
         // the tap routes to `toggleAssist`, which refuses and fires the toast. Inert in landscape
@@ -1077,6 +1080,7 @@ struct ScrollEdgeFades: Equatable {
 struct AssistToolButton: View {
     let tool: MonitorAssistTool
     let isOn: Bool
+    var compact = false
 
     var body: some View {
         // Mirrors the mockup's `.tool` box model; the 52pt floor keeps comfortable touch targets
@@ -1091,8 +1095,8 @@ struct AssistToolButton: View {
         }
         .foregroundStyle(isOn ? LiveDesign.accent : LiveDesign.muted)
         .padding(.vertical, 5)
-        .padding(.horizontal, 8)
-        .frame(minWidth: 52)
+        .padding(.horizontal, compact ? 5 : 8)
+        .frame(minWidth: compact ? 48 : 52)
         // `.tool.on`: a dim-accent fill and a same-tone dim border (no bright outline) —
         // only the icon and label read as full gold. No drop shadow: a glow would extend
         // past the frame and get clipped hard by the scroll container at the leading edge.

--- a/ios/Runner/MonitorExperience.swift
+++ b/ios/Runner/MonitorExperience.swift
@@ -740,10 +740,14 @@ extension View {
 
 struct BatteryRailModule: View {
     @Environment(NativeAppModel.self) private var model
+    let safeArea: MonitorEdgeInsets
 
     var body: some View {
         GeometryReader { proxy in
-            let layout = MonitorBatteryRailLayout.fit(railHeight: Double(proxy.size.height))
+            let layout = MonitorBatteryRailLayout.fit(
+                railHeight: Double(proxy.size.height),
+                safeArea: safeArea
+            )
 
             ZStack {
                 phoneBatteryIndicator

--- a/ios/Runner/MonitorOverlays.swift
+++ b/ios/Runner/MonitorOverlays.swift
@@ -6,6 +6,7 @@ struct FeedAssistOverlayModule: View {
     let safeArea: MonitorEdgeInsets
     let viewportWidth: Double
     let canvasOffsetX: Double
+    var horizontalDirection: MonitorHorizontalLayoutDirection = .standard
     /// Suppresses the floating scope/false-colour `MovablePanel`s. Set by `MonitorShell`'s
     /// portrait branch: those panels bleed over the narrow portrait feed strip and are redundant
     /// there — `PortraitScopesStack` already shows scopes. Landscape never passes this.
@@ -17,7 +18,8 @@ struct FeedAssistOverlayModule: View {
             let feedFrame = MonitorFeedLayout.fullBleedFrame(
                 viewportWidth: viewportWidth,
                 viewportHeight: Double(proxy.size.height),
-                safeArea: safeArea
+                safeArea: safeArea,
+                horizontalDirection: horizontalDirection
             )
             let feedRect = CGRect(
                 x: CGFloat(feedFrame.x),

--- a/ios/Runner/MonitorUnified.swift
+++ b/ios/Runner/MonitorUnified.swift
@@ -384,6 +384,8 @@ struct MonitorAssistStrip: View {
     /// Documents intent at call sites; `collapsible` always co-varies with `axis` today
     /// (horizontal → false, vertical → true), so the body branches on `axis` alone.
     var collapsible: Bool
+    /// Horizontal-only: packs the default tool set into the reduced classic-notch lane.
+    var compactHorizontal: Bool
     /// Vertical-only: height of the feed zone the rail should span when expanded.
     var feedHeight: CGFloat = 0
     /// Vertical-only: expand/collapse state, owned by the parent (`MonitorShell` sizes around it).
@@ -393,11 +395,12 @@ struct MonitorAssistStrip: View {
     @State private var edgeFades = ScrollEdgeFades(leading: false, trailing: true)
 
     init(
-        axis: Axis, collapsible: Bool, feedHeight: CGFloat = 0,
+        axis: Axis, collapsible: Bool, compactHorizontal: Bool = false, feedHeight: CGFloat = 0,
         expanded: Binding<Bool> = .constant(false)
     ) {
         self.axis = axis
         self.collapsible = collapsible
+        self.compactHorizontal = compactHorizontal
         self.feedHeight = feedHeight
         self._expanded = expanded
     }
@@ -488,7 +491,7 @@ struct MonitorAssistStrip: View {
     }
 
     private var toolRow: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: compactHorizontal ? 2 : 4) {
             ForEach(
                 Array(visibleToolbarTools.enumerated()),
                 id: \.element.id
@@ -496,7 +499,7 @@ struct MonitorAssistStrip: View {
                 if index > 0 && index.isMultiple(of: 3) {
                     assistDivider
                 }
-                AssistToolButtonRow(tool: tool)
+                AssistToolButtonRow(tool: tool, compact: compactHorizontal)
             }
             // Audio monitoring rides in its own section at the end of the strip, separated from
             // the exposure-tool groups regardless of how the groups-of-three chunking lands.
@@ -504,7 +507,7 @@ struct MonitorAssistStrip: View {
                 if !visibleToolbarTools.isEmpty {
                     assistDivider
                 }
-                AssistToolButtonRow(tool: .audioMeters)
+                AssistToolButtonRow(tool: .audioMeters, compact: compactHorizontal)
             }
         }
     }
@@ -525,7 +528,7 @@ struct MonitorAssistStrip: View {
         Rectangle()
             .fill(LiveDesign.hairlineStrong)
             .frame(width: 1, height: 28)
-            .padding(.horizontal, 4)
+            .padding(.horizontal, compactHorizontal ? 3 : 4)
     }
 
     // MARK: - axis: .vertical, collapsible: true (former `PortraitAssistRail`)
@@ -1034,15 +1037,21 @@ struct MonitorShell: View {
                         // The core map sets `collapsible` on the landscape assist zone, but there
                         // it denotes the edge-fade scroll strip — NOT a collapse pill (that is the
                         // vertical portrait rail). Rendering stays `axis`-driven (D5).
-                        MonitorAssistStrip(axis: .horizontal, collapsible: false)
-                            .environment(model)
-                            .liveViewGuideAnchor(.viewAssist)
-                            .frame(
-                                maxWidth: captureVisible ? .infinity : CGFloat(assist.frame.width),
-                                alignment: .leading
+                        MonitorAssistStrip(
+                            axis: .horizontal,
+                            collapsible: false,
+                            compactHorizontal: MonitorBatteryRailLayout.usesClassicSideNotch(
+                                safeArea: context.feedSafeArea
                             )
-                            .layoutPriority(0)
-                            .frame(maxHeight: .infinity)
+                        )
+                        .environment(model)
+                        .liveViewGuideAnchor(.viewAssist)
+                        .frame(
+                            maxWidth: captureVisible ? .infinity : CGFloat(assist.frame.width),
+                            alignment: .leading
+                        )
+                        .layoutPriority(0)
+                        .frame(maxHeight: .infinity)
                     }
                     if captureVisible {
                         MonitorCaptureStrip(fitsWidth: true)

--- a/ios/Runner/MonitorUnified.swift
+++ b/ios/Runner/MonitorUnified.swift
@@ -976,7 +976,7 @@ struct MonitorShell: View {
                                     .environment(model)
                                     .monitorModuleFrame(battery.frame, alignment: .leading)
                             } else {
-                                BatteryRailModule()
+                                BatteryRailModule(safeArea: context.feedSafeArea)
                                     .environment(model)
                                     .monitorModuleFrame(battery.frame)
                             }

--- a/ios/Runner/MonitorUnified.swift
+++ b/ios/Runner/MonitorUnified.swift
@@ -837,6 +837,7 @@ struct MonitorScopes: View {
     var safeArea: MonitorEdgeInsets = .zero
     var viewportWidth: Double = 0
     var canvasOffsetX: Double = 0
+    var horizontalDirection: MonitorHorizontalLayoutDirection = .standard
 
     var body: some View {
         switch style {
@@ -845,6 +846,7 @@ struct MonitorScopes: View {
                 safeArea: safeArea,
                 viewportWidth: viewportWidth,
                 canvasOffsetX: canvasOffsetX,
+                horizontalDirection: horizontalDirection,
                 suppressFloatingScopes: false
             )
             .environment(model)
@@ -937,13 +939,15 @@ struct MonitorShell: View {
                 LiveFeedModule(
                     safeArea: context.feedSafeArea,
                     viewportWidth: context.viewportWidth,
-                    canvasOffsetX: context.canvasOffsetX
+                    canvasOffsetX: context.canvasOffsetX,
+                    horizontalDirection: context.horizontalDirection
                 )
                 MonitorScopes(
                     style: .scopesFloating,
                     safeArea: context.feedSafeArea,
                     viewportWidth: context.viewportWidth,
-                    canvasOffsetX: context.canvasOffsetX
+                    canvasOffsetX: context.canvasOffsetX,
+                    horizontalDirection: context.horizontalDirection
                 )
             }
 
@@ -979,9 +983,16 @@ struct MonitorShell: View {
                                     .environment(model)
                                     .monitorModuleFrame(battery.frame, alignment: .leading)
                             } else {
-                                BatteryRailModule(safeArea: context.feedSafeArea)
-                                    .environment(model)
-                                    .monitorModuleFrame(battery.frame)
+                                let phoneTopClearance =
+                                    map.systemSlots.lock.y + map.systemSlots.lock.height
+                                    - battery.frame.y
+                                    + MonitorBatteryRailLayout.lockButtonGap
+                                BatteryRailModule(
+                                    safeArea: context.feedSafeArea,
+                                    phoneTopClearance: phoneTopClearance
+                                )
+                                .environment(model)
+                                .monitorModuleFrame(battery.frame)
                             }
                         }
                         MonitorSystemCluster(slots: map.systemSlots, axis: .axisVertical)

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -1,10 +1,22 @@
 import CoreImage
+import SwiftUI
 import UIKit
 import XCTest
 
 @testable import Runner
 
 final class RunnerTests: XCTestCase {
+
+    @MainActor
+    func testGlassChoiceKeepsCinemaRatioOnOneLineAtCompactProWidth() {
+        let choice = GlassChoice(title: "2.76:1")
+            .frame(width: 48)
+        let host = UIHostingController(rootView: choice)
+
+        let fittingSize = host.sizeThatFits(in: CGSize(width: 48, height: 1_000))
+
+        XCTAssertLessThanOrEqual(fittingSize.height, 52)
+    }
 
     func testDemoSettingsTabSelection() {
         XCTAssertEqual(OperatorSettingsTab.demoLaunchTab("assist"), .assist)

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -3,12 +3,12 @@ What's changed
 - System settings now links to support, bug reports, feature requests, source, privacy, and terms.
 - You can create and review a privacy-safe troubleshooting report from System settings.
 - The first live preview now opens with a short guide to camera, View Assist, and system controls.
-- Imported Custom and downloaded RED LUTs can now be deleted by pressing and holding them.
-- Waveform and RGB parade brightness now use a more practical 0–200% scale.
+- Imported Custom and downloaded RED LUTs can now be deleted by pressing and holding them, and waveform/RGB parade brightness now uses a more practical 0–200% scale.
+- Live-view controls now stay clear of the wider notch on iPhone 11-era displays.
 
 Please test
 
-- Open a live preview and complete or skip the three guide cards.
+- On a classic-notch iPhone, open a live preview, complete or skip the three guide cards, and confirm the status bar and battery indicators do not overlap the notch or lock control.
 - In Operator Setup > System, open the support links and create a troubleshooting report.
 - Choose Show Again and confirm the live-view guide returns.
 - Delete a Custom or RED LUT with a press and hold, confirm built-ins stay protected, then compare waveform and RGB parade at 100% with roughly 25% in the previous build.

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -4,11 +4,11 @@ What's changed
 - You can create and review a privacy-safe troubleshooting report from System settings.
 - The first live preview now opens with a short guide to camera, View Assist, and system controls.
 - Imported Custom and downloaded RED LUTs can now be deleted by pressing and holding them, and waveform/RGB parade brightness now uses a more practical 0–200% scale.
-- Live-view controls now stay clear of the wider notch on iPhone 11-era displays.
+- The live-view feed is now centered clear of the wider notch on iPhone 11-era displays.
 
 Please test
 
-- On a classic-notch iPhone, open a live preview, complete or skip the three guide cards, and confirm the status bar and battery indicators do not overlap the notch or lock control.
+- On a classic-notch iPhone, open a live preview, complete or skip the three guide cards, and confirm the image is centered clear of the notch with no control overlaps.
 - In Operator Setup > System, open the support links and create a troubleshooting report.
 - Choose Show Again and confirm the live-view guide returns.
 - Delete a Custom or RED LUT with a press and hold, confirm built-ins stay protected, then compare waveform and RGB parade at 100% with roughly 25% in the previous build.

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -4,11 +4,11 @@ What's changed
 - You can create and review a privacy-safe troubleshooting report from System settings.
 - The first live preview now opens with a short guide to camera, View Assist, and system controls.
 - Imported Custom and downloaded RED LUTs can now be deleted by pressing and holding them, and waveform/RGB parade brightness now uses a more practical 0–200% scale.
-- The live-view feed is now centered clear of the wider notch on iPhone 11-era displays.
+- The live-view feed now fits tightly beside the wider notch on iPhone 11-era displays.
 
 Please test
 
-- On a classic-notch iPhone, open a live preview, complete or skip the three guide cards, and confirm the image is centered clear of the notch with no control overlaps.
+- On a classic-notch iPhone, open a live preview, complete or skip the three guide cards, and confirm the image uses the space beside the notch without running beneath it or overlapping controls.
 - In Operator Setup > System, open the support links and create a troubleshooting report.
 - Choose Show Again and confirm the live-view guide returns.
 - Delete a Custom or RED LUT with a press and hold, confirm built-ins stay protected, then compare waveform and RGB parade at 100% with roughly 25% in the previous build.


### PR DESCRIPTION
## What & why

- identify classic-notch iPhones from their narrow 44–50pt landscape safe-area geometry because Apple does not expose a public notch-type API
- translate only the 16:9 live-view feed 10pt toward the fixed control rail in either physical landscape orientation, closing the oversized black gap without moving the rail or changing the feed size
- keep the classic-notch info deck clear of the lock control without altering newer iPhone spacing
- use a compact phone-battery readout below the lock on classic-notch phones while retaining the established full indicator on Dynamic Island phones
- tuck the Dynamic Island battery groups closer to the pill so the lower camera indicator clears the LUT button while the upper phone indicator remains clear of the lock
- keep Guides aspect-ratio choices single-line on non-Max iPhone 15 Pro, 16 Pro, and 17 Pro widths without changing the five-column grid or tap targets
- compact classic-notch tool spacing so LUT through PARADE remain fully visible
- cover classic-notch and Dynamic Island geometry with layout and zone-map regression tests
- track the release-facing behavior in the roadmap and TestFlight test notes

Closes #168
Closes #179

## TestFlight notes

The tester copy asks classic-notch iPhone users to verify that the image uses the available space beside the notch without running beneath it or overlapping controls. Non-Max Pro users should also verify that every Guides aspect ratio remains on one line.

## Verification

- `just native-check`
- `just check`
- 675 shared-core tests and the iOS test suite pass
- iPhone 11 simulator on iOS 26.2, deterministic live-view demo at 896x414
- iPhone 17 Pro simulator confirms the Dynamic Island battery groups clear both neighboring controls
- iPhone 17 Pro simulator confirms every Film guide ratio remains single-line; a 48pt-width iOS regression test covers the tighter compact-Pro tile case
- iPhone 11 regression capture and layout tests confirm classic-notch feed, rail, deck, and battery geometry remain unchanged by the Dynamic Island adjustment
- all four edges inspected on both device families with no clipping, overflow, or unintended empty bands
- secret scan and repository hygiene checks pass

## Checklist

- [x] `just check` passes.
- [x] Native production changes: `just native-check` passes.
- [x] Legacy prototype/reference changes are intentionally left local.
- [x] Commits follow Conventional Commits.
- [x] No proprietary assets are included.
- [x] Roadmap updated for the behavior change.
- [x] TestFlight notes include the classic-notch regression check.
- [x] Version bump is not appropriate for this scoped fix.
