### PR TITLE
feat(site): link the landing page to the now-public repository

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -307,8 +307,8 @@ Feature work tracked as its own tasks on the Kaneo board, outside the Phase 0–
   successfully decoded real Swift-camera frame, never a disconnected or synthetic fixture, and
   blocks phone, remote, and Wear camera commands while visible. Settings can replay it now when a
   real frame is available or schedule the next real frame.
-- **Public launch landing actions**: keep TestFlight available while Android and the
-  public repository are presented as clearly unavailable until their launches.
+- **Public launch landing actions**: the repository went public on 2026-07-15, so the landing page
+  links to it directly. Android stays presented as clearly unavailable until it ships.
 - **Landing-page camera compatibility** (in progress): identify the Nikon ZR, Z9, and Z5II as
   working, and the Z6, Z6II, Z6III, Zf, Z8, Z7, and Z7II as untested.
 

--- a/site/assets/app.css
+++ b/site/assets/app.css
@@ -312,17 +312,11 @@ h3 { font-size: clamp(20px, 2.4vw, 26px); line-height: 1.2; letter-spacing: -0.0
 .nav__links a:hover { color: var(--ink); }
 .nav__links a:hover::after { right: 0; }
 .nav__cta { display: flex; align-items: center; gap: 10px; }
-.nav__repo-status {
-  display: inline-flex; align-items: center; gap: 6px;
-  color: var(--faint); font-size: 14px; cursor: not-allowed;
-}
-.nav__status {
-  color: var(--faint); font-family: var(--mono); font-size: 8px;
-  letter-spacing: .08em; text-transform: uppercase;
-}
+.nav__github { font-size: 14px; color: var(--muted); }
+.nav__github:hover { color: var(--ink); }
 .nav__cta .btn { padding: 9px 16px; font-size: 14px; }
 @media (min-width: 860px) { .nav__links { display: flex; } }
-@media (max-width: 560px) { .nav__repo-status { display: none; } }
+@media (max-width: 560px) { .nav__github { display: none; } }
 
 /* ---- Footer ---- */
 .footer { background: var(--bg-deep); border-top: 1px solid var(--hairline); padding: 48px 0; }

--- a/site/index.html
+++ b/site/index.html
@@ -58,9 +58,7 @@
         <a href="#open-source">Open Source</a>
       </nav>
       <div class="nav__cta">
-        <span class="nav__repo-status" data-coming-soon="public-repo" aria-disabled="true">
-          Public repo <span class="nav__status">soon</span>
-        </span>
+        <a class="nav__github" href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener" aria-label="OpenZCine on GitHub">★ GitHub</a>
         <a class="btn btn--primary btn--magnetic" href="TESTFLIGHT_URL"><span class="btn__rec" aria-hidden="true"></span>Join the beta</a>
       </div>
     </div>
@@ -86,9 +84,7 @@
           <span class="btn btn--disabled" data-coming-soon="android" aria-disabled="true">
             Android <span class="btn__status">Coming soon</span>
           </span>
-          <span class="btn btn--disabled" data-coming-soon="public-repo" aria-disabled="true">
-            Public repo <span class="btn__status">Coming soon</span>
-          </span>
+          <a class="btn btn--ghost btn--magnetic" href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">★ Star on GitHub<span class="btn__arrow" aria-hidden="true">→</span></a>
         </div>
 
         <div class="hero__mock" data-intro>
@@ -280,9 +276,8 @@
         <p class="lead">No subscriptions, no paywalls, no telemetry. OpenZCine is Apache-2.0
           licensed and built in the open by a community of filmmakers and developers.</p>
         <div class="hero__cta">
-          <span class="btn btn--disabled" data-coming-soon="public-repo" aria-disabled="true">
-            Public repo <span class="btn__status">Coming soon</span>
-          </span>
+          <a class="btn btn--primary btn--magnetic" href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener"><span class="btn__rec" aria-hidden="true"></span>★ Star on GitHub</a>
+          <a class="btn btn--ghost btn--magnetic" href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">Contribute<span class="btn__arrow" aria-hidden="true">→</span></a>
         </div>
       </div>
     </section>
@@ -319,9 +314,7 @@
           <span class="btn btn--disabled" data-coming-soon="android" aria-disabled="true">
             Android <span class="btn__status">Coming soon</span>
           </span>
-          <span class="btn btn--disabled" data-coming-soon="public-repo" aria-disabled="true">
-            Public repo <span class="btn__status">Coming soon</span>
-          </span>
+          <a class="btn btn--ghost btn--magnetic" href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">★ Star on GitHub<span class="btn__arrow" aria-hidden="true">→</span></a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

The repository went public on 2026-07-15, so the "Public repo — Coming soon" placeholders #170 added are now false. This restores the real GitHub links in the nav, the hero, the Identity Core section, and the final CTA.

#170 also **deleted** the `.nav__github` CSS when it swapped that link for a status span, so those rules are restored too — including the `max-width: 560px` hide — and the now-dead `.nav__repo-status` / `.nav__status` rules are dropped.

**Android stays "Coming soon".** The port merged in #125 but is not on Google Play yet, so the claim would be false. `.btn--disabled` and `.btn__status` are kept for it.

## Verification

- `just check` — 827 tests, 40 suites
- Rendered over HTTP: `.nav__github` computes to **14px / `--muted`, identical to its sibling nav links**; 5 GitHub links present; only 2 `data-coming-soon="android"` markers remain
- **Desktop 1265px:** all three CTA rows fit, no overflow, uniform 49px pill heights
- **Mobile 375px:** nav link correctly hidden by the media query, no horizontal page scroll, no clipped buttons

## Kaneo

- OPE-93

🤖 Generated with [Claude Code](https://claude.com/claude-code)