### PR TITLE
fix(ios): refine camera AP support handoff

### DIFF
--- a/ios/Runner/DemoHarness.swift
+++ b/ios/Runner/DemoHarness.swift
@@ -27,6 +27,8 @@ enum DemoHarness {
     static let forcedRedAvailability = value("ZC_DEMO_RED_BLOCKED")
     /// `ZC_DEMO_OPEN_BUG_REPORT=1` opens the bug-report route chooser for screenshot checks.
     static let openBugReport = flag("ZC_DEMO_OPEN_BUG_REPORT")
+    /// `ZC_DEMO_INTERNET_CONFIRM=support|report|feature` stages the camera-AP confirmation alert.
+    static let internetHandoffConfirmation = value("ZC_DEMO_INTERNET_CONFIRM")
     /// `ZC_METAL_FEED=1` opts into the experimental GPU-native feed renderer.
     static let metalFeed = flag("ZC_METAL_FEED")
     /// `ZC_DEMO_CANVAS_SCOPES=1` forces the Canvas reference plots over the Metal trace

--- a/ios/Runner/DemoHarness.swift
+++ b/ios/Runner/DemoHarness.swift
@@ -29,6 +29,8 @@ enum DemoHarness {
     static let openBugReport = flag("ZC_DEMO_OPEN_BUG_REPORT")
     /// `ZC_DEMO_INTERNET_CONFIRM=support|report|feature` stages the camera-AP confirmation alert.
     static let internetHandoffConfirmation = value("ZC_DEMO_INTERNET_CONFIRM")
+    /// `ZC_DEMO_INTERNET_PROGRESS=support|report|feature` stages the route-waiting overlay.
+    static let internetHandoffProgress = value("ZC_DEMO_INTERNET_PROGRESS")
     /// `ZC_METAL_FEED=1` opts into the experimental GPU-native feed renderer.
     static let metalFeed = flag("ZC_METAL_FEED")
     /// `ZC_DEMO_CANVAS_SCOPES=1` forces the Canvas reference plots over the Metal trace
@@ -345,6 +347,9 @@ enum DemoHarness {
                 // normal presentation path visible beneath it if a screenshot closes the form.
                 model.openStandaloneSettings()
                 model.operatorSettingsTab = .system
+            }
+            if let destination = SettingsInternetDestination.demoValue(internetHandoffProgress) {
+                model.beginInternetDestinationPreparation(destination.title)
             }
             if let raw = env["ZC_DEMO_ORIENTATION"] {
                 // Demo/screenshot affordance: force the interface orientation so headless

--- a/ios/Runner/MonitorPanels.swift
+++ b/ios/Runner/MonitorPanels.swift
@@ -2881,6 +2881,58 @@ enum OperatorSettingsTab: String, CaseIterable, Identifiable {
     }
 }
 
+/// The internet-backed destination selected from Operator Setup.
+///
+/// Keeping the selection as a value lets the camera-AP confirmation survive the tap and route to
+/// the exact page or in-app report flow after the camera session has been disconnected.
+enum SettingsInternetDestination: String, CaseIterable, Identifiable {
+    case support
+    case reportProblem
+    case featureRequest
+    case sourceCode
+    case privacyPolicy
+    case termsOfUse
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .support: "Support"
+        case .reportProblem: "Report a Problem"
+        case .featureRequest: "Request a Feature"
+        case .sourceCode: "Source Code"
+        case .privacyPolicy: "Privacy Policy"
+        case .termsOfUse: "Terms of Use"
+        }
+    }
+
+    var webURL: URL? {
+        switch self {
+        case .support: SupportLinkCatalog.support
+        case .reportProblem: nil
+        case .featureRequest: SupportLinkCatalog.featureRequest
+        case .sourceCode: SupportLinkCatalog.source
+        case .privacyPolicy: SupportLinkCatalog.privacy
+        case .termsOfUse: SupportLinkCatalog.terms
+        }
+    }
+
+    var opensInAppReport: Bool { self == .reportProblem }
+
+    var confirmationMessage: String {
+        "To open \(title), OpenZCine will disconnect from the camera's Wi-Fi and switch to cellular or another internet-connected Wi-Fi network. You can reconnect to the camera after you finish."
+    }
+
+    static func demoValue(_ rawValue: String?) -> SettingsInternetDestination? {
+        switch rawValue {
+        case "support": .support
+        case "report": .reportProblem
+        case "feature": .featureRequest
+        default: nil
+        }
+    }
+}
+
 struct OperatorSettingsPanel: View {
     /// Real device safe-area insets (carries the landscape Dynamic Island lane) so the full-screen
     /// surface can fill the physical screen yet keep its content clear of the cutout.
@@ -2899,6 +2951,7 @@ struct OperatorSettingsPanel: View {
     @State private var diagnosticsShareItem: DiagnosticsShareItem?
     @State private var diagnosticsErrorMessage: String?
     @State private var externalLinkErrorMessage: String?
+    @State private var pendingInternetDestination: SettingsInternetDestination?
     @State private var isPreparingDiagnostics = false
     /// Standalone setup is already a root cover, so its report flow is presented above that cover.
     /// Camera-backed setup uses the root-owned presentation instead, which survives an AP hop.
@@ -2975,8 +3028,14 @@ struct OperatorSettingsPanel: View {
             DiagnosticsShareSheet(url: item.url)
         }
         .fullScreenCover(isPresented: $standaloneBugReportPresented) {
-            BugReportFlowView(onDismiss: { standaloneBugReportPresented = false })
-                .environment(model)
+            BugReportFlowView(
+                onDismiss: {
+                    standaloneBugReportPresented = false
+                    model.resumeBugReportInternetHandoffIfNeeded()
+                },
+                onBrowserHandoff: { standaloneBugReportPresented = false }
+            )
+            .environment(model)
         }
         .alert(
             "Couldn’t Share Diagnostics",
@@ -3003,8 +3062,30 @@ struct OperatorSettingsPanel: View {
                     ?? "Check cellular or another Wi-Fi network and try again."
             )
         }
+        .alert(
+            "Leave camera Wi-Fi?",
+            isPresented: Binding(
+                get: { pendingInternetDestination != nil },
+                set: { if !$0 { pendingInternetDestination = nil } }
+            ),
+            presenting: pendingInternetDestination
+        ) { destination in
+            Button("Cancel", role: .cancel) { pendingInternetDestination = nil }
+            Button("Continue") {
+                pendingInternetDestination = nil
+                activateInternetDestination(destination)
+            }
+        } message: { destination in
+            Text(destination.confirmationMessage)
+        }
         .onAppear {
-            if DemoHarness.openBugReport { presentBugReport() }
+            if let destination = SettingsInternetDestination.demoValue(
+                DemoHarness.internetHandoffConfirmation
+            ) {
+                pendingInternetDestination = destination
+            } else if DemoHarness.openBugReport {
+                presentBugReport()
+            }
         }
     }
 
@@ -3344,7 +3425,7 @@ struct OperatorSettingsPanel: View {
                 help: "Connection guides, camera controls, media workflows, and troubleshooting.",
                 showTopDivider: false
             ) {
-                systemLinkButton("Open", url: SupportLinkCatalog.support, label: "Open Support")
+                systemLinkButton("Open", destination: .support, label: "Open Support")
             }
             SettingsInlineRow(
                 title: "Report a Problem",
@@ -3352,7 +3433,7 @@ struct OperatorSettingsPanel: View {
                     "Choose an anonymous in-app report or the richer signed-in GitHub form. Either creates a public GitHub issue."
             ) {
                 SettingsActionPill(title: "Report") {
-                    presentBugReport()
+                    requestInternetDestination(.reportProblem)
                 }
                 .accessibilityLabel("Report a Problem")
             }
@@ -3361,7 +3442,7 @@ struct OperatorSettingsPanel: View {
                 help: "Start an idea in the project’s feature-request discussion category."
             ) {
                 systemLinkButton(
-                    "Request", url: SupportLinkCatalog.featureRequest, label: "Request a Feature")
+                    "Request", destination: .featureRequest, label: "Request a Feature")
             }
             SettingsInlineRow(
                 title: "Share Diagnostics",
@@ -3395,15 +3476,15 @@ struct OperatorSettingsPanel: View {
                 showTopDivider: false
             ) {
                 systemLinkButton(
-                    "Open", url: SupportLinkCatalog.source, label: "Open Source Code")
+                    "Open", destination: .sourceCode, label: "Open Source Code")
             }
             SettingsInlineRow(title: "Privacy", help: "Read the OpenZCine privacy policy.") {
                 systemLinkButton(
-                    "Open", url: SupportLinkCatalog.privacy, label: "Open Privacy Policy")
+                    "Open", destination: .privacyPolicy, label: "Open Privacy Policy")
             }
             SettingsInlineRow(title: "Terms", help: "Read the OpenZCine terms of use.") {
                 systemLinkButton(
-                    "Open", url: SupportLinkCatalog.terms, label: "Open Terms of Use")
+                    "Open", destination: .termsOfUse, label: "Open Terms of Use")
             }
         }
 
@@ -3440,21 +3521,44 @@ struct OperatorSettingsPanel: View {
         }
     }
 
-    private func systemLinkButton(_ title: String, url: URL, label: String) -> some View {
-        Button(title) { openExternalURL(url) }
+    private func systemLinkButton(
+        _ title: String,
+        destination: SettingsInternetDestination,
+        label: String
+    ) -> some View {
+        Button(title) { requestInternetDestination(destination) }
             .font(.system(size: 13, weight: .semibold))
             .foregroundStyle(LiveDesign.accent)
             .buttonStyle(.zcTapTarget)
             .accessibilityLabel(label)
     }
 
-    private func openExternalURL(_ url: URL) {
+    private func requestInternetDestination(_ destination: SettingsInternetDestination) {
+        guard !model.isOnCameraAccessPoint else {
+            pendingInternetDestination = destination
+            return
+        }
+        activateInternetDestination(destination)
+    }
+
+    private func activateInternetDestination(_ destination: SettingsInternetDestination) {
         Task {
-            guard await model.prepareExternalInternetLinkHandoff() else {
+            let routeReady =
+                if destination.opensInAppReport {
+                    await model.prepareBugReportInternetHandoff()
+                } else {
+                    await model.prepareExternalInternetLinkHandoff()
+                }
+            guard routeReady else {
                 externalLinkErrorMessage =
                     "OpenZCine couldn't reach the internet after leaving the camera's Wi-Fi. Check cellular or another Wi-Fi network and try again."
                 return
             }
+            if destination.opensInAppReport {
+                presentBugReport()
+                return
+            }
+            guard let url = destination.webURL else { return }
             openURL(url) { accepted in
                 model.completeExternalInternetLinkHandoff(browserAccepted: accepted)
             }
@@ -3680,9 +3784,14 @@ struct BugReportFlowView: View {
     @State private var destination: Destination = .chooser
 
     private let onDismiss: () -> Void
+    private let onBrowserHandoff: () -> Void
 
-    init(onDismiss: @escaping () -> Void) {
+    init(
+        onDismiss: @escaping () -> Void,
+        onBrowserHandoff: @escaping () -> Void
+    ) {
         self.onDismiss = onDismiss
+        self.onBrowserHandoff = onBrowserHandoff
     }
 
     var body: some View {
@@ -3690,6 +3799,7 @@ struct BugReportFlowView: View {
         case .chooser:
             BugReportPathChooserView(
                 onDismiss: onDismiss,
+                onBrowserHandoff: onBrowserHandoff,
                 onAnonymous: { destination = .anonymous }
             )
         case .anonymous:
@@ -3710,13 +3820,16 @@ private struct BugReportPathChooserView: View {
     @State private var externalLinkErrorMessage: String?
 
     private let onDismiss: () -> Void
+    private let onBrowserHandoff: () -> Void
     private let onAnonymous: () -> Void
 
     init(
         onDismiss: @escaping () -> Void,
+        onBrowserHandoff: @escaping () -> Void,
         onAnonymous: @escaping () -> Void
     ) {
         self.onDismiss = onDismiss
+        self.onBrowserHandoff = onBrowserHandoff
         self.onAnonymous = onAnonymous
     }
 
@@ -3881,7 +3994,7 @@ private struct BugReportPathChooserView: View {
                 if dismissWhenAccepted {
                     BugReportGitHubHandoff.dismissAfterAcceptedBrowserOpen(
                         accepted,
-                        dismiss: onDismiss
+                        dismiss: onBrowserHandoff
                     )
                 }
             }
@@ -4392,14 +4505,13 @@ struct BugReportFormView: View {
     }
 
     private func submitReport() async {
-        let usedInternetHop = appModel.isOnCameraAccessPoint
-        guard await appModel.prepareExternalInternetLinkHandoff() else {
+        guard await appModel.prepareBugReportInternetHandoff() else {
             model.recordInternetRouteFailure()
             return
         }
         await model.submit()
-        if usedInternetHop {
-            appModel.resumeExternalInternetLinkHandoffIfNeeded()
+        if model.receipt != nil {
+            appModel.resumeBugReportInternetHandoffIfNeeded()
         }
     }
 

--- a/ios/Runner/MonitorPanels.swift
+++ b/ios/Runner/MonitorPanels.swift
@@ -3542,7 +3542,16 @@ struct OperatorSettingsPanel: View {
     }
 
     private func activateInternetDestination(_ destination: SettingsInternetDestination) {
+        let showsRouteProgress = model.isOnCameraAccessPoint
+        if showsRouteProgress {
+            model.beginInternetDestinationPreparation(destination.title)
+        }
         Task {
+            defer {
+                if showsRouteProgress {
+                    model.finishInternetDestinationPreparation(destination.title)
+                }
+            }
             let routeReady =
                 if destination.opensInAppReport {
                     await model.prepareBugReportInternetHandoff()

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -605,6 +605,10 @@ final class NativeAppModel {
     /// camera-AP hop. Unlike a browser handoff, ordinary foreground transitions must not end this
     /// hop because screenshot picking can briefly move the app inactive while the form is open.
     private(set) var bugReportInternetHandoffActive = false
+    /// The selected destination shown while iOS leaves the camera AP and settles on an
+    /// internet-capable route. Root ownership keeps this visible after the monitor and Settings
+    /// panel collapse with the camera session.
+    private(set) var internetDestinationPreparationTitle: String?
     /// Share context to restore after an internet hop re-hosts the media browser (the monitor
     /// panel's view state dies with the monitor): the clips whose share sheet initiated the hop.
     /// The standalone browser consumes this on mount — reopening a single cached clip, or the
@@ -2542,6 +2546,18 @@ final class NativeAppModel {
         }
         bugReportInternetHandoffActive = true
         return true
+    }
+
+    /// Shows root-owned progress while an external destination waits for an internet route.
+    func beginInternetDestinationPreparation(_ title: String) {
+        internetDestinationPreparationTitle = title
+    }
+
+    /// Clears progress only for the task that originally set it, preventing an older handoff from
+    /// hiding a newer destination's status.
+    func finishInternetDestinationPreparation(_ title: String) {
+        guard internetDestinationPreparationTitle == title else { return }
+        internetDestinationPreparationTitle = nil
     }
 
     /// Completes a rejected browser handoff immediately so the camera is not left disconnected.
@@ -6486,6 +6502,12 @@ struct NativeAppRoot: View {
                 .environment(deliveryCoordinator)
                 .zIndex(150)
 
+            if let destinationTitle = model.internetDestinationPreparationTitle {
+                InternetDestinationPreparationOverlay(destinationTitle: destinationTitle)
+                    .transition(.opacity)
+                    .zIndex(160)
+            }
+
             if showsLaunchSplash {
                 LaunchSplashOverlay(isVisible: $showsLaunchSplash)
                     .transition(.opacity)
@@ -6654,6 +6676,45 @@ struct NativeAppRoot: View {
         )
     }
 
+}
+
+private struct InternetDestinationPreparationOverlay: View {
+    let destinationTitle: String
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.58)
+                .ignoresSafeArea()
+
+            VStack(spacing: 12) {
+                ProgressView()
+                    .controlSize(.large)
+                    .tint(LiveDesign.accent)
+
+                Text("Switching networks…")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(LiveDesign.text)
+
+                Text("Waiting for an internet connection before opening \(destinationTitle).")
+                    .font(.system(size: 14))
+                    .foregroundStyle(LiveDesign.muted)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.horizontal, 34)
+            .padding(.vertical, 24)
+            .frame(maxWidth: 430)
+            .background(LiveDesign.surface, in: RoundedRectangle(cornerRadius: 18))
+            .overlay {
+                RoundedRectangle(cornerRadius: 18)
+                    .stroke(LiveDesign.hairlineStrong, lineWidth: 1)
+            }
+            .shadow(color: .black.opacity(0.34), radius: 24, y: 12)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Switching networks")
+        .accessibilityValue("Waiting to open \(destinationTitle)")
+    }
 }
 
 // MARK: - Media library (Media page)

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -309,6 +309,14 @@ struct LUTFileStore {
     }
 }
 
+enum ExternalInternetLinkReturnPolicy {
+    /// Rejoin only after an active browser handoff actually backgrounded the app. Presentation
+    /// transitions alone can produce active-state churn while the destination is still opening.
+    static func shouldReconnect(handoffActive: Bool, sawBackground: Bool) -> Bool {
+        handoffActive && sawBackground
+    }
+}
+
 @MainActor
 @Observable
 final class NativeAppModel {
@@ -589,6 +597,14 @@ final class NativeAppModel {
     /// True only while a browser link is intentionally using an internet hop. On return to the
     /// foreground, the app rejoins the camera AP through the normal saved-profile pipeline.
     private(set) var externalInternetLinkHandoffActive = false
+    /// Set only after an accepted external-browser handoff actually backgrounds OpenZCine. This
+    /// prevents transient activation changes during presentation from prompting an immediate
+    /// camera-AP rejoin over the page the person just opened.
+    @ObservationIgnored private var externalInternetLinkSawBackground = false
+    /// True while the root-owned anonymous/GitHub report flow is using the internet side of a
+    /// camera-AP hop. Unlike a browser handoff, ordinary foreground transitions must not end this
+    /// hop because screenshot picking can briefly move the app inactive while the form is open.
+    private(set) var bugReportInternetHandoffActive = false
     /// Share context to restore after an internet hop re-hosts the media browser (the monitor
     /// panel's view state dies with the monitor): the clips whose share sheet initiated the hop.
     /// The standalone browser consumes this on mount — reopening a single cached clip, or the
@@ -2387,7 +2403,7 @@ final class NativeAppModel {
     /// download reach the internet from camera-AP transport. The download screen unblocks itself
     /// reactively when reachability flips; ``endInternetHop()`` (fired when that screen
     /// dismisses) arms the rejoin + reconnect.
-    func beginInternetHop() {
+    func beginInternetHop(rehostActivePanel: Bool = true) {
         guard !internetHopActive else { return }
         internetHopActive = true
         // Capture identity before teardown. The host falls back to the camera-AP convention
@@ -2404,20 +2420,21 @@ final class NativeAppModel {
                 return
             }
             internetHopReturn = (host, ssid)
-            // The monitor collapses when the session drops; re-host the panel that started the
-            // hop as a standalone root cover so the operator's context survives it.
-            if activePanel == .media {
-                activePanel = nil
-                isStandaloneMediaLibraryPresented = true
-            } else {
-                if activePanel == .settings {
-                    // Frame.io sign-in from Settings → Storage hops for internet; keep the
-                    // Storage tab on screen (root cover) through the disconnect + rejoin.
+            if rehostActivePanel {
+                // Long-running downloads and account sign-in keep their initiating surface alive
+                // as a root cover. Support/report actions deliberately skip this: their selected
+                // destination becomes the next surface after the camera session drops.
+                if activePanel == .media {
                     activePanel = nil
-                    isStandaloneSettingsPresented = true
+                    isStandaloneMediaLibraryPresented = true
+                } else {
+                    if activePanel == .settings {
+                        activePanel = nil
+                        isStandaloneSettingsPresented = true
+                    }
+                    pendingHopShareResumeClips = nil
                 }
-                // No media re-host → the existing browser (and its share sheet) survive in
-                // place; nothing to restore on mount.
+            } else {
                 pendingHopShareResumeClips = nil
             }
             // Nothing may pull the phone back onto the camera AP mid-download.
@@ -2496,26 +2513,70 @@ final class NativeAppModel {
     /// Leaves the camera AP only when needed and waits for a validated internet route before an
     /// external support, GitHub, or privacy link is opened.
     func prepareExternalInternetLinkHandoff() async -> Bool {
+        if bugReportInternetHandoffActive {
+            bugReportInternetHandoffActive = false
+            externalInternetLinkHandoffActive = true
+            externalInternetLinkSawBackground = false
+            return true
+        }
         guard isOnCameraAccessPoint else { return true }
-        beginInternetHop()
+        beginInternetHop(rehostActivePanel: false)
         guard await waitForInternetPath(timeoutSeconds: 30) else {
             endInternetHop()
             return false
         }
         externalInternetLinkHandoffActive = true
+        externalInternetLinkSawBackground = false
+        return true
+    }
+
+    /// Leaves the camera AP for the in-app report flow without preserving or reopening Settings.
+    /// The report becomes the root-owned destination after internet reachability is confirmed.
+    func prepareBugReportInternetHandoff() async -> Bool {
+        if bugReportInternetHandoffActive { return true }
+        guard isOnCameraAccessPoint else { return true }
+        beginInternetHop(rehostActivePanel: false)
+        guard await waitForInternetPath(timeoutSeconds: 30) else {
+            endInternetHop()
+            return false
+        }
+        bugReportInternetHandoffActive = true
         return true
     }
 
     /// Completes a rejected browser handoff immediately so the camera is not left disconnected.
     func completeExternalInternetLinkHandoff(browserAccepted: Bool) {
         guard !browserAccepted else { return }
-        resumeExternalInternetLinkHandoffIfNeeded()
+        guard externalInternetLinkHandoffActive else { return }
+        externalInternetLinkHandoffActive = false
+        externalInternetLinkSawBackground = false
+        endInternetHop()
+    }
+
+    /// Records that an accepted external page really took OpenZCine into the background. A mere
+    /// inactive/active transition is not enough evidence that the person finished with the page.
+    func noteExternalInternetLinkHandoffEnteredBackground() {
+        guard externalInternetLinkHandoffActive else { return }
+        externalInternetLinkSawBackground = true
     }
 
     /// Rejoins the camera after the person returns from the external browser.
     func resumeExternalInternetLinkHandoffIfNeeded() {
-        guard externalInternetLinkHandoffActive else { return }
+        guard
+            ExternalInternetLinkReturnPolicy.shouldReconnect(
+                handoffActive: externalInternetLinkHandoffActive,
+                sawBackground: externalInternetLinkSawBackground
+            )
+        else { return }
         externalInternetLinkHandoffActive = false
+        externalInternetLinkSawBackground = false
+        endInternetHop()
+    }
+
+    /// Rejoins the camera when the in-app report flow finishes or is explicitly closed.
+    func resumeBugReportInternetHandoffIfNeeded() {
+        guard bugReportInternetHandoffActive else { return }
+        bugReportInternetHandoffActive = false
         endInternetHop()
     }
 
@@ -6487,8 +6548,14 @@ struct NativeAppRoot: View {
             }
         }
         .fullScreenCover(isPresented: bugReportPresented) {
-            BugReportFlowView(onDismiss: { model.isBugReportPresented = false })
-                .environment(model)
+            BugReportFlowView(
+                onDismiss: {
+                    model.isBugReportPresented = false
+                    model.resumeBugReportInternetHandoffIfNeeded()
+                },
+                onBrowserHandoff: { model.isBugReportPresented = false }
+            )
+            .environment(model)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(ZCBackground().ignoresSafeArea())
@@ -6505,6 +6572,7 @@ struct NativeAppRoot: View {
             for await _ in NotificationCenter.default.notifications(
                 named: UIApplication.didEnterBackgroundNotification)
             {
+                model.noteExternalInternetLinkHandoffEnteredBackground()
                 model.enterBackground()
             }
         }

--- a/ios/RunnerTests/ExternalBetaReadinessTests.swift
+++ b/ios/RunnerTests/ExternalBetaReadinessTests.swift
@@ -36,6 +36,46 @@ struct ExternalBetaDiagnosticsTests {
         )
     }
 
+    @Test("Camera AP destinations preserve the selected route behind one consent prompt")
+    func cameraAccessPointDestinations() {
+        #expect(SettingsInternetDestination.reportProblem.opensInAppReport)
+        #expect(SettingsInternetDestination.reportProblem.webURL == nil)
+        #expect(SettingsInternetDestination.support.webURL == SupportLinkCatalog.support)
+        #expect(
+            SettingsInternetDestination.featureRequest.webURL == SupportLinkCatalog.featureRequest
+        )
+        #expect(SettingsInternetDestination.demoValue("report") == .reportProblem)
+
+        for destination in SettingsInternetDestination.allCases {
+            #expect(destination.confirmationMessage.contains(destination.title))
+            #expect(destination.confirmationMessage.contains("disconnect from the camera"))
+            #expect(destination.confirmationMessage.contains("cellular"))
+            #expect(destination.confirmationMessage.contains("internet-connected Wi-Fi"))
+        }
+    }
+
+    @Test("External pages reconnect only after the accepted browser handoff backgrounds the app")
+    func externalBrowserReturnPolicy() {
+        #expect(
+            !ExternalInternetLinkReturnPolicy.shouldReconnect(
+                handoffActive: true,
+                sawBackground: false
+            )
+        )
+        #expect(
+            ExternalInternetLinkReturnPolicy.shouldReconnect(
+                handoffActive: true,
+                sawBackground: true
+            )
+        )
+        #expect(
+            !ExternalInternetLinkReturnPolicy.shouldReconnect(
+                handoffActive: false,
+                sawBackground: true
+            )
+        )
+    }
+
     @Test("GitHub report handoff dismisses the chooser only after a browser accepts it")
     func githubReportHandoff() {
         var dismissalCount = 0

--- a/ios/RunnerTests/ExternalBetaReadinessTests.swift
+++ b/ios/RunnerTests/ExternalBetaReadinessTests.swift
@@ -76,6 +76,22 @@ struct ExternalBetaDiagnosticsTests {
         )
     }
 
+    @Test("Internet route progress survives Settings and ignores stale completion")
+    @MainActor
+    func internetRouteProgress() {
+        let model = NativeAppModel()
+
+        model.beginInternetDestinationPreparation("Support")
+        #expect(model.internetDestinationPreparationTitle == "Support")
+
+        model.beginInternetDestinationPreparation("Report a Problem")
+        model.finishInternetDestinationPreparation("Support")
+        #expect(model.internetDestinationPreparationTitle == "Report a Problem")
+
+        model.finishInternetDestinationPreparation("Report a Problem")
+        #expect(model.internetDestinationPreparationTitle == nil)
+    }
+
     @Test("GitHub report handoff dismisses the chooser only after a browser accepts it")
     func githubReportHandoff() {
         var dismissalCount = 0

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -3,7 +3,7 @@ What's changed
 - Report a Problem in Operator Setup > System now lets you choose an anonymous public report or the signed-in GitHub bug form.
 - The anonymous form can optionally include a privacy-filtered app activity log or selected screenshots; attachments are public.
 - Feature requests still open the community discussion where you sign in.
-- When the camera is connected through its Wi-Fi access point, opening Support, Report a Problem, or Request a Feature temporarily leaves that network so the web page can load, then reconnects to the camera when you return to OpenZCine.
+- On the camera's Wi-Fi access point, Support, Report a Problem, and Request a Feature now ask before switching to cellular or internet-connected Wi-Fi, then open the selected destination directly without reopening Settings.
 - Sharing Diagnostics remains a separate review-before-sharing option.
 
 Please test
@@ -11,4 +11,4 @@ Please test
 - In Operator Setup > System, open Report a Problem and confirm both choices say that reports become public GitHub issues.
 - Choose Report Anonymously, enter a non-sensitive real bug, and confirm it completes without a GitHub sign-in screen before you return to System.
 - In the anonymous form, toggle each optional attachment control. Confirm the warning explains that screenshot pixels can still contain sensitive information even after file metadata is removed.
-- Reopen Report a Problem and choose Continue with GitHub, then open Request a Feature. Confirm each opens the appropriate GitHub page. While connected to a camera over its Wi-Fi access point, also open Support, Report a Problem, and Request a Feature, then return to OpenZCine and confirm the camera reconnects.
+- Reopen Report a Problem and choose Continue with GitHub, then open Request a Feature. On the camera's Wi-Fi access point, confirm Support, Report a Problem, and Request a Feature each show the network-switch warning, Cancel stays connected, and Continue opens the selected destination without reopening Settings or prompting to rejoin immediately. Confirm the camera reconnect prompt appears only after returning from a web page, submitting a report, or closing the report flow.

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -3,7 +3,7 @@ What's changed
 - Report a Problem in Operator Setup > System now lets you choose an anonymous public report or the signed-in GitHub bug form.
 - The anonymous form can optionally include a privacy-filtered app activity log or selected screenshots; attachments are public.
 - Feature requests still open the community discussion where you sign in.
-- On the camera's Wi-Fi access point, Support, Report a Problem, and Request a Feature now ask before switching to cellular or internet-connected Wi-Fi, then open the selected destination directly without reopening Settings.
+- On the camera's Wi-Fi access point, Support, Report a Problem, and Request a Feature now ask before switching networks, show progress while internet reconnects, then open the selected destination directly without reopening Settings.
 - Sharing Diagnostics remains a separate review-before-sharing option.
 
 Please test
@@ -11,4 +11,4 @@ Please test
 - In Operator Setup > System, open Report a Problem and confirm both choices say that reports become public GitHub issues.
 - Choose Report Anonymously, enter a non-sensitive real bug, and confirm it completes without a GitHub sign-in screen before you return to System.
 - In the anonymous form, toggle each optional attachment control. Confirm the warning explains that screenshot pixels can still contain sensitive information even after file metadata is removed.
-- Reopen Report a Problem and choose Continue with GitHub, then open Request a Feature. On the camera's Wi-Fi access point, confirm Support, Report a Problem, and Request a Feature each show the network-switch warning, Cancel stays connected, and Continue opens the selected destination without reopening Settings or prompting to rejoin immediately. Confirm the camera reconnect prompt appears only after returning from a web page, submitting a report, or closing the report flow.
+- Reopen Report a Problem and choose Continue with GitHub, then open Request a Feature. On the camera's Wi-Fi access point, confirm Support, Report a Problem, and Request a Feature each show the network-switch warning, Cancel stays connected, and Continue shows a destination-specific progress prompt before opening the selected destination without reopening Settings or prompting to rejoin immediately. Confirm the camera reconnect prompt appears only after returning from a web page, submitting a report, or closing the report flow.


### PR DESCRIPTION
## Summary

- ask for confirmation before leaving the camera access point for Support, Report a Problem, Request a Feature, and other internet-backed settings links
- preserve the selected destination and open it directly after internet reachability returns instead of reopening Settings
- show destination-specific progress while iOS switches to an internet-capable route
- defer camera rejoin until the external page is left, an anonymous report succeeds, or the report flow is closed

## Root cause

The original handoff re-hosted Settings as a standalone cover and treated every foreground activation as a browser return. That lost the selected route, made the network wait look idle on the startup screen, and could prompt to rejoin the camera while the requested destination was still opening.

## Validation

- `just native-check`
- `just check`
- focused Swift Testing coverage for destination routing, progress ownership, and browser-return policy
- confirmation and progress states screenshot-verified on an iPhone 16 Pro simulator
- signed Debug build installed, launched, and user-verified on the connected iPad (2)

Follow-up to #196.
