### PR TITLE
feat(site): clarify Nikon camera compatibility

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -127,8 +127,10 @@ Feature work tracked as its own tasks on the Kaneo board, outside the Phase 0–
   where 100% matches the former 25% appearance and saved iOS settings migrate without a visual jump.
 - **Android beta-readiness parity** (planned) — port the diagnostics, support links, and live-view
   guide after the iOS behavior is validated with external testers.
-- **Public launch landing actions** (in progress): keep TestFlight available while Android and the
+- **Public launch landing actions**: keep TestFlight available while Android and the
   public repository are presented as clearly unavailable until their launches.
+- **Landing-page camera compatibility** (in progress): identify the Nikon ZR, Z9, and Z5II as
+  working, and the Z6, Z6II, Z6III, Zf, Z8, Z7, and Z7II as untested.
 
 ## Milestone Success Criteria
 

--- a/site/assets/app.css
+++ b/site/assets/app.css
@@ -731,6 +731,9 @@ h3 { font-size: clamp(20px, 2.4vw, 26px); line-height: 1.2; letter-spacing: -0.0
 /* ---- Ticks + badges ---- */
 .ticks { list-style: none; display: flex; flex-direction: column; gap: 10px; margin-top: 12px; }
 .ticks li { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.ticks--cameras li { align-items: flex-start; }
+.ticks--cameras li > :first-child { min-width: 0; }
+.ticks--cameras .badge { flex-shrink: 0; margin-top: 2px; }
 .badge {
   font-family: var(--mono); font-size: 11px; padding: 2px 9px; border-radius: 999px;
   background: var(--accent-soft); color: var(--accent); border: 1px solid var(--accent-soft);

--- a/site/index.html
+++ b/site/index.html
@@ -299,9 +299,11 @@
         </article>
         <article class="feat glass">
           <h3>Supported cameras</h3>
-          <ul class="ticks">
-            <li>Nikon ZR <span class="badge">first</span></li>
-            <li>Full Nikon Z mirrorless line <span class="badge badge--soon">roadmap</span></li>
+          <ul class="ticks ticks--cameras">
+            <li><span>Nikon ZR · Z9 · Z5II</span><span class="badge">working</span></li>
+            <li><span>Nikon Z6 · Z6II · Z6III · Zf · Z8 · Z7 · Z7II</span>
+              <span class="badge badge--soon">untested</span>
+            </li>
           </ul>
         </article>
       </div>


### PR DESCRIPTION
## Summary

- mark Nikon ZR, Z9, and Z5II as working
- list Nikon Z6, Z6II, Z6III, Zf, Z8, Z7, and Z7II as untested
- keep the longer camera list readable at desktop and mobile widths

## Verification

- `just check`
- visual QA at 1280 x 800 and 375 x 812
- verified no horizontal overflow and clean multi-line wrapping

Closes #172