### PR TITLE
fix(android): preserve live view after event socket loss

### DIFF
--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSession.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSession.kt
@@ -577,7 +577,12 @@ class SwiftCoreCameraSession internal constructor(
                     }
 
                     override fun onEnded(message: String?) {
-                        if (message != null) markEventChannelEnded(attempt, message)
+                        if (message == null) return
+                        if (usbTransport == null) {
+                            reportEventChannelDegraded(attempt, message)
+                        } else {
+                            markTerminalEventChannelEnded(attempt, message)
+                        }
                     }
                 },
             )
@@ -589,25 +594,68 @@ class SwiftCoreCameraSession internal constructor(
     }
 
     /**
-     * Makes an unexpected event-channel loss terminal for this session. The
-     * native reader has already closed the command socket before this callback,
-     * so dropping to disconnected cannot leave a hidden, usable control link.
+     * Records a PTP-IP event-channel loss without dropping a still-healthy
+     * command or live-view socket. PTP-IP owns those sockets independently,
+     * matching the iOS session behavior; a later command or frame failure
+     * remains responsible for recovery.
      */
-    private fun markEventChannelEnded(attempt: Long, message: String) {
-        val ownsAttempt =
+    private fun reportEventChannelDegraded(attempt: Long, message: String) {
+        if (isCurrentAttempt(attempt)) phaseLogger("eventChannelEnded", message)
+    }
+
+    /**
+     * Tears down a USB session after an interrupt-endpoint failure. USB events
+     * share the claimed transport with commands, so this is terminal unlike a
+     * PTP-IP event-socket failure.
+     */
+    private fun markTerminalEventChannelEnded(attempt: Long, message: String) {
+        val connectionOwner =
             synchronized(attemptLock) {
-                if (activeAttempt != attempt) return@synchronized false
+                if (activeAttempt != attempt) return@synchronized null
                 activeAttempt = null
+                val owner = activeConnectionOwner
                 activeConnectionOwner = null
-                _state.value = CameraSessionState.Disconnected
-                true
+                // Keep monitor recovery paused until teardown releases the
+                // claimed USB transport. A reconnect before that point can
+                // contend for the body while its previous PTP slot is live.
+                _state.value = CameraSessionState.Connecting
+                owner
             }
-        if (!ownsAttempt) return
+        if (connectionOwner == null) return
         ignoreLiveRecordingStateUntilNanos = 0L
         cameraRecordingEventVersion = 0L
         _recordingState.value = CameraRecordingState.STANDBY
         stopPropertyRefresh(clearSnapshot = true)
         phaseLogger("eventChannelEnded", message)
+        propertyRefreshScope.launch {
+            try {
+                // The native event reader marks itself inactive before this
+                // callback, so this owned teardown cannot wait for its own
+                // reader thread. Match normal disconnect ownership: wait for
+                // any in-flight command, use IO for JNI, and only then allow
+                // monitor recovery to begin another USB attempt.
+                withContext(NonCancellable) {
+                    cameraCommandMutex.withLock {
+                        if (core.isAvailable) {
+                            withContext(propertyRefreshDispatcher) {
+                                core.disconnect(connectionOwner)
+                            }
+                        }
+                    }
+                }
+            } catch (error: Throwable) {
+                phaseLogger(
+                    "eventChannelCleanupFailed",
+                    error.message ?: "Camera event-channel cleanup failed.",
+                )
+            } finally {
+                synchronized(attemptLock) {
+                    if (activeAttempt == null && _state.value is CameraSessionState.Connecting) {
+                        _state.value = CameraSessionState.Disconnected
+                    }
+                }
+            }
+        }
     }
 
     /** Maps only established event codes; all other camera data remains raw. */

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/PairingExperience.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/PairingExperience.kt
@@ -9,6 +9,7 @@ import android.net.Uri
 import android.net.nsd.NsdManager
 import android.os.Build
 import android.provider.Settings
+import android.util.Log
 import androidx.annotation.StringRes
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -130,18 +131,34 @@ public fun realPairingEnvironment(context: Context): PairingEnvironment {
         joinCameraAp = { ssid, passphrase -> joiner.join(ssid, passphrase) },
         releaseCameraAp = joiner::release,
         hotspotCameras = discovery.cameras(),
-        createSession = { host -> SwiftCoreCameraSession(host) },
+        createSession = { host -> SwiftCoreCameraSession(host, ::logCameraSessionPhase) },
         usbCameraSource = usbCameraSource,
         createUsbSession = { opened ->
             SwiftCoreCameraSession(
                 host = opened.hostKey,
                 cameraNameHint = opened.displayName,
                 usbTransport = opened.transport,
+                phaseLogger = ::logCameraSessionPhase,
             )
         },
         credentials = CameraWifiCredentialStore(context),
     )
 }
+
+/** Emits only safe connection failures to logcat, never pairing-phase details. */
+private fun logCameraSessionPhase(phase: String, detail: String) {
+    val message = cameraSessionDiagnosticMessage(phase, detail) ?: return
+    Log.w(CAMERA_SESSION_LOG_TAG, message)
+}
+
+private const val CAMERA_SESSION_LOG_TAG = "SwiftCoreCameraSession"
+
+/** Returns only diagnostics whose phase cannot carry the camera pairing credential. */
+internal fun cameraSessionDiagnosticMessage(phase: String, detail: String): String? =
+    when (phase) {
+        "failed", "eventChannelEnded", "eventChannelCleanupFailed" -> "$phase: $detail"
+        else -> null
+    }
 
 /**
  * Debug-only wizard script: a forced starting state plus a fake environment,

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSessionTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSessionTest.kt
@@ -455,19 +455,110 @@ class SwiftCoreCameraSessionTest {
     }
 
     @Test
-    fun `unexpected event channel end makes the session disconnected`() = runTest {
+    fun `PTP-IP event channel end keeps the command session connected`() = runTest {
         val bridge = FakeBridge()
-        val session = SwiftCoreCameraSession("192.168.1.1", { _, _ -> }, bridge)
+        val phases = mutableListOf<Pair<String, String>>()
+        val session =
+            SwiftCoreCameraSession(
+                "192.168.1.1",
+                { phase, detail -> phases += phase to detail },
+                bridge,
+            )
         val connecting = async { session.connect() }
         runCurrent()
         bridge.listeners.single().onConnected("ZR", "NIKON ZR", "6001234")
         connecting.await()
 
         bridge.eventListeners.single().onEnded("The camera closed the connection.")
-        bridge.eventListeners.single().onEvent(0xC10A, 10, longArrayOf())
+
+        assertEquals(
+            CameraSessionState.Connected(CameraIdentity("ZR", "NIKON ZR", "6001234")),
+            session.state.value,
+        )
+        assertEquals(listOf("eventChannelEnded" to "The camera closed the connection."), phases)
+
+        session.setRecording(true)
+        assertEquals(listOf(true), bridge.recordingRequests)
+
+        session.disconnect()
+        assertEquals(1, bridge.disconnects)
+    }
+
+    @Test
+    fun `USB event channel end tears down its native owner`() = runTest {
+        val bridge = FakeBridge()
+        val transport = FakeUsbTransport()
+        val session =
+            SwiftCoreCameraSession(
+                host = "usb:5d6f4d746ecf9da40a1b0ce273d3d8d3",
+                phaseLogger = { _, _ -> },
+                core = bridge,
+                propertyRefreshScope = this,
+                propertyRefreshDispatcher = StandardTestDispatcher(testScheduler),
+                automaticallyRefreshProperties = false,
+                usbTransport = transport,
+                cameraNameHint = "Nikon USB camera",
+            )
+        val connecting = async { session.connect() }
+        runCurrent()
+        bridge.listeners.single().onConnected("ZR", "NIKON ZR", "6001234")
+        connecting.await()
+
+        bridge.eventListeners.single().onEnded("The camera closed the USB event endpoint.")
+
+        assertEquals(CameraSessionState.Connecting, session.state.value)
+        runCurrent()
+        assertEquals(CameraSessionState.Disconnected, session.state.value)
+        assertEquals(1, bridge.disconnects)
+        assertTrue(transport.isClosed())
+    }
+
+    @Test
+    fun `USB event teardown waits for an in-flight camera command`() = runTest {
+        val bridge = FakeBridge()
+        val transport = FakeUsbTransport()
+        val session =
+            SwiftCoreCameraSession(
+                host = "usb:5d6f4d746ecf9da40a1b0ce273d3d8d3",
+                phaseLogger = { _, _ -> },
+                core = bridge,
+                propertyRefreshScope = this,
+                propertyRefreshDispatcher = StandardTestDispatcher(testScheduler),
+                automaticallyRefreshProperties = false,
+                usbTransport = transport,
+                cameraNameHint = "Nikon USB camera",
+            )
+        val connecting = async { session.connect() }
+        runCurrent()
+        bridge.listeners.single().onConnected("ZR", "NIKON ZR", "6001234")
+        connecting.await()
+
+        val commandStarted = CountDownLatch(1)
+        val releaseCommand = CountDownLatch(1)
+        bridge.controlHandler = { _, _ ->
+            commandStarted.countDown()
+            check(releaseCommand.await(5, TimeUnit.SECONDS))
+            SwiftCore.CONTROL_COMMAND_ACCEPTED
+        }
+        val command = async(Dispatchers.Default) { session.applyControl(CameraControl.ISO, "800") }
+        try {
+            assertTrue(commandStarted.await(5, TimeUnit.SECONDS))
+            bridge.eventListeners.single().onEnded("The camera closed the USB event endpoint.")
+            runCurrent()
+
+            assertEquals(CameraSessionState.Connecting, session.state.value)
+            assertEquals(0, bridge.disconnects)
+
+            releaseCommand.countDown()
+            command.await()
+            runCurrent()
+        } finally {
+            releaseCommand.countDown()
+        }
 
         assertEquals(CameraSessionState.Disconnected, session.state.value)
-        assertEquals(CameraRecordingState.STANDBY, session.recordingState.value)
+        assertEquals(1, bridge.disconnects)
+        assertTrue(transport.isClosed())
     }
 
     @Test

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/pairing/CameraSessionDiagnosticsTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/pairing/CameraSessionDiagnosticsTest.kt
@@ -1,0 +1,24 @@
+package com.opencapture.openzcine.pairing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class CameraSessionDiagnosticsTest {
+    @Test
+    fun `pairing phase details never enter camera session diagnostics`() {
+        assertNull(cameraSessionDiagnosticMessage("confirmOnCamera", "123456"))
+        assertNull(cameraSessionDiagnosticMessage("handshaking", "192.168.1.1"))
+    }
+
+    @Test
+    fun `safe terminal diagnostics retain their failure detail`() {
+        assertEquals(
+            "eventChannelEnded: The camera closed the connection.",
+            cameraSessionDiagnosticMessage(
+                "eventChannelEnded",
+                "The camera closed the connection.",
+            ),
+        )
+    }
+}

--- a/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
+++ b/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
@@ -2064,11 +2064,14 @@ public final class PTPIPClientSession: @unchecked Sendable {
     /// event that the shared core has not classified yet.
     ///
     /// Idle reads time out normally and keep draining. Any other transport
-    /// failure ends the stream, closes the command socket (the session is no
-    /// longer trustworthy), and is passed to [onEnded] as an operator-facing
-    /// message. The callback is delivered at most once. A session owns one
-    /// drain for its lifetime; disconnect closes the event socket and joins its
-    /// reader before tearing down the command socket.
+    /// failure ends only this event stream and is passed to [onEnded] as an
+    /// operator-facing message. PTP-IP owns independent command and event
+    /// sockets: a closed event socket does not by itself prove that the
+    /// command or live-view channel has failed. Those paths retain their own
+    /// health checks and stay available until they fail or the owner tears the
+    /// session down. The callback is delivered at most once. A session owns
+    /// one drain for its lifetime; disconnect closes the event socket and
+    /// joins its reader before tearing down the command socket.
     public func startEventDrain(
         onEvent: @escaping @Sendable (PTPEvent) -> Void,
         onEnded: @escaping @Sendable (String?) -> Void
@@ -2141,7 +2144,7 @@ public final class PTPIPClientSession: @unchecked Sendable {
                 return
             }
         #endif
-        guard let event, let command else {
+        guard let event, command != nil else {
             finishEventDrain(
                 onEnded: onEnded,
                 failure: PTPIPClientSessionError.connectionClosed.localizedDescription
@@ -2171,17 +2174,9 @@ public final class PTPIPClientSession: @unchecked Sendable {
             }
         }
 
-        if failure != nil {
-            // A broken event channel means this PTP-IP session can no longer
-            // guarantee camera-authoritative state. Close the command socket
-            // too, waking any in-flight transaction before Kotlin receives the
-            // terminal callback and is allowed to reconnect.
-            command.close()
-            transactionLock.lock()
-            isClosed = true
-            transactionLock.unlock()
-        }
-
+        // The event reader is permanently finished for this socket. Release
+        // its descriptor now while preserving the independent command link.
+        if failure != nil { event.close() }
         finishEventDrain(onEnded: onEnded, failure: failure)
     }
 

--- a/Tests/OpenZCineAndroidFacadeTests/EventDrainTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/EventDrainTests.swift
@@ -1,7 +1,8 @@
 // Event-channel lifecycle tests against the scripted fake ZR. These cover the
 // second PTP-IP socket that the command/live-view tests do not read: raw event
-// preservation, Nikon record lifecycle delivery, and terminal teardown.
+// preservation, Nikon record lifecycle delivery, and independent socket recovery.
 
+import Dispatch
 import Foundation
 import OpenZCineCore
 import Testing
@@ -65,7 +66,7 @@ struct EventDrainTests {
         }
     }
 
-    @Test func eventChannelFailureClosesTheUntrustworthyCommandSession() throws {
+    @Test func eventChannelFailureLeavesCommandAndLiveViewUsable() throws {
         let server = try FakeZRServer()
         defer { server.stop() }
         let session = try connect(to: server)
@@ -81,9 +82,12 @@ struct EventDrainTests {
         try collector.waitForEnd()
 
         #expect(collector.terminalMessage != nil)
-        #expect(throws: PTPIPClientSessionError.self) {
-            try session.startRecording()
-        }
+        let firstFrame = DispatchSemaphore(value: 0)
+        try session.startLiveView(
+            onFrame: { _, _ in firstFrame.signal() },
+            onEnded: {})
+        defer { session.stopLiveView() }
+        #expect(firstFrame.wait(timeout: .now() + .seconds(5)) == .success)
     }
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -164,6 +164,14 @@ Feature work tracked as its own tasks on the Kaneo board, outside the Phase 0–
   base-ISO switching, focus-ring descriptor narrowing, white-balance and audio modes, the omitted
   movie-VR fallback, electronic-VR rejection for R3D NE/N-RAW/ProRes RAW, readback timing and
   rejection feedback, plus RTT freshness across reconnect and transport replacement.
+- **Android live-view event-channel resilience** (OPE-96, in review; OPE-100, planned): an
+  independent PTP-IP event-socket failure no longer discards a healthy Android command and
+  live-view session, while a shared USB event-endpoint failure remains terminal and releases its
+  transport before recovery. OPE-100 will establish whether the Nikon ZR supports a bounded
+  in-session event-stream re-open or requires a complete reconnect. **[VERIFY-ON-HW]** With a
+  supported Nikon ZR, observe or induce event-stream loss, confirm that the feed and commands stay
+  usable when the command channel is healthy, and confirm record-state/property-event recovery or
+  a safe reconnect when it is not.
 - **Android authoritative monitor readouts** (OPE-63, in review): render live-view timecode only
   from the camera frame accepted for display; render resolution, codec, card space, recording FPS,
   camera battery, ISO, shutter, iris, focus, and white balance from `CameraPropertySnapshot`; and


### PR DESCRIPTION
## Android-only live-view fix

Kaneo: OPE-96

### What changed

- Preserve a healthy Android PTP-IP command and live-view path when only its independent event socket ends.
- Keep USB event-endpoint loss terminal, with serialized owner-scoped teardown before recovery can reconnect.
- Add privacy-safe terminal diagnostics while excluding pairing-phase details such as the camera PIN.
- Add Kotlin and Swift regression coverage for event-loss behavior, teardown ordering, and diagnostic redaction.

### Scope

This changes Android Compose/JNI integration and the Swift module compiled into the Android native library. No iOS application code changed.

### Validation

- `just android-check`
- `just check`
- Clean debug build installed and launched on Samsung SM-A127F (`R58R92BL76K`)
- End-to-end Android device run against the in-repo fake ZR confirmed the feed remains visible after the updated transport path.

### Hardware follow-up

The saved ZR access point was not visible during final validation, so a physical-camera confirmation remains required: keep a real feed running for at least ten seconds, then verify record start/stop. This PR stays draft until that pass is available.

OPE-100 records the separate planned investigation for re-opening an event socket after it has failed.