### PR TITLE
fix(android): refresh raw frame-size modes

### DIFF
--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/CommandMonitorTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/CommandMonitorTest.kt
@@ -24,6 +24,41 @@ class CommandMonitorTest {
         assertEquals(24f, commandTileValueSize("5600K"))
         assertEquals(20f, commandTileValueSize("R3D NE HQ"))
         assertEquals(16f, commandTileValueSize("6000x3336 · 25p"))
+        assertEquals(16f, commandTileValueSize("[DX] 4K · 100p"))
+    }
+
+    @Test
+    fun `dashboard preserves raw frame size image area labels`() {
+        val presentation =
+            commandDashboardPresentation(
+                snapshot =
+                    CameraPropertySnapshot(
+                        resolutionFrameRate = "[DX] 4K · 100p",
+                        controlCapabilities =
+                            CameraControlCapabilities(
+                                resolutionFrameRates =
+                                    listOf(
+                                        "[FX] 6K · 25p",
+                                        "[FX] 4K · 50p",
+                                        "[DX] 4K · 100p",
+                                    ),
+                            ),
+                    ),
+                refreshStatus = CameraPropertyRefreshStatus.Ready,
+                sessionState =
+                    CameraSessionState.Connected(
+                        CameraIdentity(name = "NIKON ZR", model = "ZR", serialNumber = "ZR-01"),
+                    ),
+                tileOrder = CommandTileKind.entries.toList(),
+            )
+
+        val resolution =
+            presentation.tiles.first { it.kind == CommandTileKind.RESOLUTION_FRAMERATE }
+        assertEquals("[DX] 4K · 100p", resolution.value)
+        assertEquals(
+            listOf("[FX] 6K · 25p", "[FX] 4K · 50p", "[DX] 4K · 100p"),
+            assertNotNull(resolution.request).options,
+        )
     }
 
     @Test

--- a/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
+++ b/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
@@ -199,6 +199,38 @@ private enum AndroidNikonZRControlFallback {
     ]
 }
 
+/// Nikon ZR RAW image area is selected by the camera's frame-size mode, not a separate writable
+/// crop property. These labels make that camera-provided meaning visible only for documented,
+/// exact ZR RAW modes; every other advertised mode keeps its generic resolution/rate label.
+private enum AndroidNikonZRRawCropPresentation {
+    static func label(
+        for mode: PTPCameraScreenSizeMode,
+        currentCodec: String?,
+        usesNikonZRFallbacks: Bool
+    ) -> String {
+        guard usesNikonZRFallbacks,
+            let currentCodec,
+            ["N-RAW", "R3D NE"].contains(currentCodec),
+            let imageArea = imageArea(for: mode.raw)
+        else {
+            return mode.label
+        }
+        return "[\(imageArea)] \(mode.label)"
+    }
+
+    private static func imageArea(for rawScreenSize: UInt64) -> String? {
+        let size = PTPCameraPropertyDecoders.screenSize(rawScreenSize)
+        switch (size.width, size.height) {
+        case (6_048, 3_402), (4_032, 2_268):
+            return "FX"
+        case (3_984, 2_240):
+            return "DX"
+        default:
+            return nil
+        }
+    }
+}
+
 /// Exact camera-advertised values retained inside the Swift session.
 private struct AndroidRawControlCatalog: Sendable {
     var isComplete = false
@@ -228,11 +260,46 @@ private struct AndroidRawControlCatalog: Sendable {
     func capabilities(
         properties: PTPCameraPropertySnapshot,
         whiteBalanceTint: String?,
+        isScreenSizeReadbackCurrent: Bool,
         usesNikonZRFallbacks: Bool
     ) -> AndroidCameraControlCapabilities {
         guard isComplete else { return .empty }
         let currentCodec = recognizedCurrentCodec(properties.fileType)
         let showsDualBaseCircuits = currentCodec.map(ISOPickerPolicy.showsDualBaseCircuits) ?? false
+        let currentScreenSizeLabel: String?
+        if isScreenSizeReadbackCurrent,
+            let rawScreenSize = properties.rawScreenSize,
+            let mode = screenSizes.first(where: { $0.raw == rawScreenSize })
+        {
+            currentScreenSizeLabel = screenSizeLabel(
+                for: mode,
+                currentCodec: currentCodec,
+                usesNikonZRFallbacks: usesNikonZRFallbacks)
+        } else {
+            currentScreenSizeLabel = nil
+        }
+        let resolutionFrameRate: String?
+        if !isScreenSizeReadbackCurrent {
+            // The codec has changed but its D0A0 value has not been read back yet. Do not present
+            // the previous codec's resolution as the active selection while the picker uses the
+            // new descriptor domain.
+            resolutionFrameRate = nil
+        } else if let currentScreenSizeLabel {
+            resolutionFrameRate = currentScreenSizeLabel
+        } else if screenSizes.isEmpty {
+            // Some bodies expose a current D0A0 value without a writable enum descriptor. Keep the
+            // established read-only monitor presentation for that case.
+            resolutionFrameRate =
+                MonitorTextFormat.resolutionLabel(
+                    fromProperty: properties.resolution,
+                    frameRate: properties.fps ?? 0,
+                    fallback: ""
+                ).nilIfEmpty
+        } else {
+            // A fresh value that does not belong to the refreshed descriptor domain is not a safe
+            // selection to display or write.
+            resolutionFrameRate = nil
+        }
         let activeShutterValues: [String] =
             switch properties.shutterMode {
             case .angle: shutterAngles.map(\.label)
@@ -264,11 +331,7 @@ private struct AndroidRawControlCatalog: Sendable {
                 ? whiteBalanceKelvin.map(\.label) : [])
             + whiteBalanceModes.filter { $0.label != "Color temp" }.map(\.label)
         return AndroidCameraControlCapabilities(
-            resolutionFrameRate: MonitorTextFormat.resolutionLabel(
-                fromProperty: properties.resolution,
-                frameRate: properties.fps ?? 0,
-                fallback: ""
-            ).nilIfEmpty,
+            resolutionFrameRate: resolutionFrameRate,
             codec: properties.fileType.map(MonitorTextFormat.codecShortLabel),
             whiteBalanceTint: whiteBalanceTint,
             isoValues: isoValues,
@@ -287,7 +350,12 @@ private struct AndroidRawControlCatalog: Sendable {
             shutterModes: shutterModes.map(\.label),
             shutterLocks: shutterLocks.map(\.label),
             whiteBalanceTints: whiteBalanceTints.map(\.label),
-            resolutionFrameRates: screenSizes.map(\.label),
+            resolutionFrameRates: screenSizes.map {
+                screenSizeLabel(
+                    for: $0,
+                    currentCodec: currentCodec,
+                    usesNikonZRFallbacks: usesNikonZRFallbacks)
+            },
             codecs: fileTypes.map(\.label),
             vibrationReduction: vibrationReduction.map(\.label),
             electronicVR:
@@ -300,6 +368,31 @@ private struct AndroidRawControlCatalog: Sendable {
         guard let codec else { return nil }
         let label = MonitorTextFormat.codecShortLabel(codec)
         return fileTypes.contains(where: { $0.label == label }) ? label : nil
+    }
+
+    func screenSizeMode(
+        for label: String,
+        properties: PTPCameraPropertySnapshot,
+        usesNikonZRFallbacks: Bool
+    ) -> PTPCameraScreenSizeMode? {
+        let currentCodec = recognizedCurrentCodec(properties.fileType)
+        return screenSizes.first {
+            screenSizeLabel(
+                for: $0,
+                currentCodec: currentCodec,
+                usesNikonZRFallbacks: usesNikonZRFallbacks) == label
+        }
+    }
+
+    private func screenSizeLabel(
+        for mode: PTPCameraScreenSizeMode,
+        currentCodec: String?,
+        usesNikonZRFallbacks: Bool
+    ) -> String {
+        AndroidNikonZRRawCropPresentation.label(
+            for: mode,
+            currentCodec: currentCodec,
+            usesNikonZRFallbacks: usesNikonZRFallbacks)
     }
 
     private func uniqueLabels(_ values: [String]) -> [String] {
@@ -345,6 +438,10 @@ public final class PTPIPClientSession: @unchecked Sendable {
     /// `commandLifecycleLock` is held so a refresh cannot race control writes,
     /// media ownership, or teardown.
     private var androidPropertySnapshot = PTPCameraPropertySnapshot()
+    /// `false` from a codec transition until `MovScreenSize` (`D0A0`) is read back again. This
+    /// prevents a previous codec's active resolution from being rendered as current while its
+    /// camera-advertised picker domain is already refreshed.
+    private var androidScreenSizeReadbackIsCurrent = false
     private var androidStorageInfo: PTPStorageInfo?
     private var androidStorageSlots: [AndroidCameraStorageSlot] = []
     private var androidControlCatalog = AndroidRawControlCatalog()
@@ -797,11 +894,13 @@ public final class PTPIPClientSession: @unchecked Sendable {
     ///
     /// The bootstrap is deliberately bounded to the high-value header and
     /// safety fields. Subsequent calls read one property in the shared core's
-    /// conservative round-robin order, so polling does not monopolize the
-    /// command channel or starve live-view frame fetches. A `DevicePropChanged`
-    /// request is accepted only for a property already supported by that core
-    /// order. Any unsupported body/mode read preserves accumulated values and
-    /// returns a non-terminal result; it never disconnects the session.
+    /// conservative round-robin order, except `MovFileType` is placed directly
+    /// before its Android-specific `MovScreenSize` dependency. Polling never
+    /// monopolizes the command channel or starves live-view frame fetches. A
+    /// `DevicePropChanged` request is accepted only for a property already
+    /// supported by that core order. Any unsupported body/mode read preserves
+    /// accumulated values and returns a non-terminal result; it never
+    /// disconnects the session.
     public func refreshAndroidPropertySnapshot(
         _ request: AndroidCameraPropertyRefreshRequest
     ) -> AndroidCameraPropertyReadback {
@@ -828,13 +927,23 @@ public final class PTPIPClientSession: @unchecked Sendable {
             }
             return androidPropertyReadback(result: result)
         case .next(let isRecording):
-            let pollOrder = PTPPropertyCode.monitorPollOrder(isRecording: isRecording)
+            let pollOrder = Self.androidMonitorPollOrder(isRecording: isRecording)
             guard !pollOrder.isEmpty else {
                 return androidPropertyReadback(result: .accepted)
             }
             let property = pollOrder[androidPropertyPollIndex % pollOrder.count]
             androidPropertyPollIndex = (androidPropertyPollIndex + 1) % pollOrder.count
+            let previousFileType = androidPropertySnapshot.fileType
             var result = refreshAndroidProperty(property)
+            if property == .movieFileType,
+                result == .accepted,
+                androidPropertySnapshot.fileType != previousFileType
+            {
+                result = mergedAndroidPropertyRefreshResult(
+                    result,
+                    refreshAndroidScreenSizeAfterCodecChange()
+                )
+            }
             if result != .transportFailed,
                 CameraMonitorPollPolicy.isDue(
                     lastRefreshAt: androidLastStorageRefreshAt,
@@ -862,7 +971,16 @@ public final class PTPIPClientSession: @unchecked Sendable {
                 // model knows how to decode one.
                 return androidPropertyReadback(result: .accepted)
             }
-            return androidPropertyReadback(result: refreshAndroidProperty(property))
+            let result = refreshAndroidProperty(property)
+            guard property == .movieFileType, result == .accepted else {
+                return androidPropertyReadback(result: result)
+            }
+            return androidPropertyReadback(
+                result: mergedAndroidPropertyRefreshResult(
+                    result,
+                    refreshAndroidScreenSizeAfterCodecChange()
+                )
+            )
         }
     }
 
@@ -873,8 +991,24 @@ public final class PTPIPClientSession: @unchecked Sendable {
     ) -> AndroidCameraPropertyRefreshResult {
         do {
             let data = try readProperty(property)
+            guard property != .movieRecordScreenSize || data.count >= 8 else {
+                androidScreenSizeReadbackIsCurrent = false
+                return .transportFailed
+            }
+            guard property != .movieFileType || data.count >= 4 else {
+                return .transportFailed
+            }
+            let previousFileType = androidPropertySnapshot.fileType
             androidPropertySnapshot = androidPropertySnapshot.applying(
                 property: property, data: data)
+            if property == .movieRecordScreenSize {
+                androidScreenSizeReadbackIsCurrent = true
+            } else if property == .movieFileType,
+                previousFileType != nil,
+                androidPropertySnapshot.fileType != previousFileType
+            {
+                androidScreenSizeReadbackIsCurrent = false
+            }
             return .accepted
         } catch let error as PTPIPClientSessionError {
             switch error {
@@ -1390,6 +1524,7 @@ public final class PTPIPClientSession: @unchecked Sendable {
             controls: androidControlCatalog.capabilities(
                 properties: androidPropertySnapshot,
                 whiteBalanceTint: androidWhiteBalanceTint,
+                isScreenSizeReadbackCurrent: androidScreenSizeReadbackIsCurrent,
                 usesNikonZRFallbacks: usesNikonZRFallbacks)
         )
     }
@@ -1423,6 +1558,25 @@ public final class PTPIPClientSession: @unchecked Sendable {
         .batteryLevel,
         .warningStatus,
     ]
+
+    /// Android keeps codec immediately before its codec-dependent frame-size value so a missed
+    /// property event cannot publish a new D0A0 value with the prior codec's picker domain.
+    static func androidMonitorPollOrder(isRecording: Bool) -> [PTPPropertyCode] {
+        isRecording ? PTPPropertyCode.recordingMonitorPollOrder : androidLiveMonitorPollOrder
+    }
+
+    private static let androidLiveMonitorPollOrder: [PTPPropertyCode] = {
+        var pollOrder = PTPPropertyCode.liveMonitorPollOrder
+        guard
+            let screenSizeIndex = pollOrder.firstIndex(of: .movieRecordScreenSize),
+            let fileTypeIndex = pollOrder.firstIndex(of: .movieFileType)
+        else {
+            return pollOrder
+        }
+        let fileType = pollOrder.remove(at: fileTypeIndex)
+        pollOrder.insert(fileType, at: screenSizeIndex)
+        return pollOrder
+    }()
 
     // MARK: - Recording
 
@@ -1544,7 +1698,29 @@ public final class PTPIPClientSession: @unchecked Sendable {
             // The selected preset chooses a different tune property. Rebuild
             // that capability now or fail closed until the next descriptor pass.
             try? refreshAndroidWhiteBalanceTintDescriptor()
+        } else if control == .codec {
+            _ = refreshAndroidScreenSizeAfterCodecChange()
         }
+    }
+
+    /// Rebuilds the codec-dependent `MovScreenSize` domain immediately after a confirmed codec
+    /// write, a camera-originated property event, or a newly observed normal-poll transition.
+    /// Retaining the previous descriptor would let Android show and write combinations the newly
+    /// selected codec does not advertise. A failed refresh clears this one domain and withholds
+    /// the active selection until a valid D0A0 readback arrives, so the UI fails closed rather
+    /// than reusing stale modes.
+    private func refreshAndroidScreenSizeAfterCodecChange() -> AndroidCameraPropertyRefreshResult {
+        androidScreenSizeReadbackIsCurrent = false
+        do {
+            try refreshAndroidScreenSizeDescriptor()
+        } catch let error as PTPIPClientSessionError {
+            return androidDescriptorResult(for: error)
+        } catch {
+            return .transportFailed
+        }
+        // A codec transition can make the camera choose a compatible screen size itself. Refresh
+        // the active raw value too, so the current label and picker selection stay in sync.
+        return refreshAndroidProperty(.movieRecordScreenSize)
     }
 
     private func androidControlWrites(
@@ -1635,8 +1811,12 @@ public final class PTPIPClientSession: @unchecked Sendable {
         case .whiteBalanceTint:
             return whiteBalanceTintWrite(label: label).map { [$0] } ?? []
         case .resolutionFrameRate:
-            return androidControlCatalog.screenSizes.first(where: { $0.label == label })
-                .map { [PTPCameraPropertyWrite.screenSize(raw: $0.raw)] } ?? []
+            return androidControlCatalog.screenSizeMode(
+                for: label,
+                properties: androidPropertySnapshot,
+                usesNikonZRFallbacks: usesNikonZRFallbacks
+            )
+            .map { [PTPCameraPropertyWrite.screenSize(raw: $0.raw)] } ?? []
         case .codec:
             return androidControlCatalog.fileTypes.first(where: { $0.label == label })
                 .map { [PTPCameraPropertyWrite.fileType(raw: $0.raw)] } ?? []
@@ -1663,6 +1843,7 @@ public final class PTPIPClientSession: @unchecked Sendable {
         let capabilities = androidControlCatalog.capabilities(
             properties: androidPropertySnapshot,
             whiteBalanceTint: androidWhiteBalanceTint,
+            isScreenSizeReadbackCurrent: androidScreenSizeReadbackIsCurrent,
             usesNikonZRFallbacks: usesNikonZRFallbacks)
         return switch control {
         case .iso: capabilities.isoValues

--- a/Tests/OpenZCineAndroidFacadeTests/AndroidCameraPropertyReadbackTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/AndroidCameraPropertyReadbackTests.swift
@@ -47,7 +47,8 @@ struct AndroidCameraPropertyReadbackTests {
 
         // One complete low-rate pass fills the fields intentionally omitted
         // from the bounded bootstrap (lens, focus, audio, VR, and grid).
-        for _ in PTPPropertyCode.liveMonitorPollOrder {
+        let androidPollOrder = PTPIPClientSession.androidMonitorPollOrder(isRecording: false)
+        for _ in androidPollOrder {
             _ = session.refreshAndroidPropertySnapshot(.next(isRecording: false))
         }
         let complete = session.refreshAndroidPropertySnapshot(.propertyChanged(0xDEAD))
@@ -92,9 +93,9 @@ struct AndroidCameraPropertyReadbackTests {
                 == PTPPropertyCode.movieWbTuneColorTemp.rawValue)
         let roundRobinReads = Array(
             propertyReads.dropFirst(expectedBootstrap.count + 1)
-                .prefix(PTPPropertyCode.liveMonitorPollOrder.count)
+                .prefix(androidPollOrder.count)
                 .compactMap(\.parameters.first))
-        #expect(roundRobinReads == PTPPropertyCode.liveMonitorPollOrder.map(\.rawValue))
+        #expect(roundRobinReads == androidPollOrder.map(\.rawValue))
 
         let wire = AndroidCameraPropertyReadbackWire.encode(complete)
         let fields = wireFields(wire)

--- a/Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift
@@ -154,8 +154,13 @@ final class FakeZRServer: @unchecked Sendable {
         var focusModeRaw: UInt8 = 1  // AF-C
         var focusAreaRaw: UInt16 = 0x8033  // Subject
         var focusSubjectRaw: UInt8 = 2  // People
+        /// Current packed movie-screen-size value returned by property readback.
+        var movieRecordScreenSizeRaw: UInt64 = 0x1770_0D08_0019_0000
         /// Current packed movie-file-type value returned by property readback.
         var movieFileTypeRaw: UInt32 = 0x0031_0A03
+        /// Optional codec-specific `MovScreenSize` descriptor domains. When configured, a codec
+        /// write switches the current screen size to the first value in that codec's domain.
+        var screenSizeModesByFileType: [UInt32: [UInt64]] = [:]
     }
 
     let port: UInt16
@@ -280,6 +285,15 @@ final class FakeZRServer: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return propertyWriteLog
+    }
+
+    /// Changes the camera-side codec without recording an app property write. Tests use this to
+    /// exercise the same state transition that a physical body's `DevicePropChanged(D0AF)` event
+    /// announces.
+    func setCameraMovieFileType(_ raw: UInt32) {
+        lock.lock()
+        defer { lock.unlock() }
+        updateCameraMovieFileTypeLocked(raw)
     }
 
     /// Transaction IDs in arrival order (parallel to `receivedOperations`).
@@ -802,6 +816,7 @@ final class FakeZRServer: @unchecked Sendable {
     private func cameraPropertyData(for property: PTPPropertyCode) -> Data? {
         lock.lock()
         let overridden = propertyValueOverrides[property.rawValue]
+        let activeMovieFileTypeRaw = activeMovieFileTypeRawLocked()
         lock.unlock()
         if let overridden { return overridden }
         switch property {
@@ -829,9 +844,12 @@ final class FakeZRServer: @unchecked Sendable {
         case .movieWBColorTemp:
             return Data(ByteCoding.uint16LE(5_600))
         case .movieRecordScreenSize:
-            return Data(ByteCoding.uint64LE(0x1770_0D08_0019_0000))
+            let raw =
+                options.screenSizeModesByFileType[activeMovieFileTypeRaw]?.first
+                ?? options.movieRecordScreenSizeRaw
+            return Data(ByteCoding.uint64LE(raw))
         case .movieFileType:
-            return Data(ByteCoding.uint32LE(options.movieFileTypeRaw))
+            return Data(ByteCoding.uint32LE(activeMovieFileTypeRaw))
         case .batteryLevel:
             return Data([options.batteryPercent])
         case .acPower:
@@ -889,6 +907,15 @@ final class FakeZRServer: @unchecked Sendable {
 
     /// Protocol-shaped descriptor datasets consumed only by shared-core decoders.
     private func cameraPropertyDescriptor(for property: PTPPropertyCode) -> Data? {
+        if property == .movieRecordScreenSize,
+            let modes = screenSizeModesForActiveFileType(),
+            !modes.isEmpty
+        {
+            return enumDescriptor(
+                property: property,
+                valueByteCount: 8,
+                values: modes.map(ByteCoding.uint64LE))
+        }
         if let values = options.descriptorEnumOverrides[property],
             let byteCount = descriptorValueByteCount(property)
         {
@@ -982,6 +1009,21 @@ final class FakeZRServer: @unchecked Sendable {
         default:
             return nil
         }
+    }
+
+    private func screenSizeModesForActiveFileType() -> [UInt64]? {
+        lock.lock()
+        defer { lock.unlock() }
+        return options.screenSizeModesByFileType[activeMovieFileTypeRawLocked()]
+    }
+
+    private func activeMovieFileTypeRawLocked() -> UInt32 {
+        guard let data = propertyValueOverrides[PTPPropertyCode.movieFileType.rawValue],
+            data.count >= MemoryLayout<UInt32>.size
+        else {
+            return options.movieFileTypeRaw
+        }
+        return ByteCoding.readUInt32LE(Array(data), at: 0)
     }
 
     private func descriptorValueByteCount(_ property: PTPPropertyCode) -> Int? {
@@ -1140,6 +1182,8 @@ final class FakeZRServer: @unchecked Sendable {
         let bytes = Array(data)
         propertyValueOverrides[property] = data
         switch PTPPropertyCode(rawValue: property) {
+        case .movieFileType where bytes.count >= MemoryLayout<UInt32>.size:
+            updateCameraMovieFileTypeLocked(ByteCoding.readUInt32LE(bytes, at: 0))
         case .movieFocusMode where !bytes.isEmpty:
             focusModeRaw = bytes[0]
         case .movieFocusMeteringMode where bytes.count >= 2:
@@ -1149,6 +1193,14 @@ final class FakeZRServer: @unchecked Sendable {
             focusSubjectDetectionActive = bytes[0] != 0
         default:
             break
+        }
+    }
+
+    private func updateCameraMovieFileTypeLocked(_ raw: UInt32) {
+        propertyValueOverrides[PTPPropertyCode.movieFileType.rawValue] = Data(
+            ByteCoding.uint32LE(raw))
+        if options.screenSizeModesByFileType[raw] != nil {
+            propertyValueOverrides[PTPPropertyCode.movieRecordScreenSize.rawValue] = nil
         }
     }
 

--- a/Tests/OpenZCineAndroidFacadeTests/LiveViewPumpTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/LiveViewPumpTests.swift
@@ -179,11 +179,27 @@ struct LiveViewPumpTests {
     /// `ZC_FAKE_ZR_PORT=15740 swift test --filter servesFakeZRForDevice` on the
     /// Mac, `adb reverse tcp:15740 tcp:15740`, then launch the app with
     /// `--es zc.session.host 127.0.0.1`. Serves for an hour or until killed.
+    /// `ZC_FAKE_ZR_RAW_CROP=1` starts in R3D NE with the documented FX/DX RAW
+    /// frame-size domain so the Android picker can be visually checked.
     @Test(.enabled(if: ProcessInfo.processInfo.environment["ZC_FAKE_ZR_PORT"] != nil))
     func servesFakeZRForDeviceEndToEnd() throws {
         var options = FakeZRServer.Options()
         options.port =
             UInt16(ProcessInfo.processInfo.environment["ZC_FAKE_ZR_PORT"] ?? "") ?? 15_740
+        if ProcessInfo.processInfo.environment["ZC_FAKE_ZR_RAW_CROP"] == "1" {
+            let r3dNE: UInt32 = 0x0031_0A03
+            let nRAW: UInt32 = 0x0002_0C02
+            let fx6K25 = UInt64(6_048) << 48 | UInt64(3_402) << 32 | UInt64(25) << 16
+            let fx4K50 = UInt64(4_032) << 48 | UInt64(2_268) << 32 | UInt64(50) << 16
+            let dx4K100 = UInt64(3_984) << 48 | UInt64(2_240) << 32 | UInt64(100) << 16
+            options.movieFileTypeRaw = r3dNE
+            options.movieRecordScreenSizeRaw = fx6K25
+            options.descriptorEnumOverrides[.movieFileType] = [r3dNE, nRAW]
+            options.screenSizeModesByFileType = [
+                r3dNE: [fx6K25, fx4K50, dx4K100],
+                nRAW: [fx6K25, fx4K50, dx4K100],
+            ]
+        }
         let server = try FakeZRServer(options: options)
         print("fake ZR serving on 127.0.0.1:\(server.port) — Ctrl-C to stop")
         Thread.sleep(forTimeInterval: 3_600)

--- a/Tests/OpenZCineAndroidFacadeTests/PTPIPClientSessionTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/PTPIPClientSessionTests.swift
@@ -319,6 +319,233 @@ struct PTPIPClientSessionTests {
         #expect(server.receivedPropertyWrites().count == rejectedBaseline)
     }
 
+    @Test func rawCodecChangesRefreshZRFrameSizeModesAndPreserveExactWrites() throws {
+        let h265: UInt32 = 0x0001_0A01
+        let r3dNE: UInt32 = 0x0031_0A03
+        let nRAW: UInt32 = 0x0002_0C02
+        let h265ScreenSize: UInt64 = 0x0F00_0870_003C_0000
+        let fx6K25 = UInt64(6_048) << 48 | UInt64(3_402) << 32 | UInt64(25) << 16
+        let fx4K50 = UInt64(4_032) << 48 | UInt64(2_268) << 32 | UInt64(50) << 16
+        let dx4K100 = UInt64(3_984) << 48 | UInt64(2_240) << 32 | UInt64(100) << 16
+
+        var options = FakeZRServer.Options()
+        options.movieFileTypeRaw = h265
+        options.movieRecordScreenSizeRaw = h265ScreenSize
+        options.descriptorEnumOverrides[.movieFileType] = [h265, r3dNE, nRAW]
+        options.screenSizeModesByFileType = [
+            h265: [h265ScreenSize],
+            r3dNE: [fx6K25, fx4K50, dx4K100],
+            nRAW: [fx6K25, fx4K50, dx4K100],
+        ]
+        let server = try FakeZRServer(options: options)
+        defer { server.stop() }
+        let session = try connect(to: server)
+        defer { session.disconnect() }
+
+        let bootstrap = session.refreshAndroidPropertySnapshot(.bootstrap)
+        #expect(bootstrap.controls.codec == "H.265")
+        #expect(bootstrap.controls.resolutionFrameRate == "4K · 60p")
+        #expect(bootstrap.controls.resolutionFrameRates == ["4K · 60p"])
+
+        let screenSizeDescriptorReadsBeforeCodecChange =
+            server.receivedRequests().filter {
+                $0.operation == .getDevicePropDescEx
+                    && $0.parameters.first == PTPPropertyCode.movieRecordScreenSize.rawValue
+            }.count
+        server.setCameraMovieFileType(r3dNE)
+
+        let r3dReadback = session.refreshAndroidPropertySnapshot(
+            .propertyChanged(PTPPropertyCode.movieFileType.rawValue))
+        #expect(r3dReadback.result == .accepted)
+        #expect(r3dReadback.controls.codec == "R3D NE")
+        #expect(r3dReadback.controls.resolutionFrameRate == "[FX] 6K · 25p")
+        #expect(
+            r3dReadback.controls.resolutionFrameRates
+                == ["[FX] 6K · 25p", "[FX] 4K · 50p", "[DX] 4K · 100p"])
+        #expect(
+            server.receivedRequests().filter {
+                $0.operation == .getDevicePropDescEx
+                    && $0.parameters.first == PTPPropertyCode.movieRecordScreenSize.rawValue
+            }.count == screenSizeDescriptorReadsBeforeCodecChange + 1)
+
+        let writeBaseline = server.receivedPropertyWrites().count
+        try session.applyAndroidControl(.resolutionFrameRate, label: "[DX] 4K · 100p")
+        #expect(
+            server.receivedPropertyWrites().dropFirst(writeBaseline).first
+                == FakeZRPropertyWrite(
+                    operation: .setDevicePropValue,
+                    property: PTPPropertyCode.movieRecordScreenSize.rawValue,
+                    data: Data(ByteCoding.uint64LE(dx4K100))))
+
+        let dxReadback = session.refreshAndroidPropertySnapshot(
+            .propertyChanged(PTPPropertyCode.movieRecordScreenSize.rawValue))
+        #expect(dxReadback.controls.resolutionFrameRate == "[DX] 4K · 100p")
+
+        let screenSizeDescriptorReadsBeforeNRAWWrite =
+            server.receivedRequests().filter {
+                $0.operation == .getDevicePropDescEx
+                    && $0.parameters.first == PTPPropertyCode.movieRecordScreenSize.rawValue
+            }.count
+        let screenSizeValueReadsBeforeNRAWWrite =
+            server.receivedRequests().filter {
+                $0.operation == .getDevicePropValueEx
+                    && $0.parameters.first == PTPPropertyCode.movieRecordScreenSize.rawValue
+            }.count
+        try session.applyAndroidControl(.codec, label: "N-RAW")
+        #expect(
+            server.receivedRequests().filter {
+                $0.operation == .getDevicePropDescEx
+                    && $0.parameters.first == PTPPropertyCode.movieRecordScreenSize.rawValue
+            }.count == screenSizeDescriptorReadsBeforeNRAWWrite + 1)
+        #expect(
+            server.receivedRequests().filter {
+                $0.operation == .getDevicePropValueEx
+                    && $0.parameters.first == PTPPropertyCode.movieRecordScreenSize.rawValue
+            }.count == screenSizeValueReadsBeforeNRAWWrite + 1)
+        let nRAWReadback = session.refreshAndroidPropertySnapshot(
+            .propertyChanged(PTPPropertyCode.batteryLevel.rawValue))
+        #expect(nRAWReadback.result == .accepted)
+        #expect(nRAWReadback.controls.codec == "N-RAW")
+        #expect(nRAWReadback.controls.resolutionFrameRate == "[FX] 6K · 25p")
+        #expect(
+            nRAWReadback.controls.resolutionFrameRates
+                == ["[FX] 6K · 25p", "[FX] 4K · 50p", "[DX] 4K · 100p"])
+    }
+
+    @Test func rawCodecChangeWithholdsStaleFrameSizeWhileD0A0ReadbackSettles() throws {
+        let h265: UInt32 = 0x0001_0A01
+        let r3dNE: UInt32 = 0x0031_0A03
+        let h265ScreenSize: UInt64 = 0x0F00_0870_003C_0000
+        let fx6K25 = UInt64(6_048) << 48 | UInt64(3_402) << 32 | UInt64(25) << 16
+        let dx4K100 = UInt64(3_984) << 48 | UInt64(2_240) << 32 | UInt64(100) << 16
+
+        var options = FakeZRServer.Options()
+        options.movieFileTypeRaw = h265
+        options.movieRecordScreenSizeRaw = h265ScreenSize
+        options.descriptorEnumOverrides[.movieFileType] = [h265, r3dNE]
+        options.screenSizeModesByFileType = [
+            h265: [h265ScreenSize],
+            r3dNE: [fx6K25, dx4K100],
+        ]
+        options.shortPropertyCodesAfterFirstRead = [PTPPropertyCode.movieRecordScreenSize.rawValue]
+        let server = try FakeZRServer(options: options)
+        defer { server.stop() }
+        let session = try connect(to: server)
+        defer { session.disconnect() }
+
+        let bootstrap = session.refreshAndroidPropertySnapshot(.bootstrap)
+        #expect(bootstrap.controls.resolutionFrameRate == "4K · 60p")
+
+        server.setCameraMovieFileType(r3dNE)
+        let settlingReadback = session.refreshAndroidPropertySnapshot(
+            .propertyChanged(PTPPropertyCode.movieFileType.rawValue))
+        #expect(settlingReadback.result == .transportFailed)
+        #expect(settlingReadback.controls.codec == "R3D NE")
+        #expect(settlingReadback.controls.resolutionFrameRate == nil)
+        #expect(
+            settlingReadback.controls.resolutionFrameRates
+                == ["[FX] 6K · 25p", "[DX] 4K · 100p"])
+    }
+
+    @Test func rawCodecPollRefreshesFrameSizeModesWhenEventIsMissed() throws {
+        let h265: UInt32 = 0x0001_0A01
+        let r3dNE: UInt32 = 0x0031_0A03
+        let h265ScreenSize: UInt64 = 0x0F00_0870_003C_0000
+        let fx6K25 = UInt64(6_048) << 48 | UInt64(3_402) << 32 | UInt64(25) << 16
+        let dx4K100 = UInt64(3_984) << 48 | UInt64(2_240) << 32 | UInt64(100) << 16
+
+        var options = FakeZRServer.Options()
+        options.movieFileTypeRaw = h265
+        options.movieRecordScreenSizeRaw = h265ScreenSize
+        options.descriptorEnumOverrides[.movieFileType] = [h265, r3dNE]
+        options.screenSizeModesByFileType = [
+            h265: [h265ScreenSize],
+            r3dNE: [fx6K25, dx4K100],
+        ]
+        let server = try FakeZRServer(options: options)
+        defer { server.stop() }
+        let session = try connect(to: server)
+        defer { session.disconnect() }
+
+        let bootstrap = session.refreshAndroidPropertySnapshot(.bootstrap)
+        #expect(bootstrap.controls.codec == "H.265")
+        #expect(bootstrap.controls.resolutionFrameRates == ["4K · 60p"])
+        let screenSizeDescriptorReadsBeforeCodecChange =
+            server.receivedRequests().filter {
+                $0.operation == .getDevicePropDescEx
+                    && $0.parameters.first == PTPPropertyCode.movieRecordScreenSize.rawValue
+            }.count
+
+        // The event may be delayed, dropped, or reordered. The regular monitor poll must still
+        // invalidate and rebuild the codec-dependent D0A0 descriptor after it observes D0AF.
+        server.setCameraMovieFileType(r3dNE)
+        let requestBaseline = server.receivedRequests().count
+        let pollOrder = PTPIPClientSession.androidMonitorPollOrder(isRecording: false)
+        guard let codecPollIndex = pollOrder.firstIndex(of: .movieFileType) else {
+            Issue.record("The live monitor poll must include MovFileType.")
+            return
+        }
+        var r3dReadback = bootstrap
+        for _ in 0...codecPollIndex {
+            r3dReadback = session.refreshAndroidPropertySnapshot(.next(isRecording: false))
+        }
+
+        #expect(r3dReadback.result == .accepted)
+        #expect(r3dReadback.controls.codec == "R3D NE")
+        #expect(r3dReadback.controls.resolutionFrameRate == "[FX] 6K · 25p")
+        #expect(
+            r3dReadback.controls.resolutionFrameRates
+                == ["[FX] 6K · 25p", "[DX] 4K · 100p"])
+        #expect(
+            server.receivedRequests().filter {
+                $0.operation == .getDevicePropDescEx
+                    && $0.parameters.first == PTPPropertyCode.movieRecordScreenSize.rawValue
+            }.count == screenSizeDescriptorReadsBeforeCodecChange + 1)
+        #expect(
+            Array(server.receivedRequests().dropFirst(requestBaseline).suffix(3))
+                == [
+                    FakeZRRequest(
+                        operation: .getDevicePropValueEx,
+                        parameters: [PTPPropertyCode.movieFileType.rawValue],
+                        dataPhase: .dataIn),
+                    FakeZRRequest(
+                        operation: .getDevicePropDescEx,
+                        parameters: [PTPPropertyCode.movieRecordScreenSize.rawValue],
+                        dataPhase: .dataIn),
+                    FakeZRRequest(
+                        operation: .getDevicePropValueEx,
+                        parameters: [PTPPropertyCode.movieRecordScreenSize.rawValue],
+                        dataPhase: .dataIn),
+                ])
+    }
+
+    @Test func rawImageAreaLabelsAreRestrictedToNikonZR() throws {
+        let r3dNE: UInt32 = 0x0031_0A03
+        let fx6K25 = UInt64(6_048) << 48 | UInt64(3_402) << 32 | UInt64(25) << 16
+        let dx4K100 = UInt64(3_984) << 48 | UInt64(2_240) << 32 | UInt64(100) << 16
+
+        func resolutionFrameRates(model: String) throws -> [String] {
+            var options = FakeZRServer.Options()
+            options.model = model
+            options.movieFileTypeRaw = r3dNE
+            options.movieRecordScreenSizeRaw = fx6K25
+            options.descriptorEnumOverrides[.movieFileType] = [r3dNE]
+            options.screenSizeModesByFileType = [r3dNE: [fx6K25, dx4K100]]
+            let server = try FakeZRServer(options: options)
+            defer { server.stop() }
+            let session = try connect(to: server)
+            defer { session.disconnect() }
+            return session.refreshAndroidPropertySnapshot(.bootstrap).controls.resolutionFrameRates
+        }
+
+        #expect(
+            try resolutionFrameRates(model: "ZR")
+                == ["[FX] 6K · 25p", "[DX] 4K · 100p"])
+        #expect(
+            try resolutionFrameRates(model: "Z8")
+                == ["6K · 25p", "4K · 100p"])
+    }
+
     @Test func dynamicAndroidControlsPreserveAdvertisedRawValuesEndToEnd() throws {
         var options = FakeZRServer.Options()
         options.descriptorEnumOverrides = [

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -151,19 +151,22 @@ Feature work tracked as its own tasks on the Kaneo board, outside the Phase 0–
   Swift-authorized options. The dynamic option seam now covers ISO scoped to the active codec and
   base circuit, mounted-lens aperture, white-balance Kelvin and presets, focus mode/area/subject,
   audio sensitivity/input/wind filter/attenuator/32-bit float, resolution/frame rate, codec, active
-  shutter values, shutter mode and lock, white-balance tint, movie VR, and electronic VR. Exact
-  Nikon ZR identity gates the stable fallback domains needed for omitted or temporarily narrowed
-  descriptors; other models fail closed. Electronic VR also fails closed until codec readback is
-  known and remains unavailable for every RAW codec family. Writes are serialized, rejected when
-  the active Swift capability set does not contain the label, and accepted only after authoritative
-  property readback matches. Both PTP-IP and USB-C publish measured command/response RTT through the
-  session and clear it on disconnect. Fake-camera transport tests cover exact descriptor writes,
-  model scoping, base-circuit changes, RAW rejection, readback rejection, RTT, and Compose option
-  policy. **[VERIFY-ON-HW]** On a supported Nikon ZR over both Wi-Fi and USB-C, confirm descriptor
-  values and raw write acceptance in each recording mode, lens swaps and aperture bounds, Low/High
-  base-ISO switching, focus-ring descriptor narrowing, white-balance and audio modes, the omitted
-  movie-VR fallback, electronic-VR rejection for R3D NE/N-RAW/ProRes RAW, readback timing and
-  rejection feedback, plus RTT freshness across reconnect and transport replacement.
+  shutter values, shutter mode and lock, white-balance tint, movie VR, and electronic VR. For
+  N-RAW and R3D NE, Nikon ZR image area is frame-size-owned: Android labels documented,
+  device-advertised FX/DX modes in that existing picker and reloads the screen-size descriptor after
+  each codec change, never inventing a separate crop write (OPE-95). Exact Nikon ZR identity gates
+  the stable fallback domains needed for omitted or temporarily narrowed descriptors; other models
+  fail closed. Electronic VR also fails closed until codec readback is known and remains unavailable
+  for every RAW codec family. Writes are serialized, rejected when the active Swift capability set
+  does not contain the label, and accepted only after authoritative property readback matches. Both
+  PTP-IP and USB-C publish measured command/response RTT through the session and clear it on
+  disconnect. Fake-camera transport tests cover exact descriptor writes, model scoping, base-circuit
+  changes, RAW rejection, readback rejection, RTT, and Compose option policy. **[VERIFY-ON-HW]** On
+  a supported Nikon ZR over both Wi-Fi and USB-C, confirm descriptor values and raw write acceptance
+  in each recording mode, lens swaps and aperture bounds, Low/High base-ISO switching, focus-ring
+  descriptor narrowing, white-balance and audio modes, the omitted movie-VR fallback, electronic-VR
+  rejection for R3D NE/N-RAW/ProRes RAW, RAW FX/DX labels after every codec transition, readback
+  timing and rejection feedback, plus RTT freshness across reconnect and transport replacement.
 - **Android authoritative monitor readouts** (OPE-63, in review): render live-view timecode only
   from the camera frame accepted for display; render resolution, codec, card space, recording FPS,
   camera battery, ISO, shutter, iris, focus, and white balance from `CameraPropertySnapshot`; and

--- a/docs/investigations/android-raw-crop-modes.md
+++ b/docs/investigations/android-raw-crop-modes.md
@@ -1,0 +1,49 @@
+# Android RAW crop-mode investigation
+
+Status: **IMPLEMENTED, hardware verification pending**
+
+Scope: Android's Swift facade and Compose-facing recording-format presentation. No iOS app-shell
+code is changed by this work.
+
+Tracked by Kaneo OPE-95.
+
+## Finding
+
+Nikon ZR does not use a separate selectable video image-area control for N-RAW or R3D NE. Nikon
+states that image area follows the selected frame size/frame rate for those RAW formats, and its
+ordinary `Image area > Choose image area` setting does not apply. Nikon's RAW mode table documents
+the FX 6048×3402 and 4032×2268 modes, plus the DX 3984×2240 modes.
+
+Sources:
+
+- [Nikon ZR video image area options](https://onlinemanual.nikonimglib.com/zr/en/19-11.html)
+- [Nikon ZR RAW frame-size and frame-rate options](https://onlinemanual.nikonimglib.com/zr/en/19-02.html)
+
+The user-visible issue was therefore not a missing independent crop control. Android loaded the
+camera's `MovScreenSize` (`D0A0`) descriptor at connection time, but a confirmed codec
+(`MovFileType`, `D0AF`) change did not immediately reload that codec-dependent descriptor. Until a
+later timed refresh, Android could show the old codec's available frame-size modes.
+
+## Android behavior
+
+- After every confirmed codec write, camera-originated codec property event, or newly detected
+  codec change during normal polling, Android reloads `D0A0` and re-reads the active screen-size
+  value before publishing the next property snapshot.
+- The existing resolution/frame-rate picker shows `[FX]` for device-advertised 6048×3402 and
+  4032×2268 modes, and `[DX]` for device-advertised 3984×2240 modes, but only for an identified
+  Nikon ZR while N-RAW or R3D NE is active.
+- The picker still writes the exact 64-bit descriptor value supplied by the camera. There is no
+  synthetic crop property or hand-packed frame-size value.
+- Unknown bodies, non-RAW codecs, and unrecognised dimensions retain their existing generic labels.
+
+The fake ZR now supports codec-specific screen-size descriptor domains. The regression test changes
+from H.265 to R3D NE and N-RAW, verifies the immediate descriptor reload and FX/DX labels, then
+verifies that selecting the DX mode writes its exact advertised raw value.
+
+## Hardware follow-up
+
+**[VERIFY-ON-HW]** With a supported Nikon ZR over Wi-Fi and USB-C, switch among H.265, N-RAW, and
+R3D NE and confirm that every available frame-size option refreshes immediately, displays the
+camera's FX/DX semantics correctly, and is accepted by the camera. Do not probe or write possible
+Nikon crop-related properties until a real ZR descriptor capture establishes their meaning in RAW
+video.


### PR DESCRIPTION
## Summary

- Android-only change. No iOS app-shell source changes.
- Nikon ZR N-RAW and R3D NE image area follows camera frame size/frame rate, so this keeps the existing resolution picker and adds no speculative crop-property write.
- Refreshes the camera-advertised `MovScreenSize` (`D0A0`) domain after confirmed codec writes, codec events, and detected codec transitions during normal Android polling.
- Shows documented FX/DX labels only for exact Nikon ZR RAW frame sizes, while preserving the exact 64-bit camera-advertised write value.
- Polls `MovFileType` before its Android-only dependent frame-size read so a missed event cannot briefly expose the old picker domain.

## Verification

- `just android-check`
- `just native-check`
- `just check`
- Connected Android device visual check using the fake ZR RAW domain, including selecting DX and switching R3D NE to N-RAW.

## Hardware follow-up

Physical Nikon ZR verification over Wi-Fi and USB-C remains pending.

## CI

The commit intentionally uses `[skip ci]` at the maintainer's request to avoid remote CI spend.