### PR TITLE
feat: add privacy-safe failure traces to bug reports

### DIFF
--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
@@ -220,7 +220,11 @@ class MainActivity : ComponentActivity() {
                 val pairingEnvironment =
                     remember(pairingScript) {
                         pairingScript?.environment
-                            ?: realPairingEnvironment(applicationContext)
+                            ?: realPairingEnvironment(applicationContext) { phase, _ ->
+                                AndroidDiagnosticEvent.fromFailurePhase(phase)?.let {
+                                    diagnostics.record(it)
+                                }
+                            }
                     }
                 // USB attach/detach must stay observed while a handed-off
                 // session is on the monitor; close the Android receiver only

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSession.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSession.kt
@@ -270,6 +270,7 @@ class SwiftCoreCameraSession internal constructor(
         SwiftCoreLiveFrameSource(
             onRecordingState = ::applyCameraRecordingState,
             onCommandRoundTrip = ::updateRoundTripMeasurement,
+            onFailurePhase = { phase -> phaseLogger(phase, "") },
         )
 
     /**

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreLiveFrameSource.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreLiveFrameSource.kt
@@ -27,7 +27,8 @@ import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.withContext
 
-private class LiveViewEndedException : IllegalStateException("The native live-view pump ended.")
+private class LiveViewEndedException(val generation: Long) :
+    IllegalStateException("The native live-view pump ended.")
 
 private data class StreamFrame(
     val generation: Long,
@@ -159,6 +160,7 @@ class SwiftCoreLiveFrameSource(
     private val restartDelayMillis: Long = 250L,
     private val onRecordingState: (Boolean) -> Unit = {},
     private val onCommandRoundTrip: () -> Unit = {},
+    private val onFailurePhase: (String) -> Unit = {},
     private val stopDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val beforeStartReservation: suspend () -> Unit = {},
 ) : LiveFrameSource {
@@ -171,6 +173,7 @@ class SwiftCoreLiveFrameSource(
     private var requestedPreviewVersion = 0L
     private var appliedPreview: SwiftLiveViewRequest? = null
     private var nativePumpState: NativePumpState = NativePumpState.Idle
+    private var intentionalRestartGeneration: Long? = null
     private val previewUpdates = Channel<Unit>(Channel.CONFLATED)
     private val pumpStateUpdates = Channel<Unit>(Channel.CONFLATED)
     private val _previewState = MutableStateFlow<SwiftLiveViewPreviewState>(SwiftLiveViewPreviewState.Idle)
@@ -391,12 +394,13 @@ class SwiftCoreLiveFrameSource(
                         }
 
                         override fun onEnded() {
-                            close(LiveViewEndedException())
+                            close(LiveViewEndedException(generation))
                         }
                         },
                     )
                 } catch (error: Throwable) {
                     failPumpStart(generation)
+                    onFailurePhase("liveViewFailed")
                     throw error
                 }
                 if (completePumpStart(reservation)) {
@@ -409,6 +413,16 @@ class SwiftCoreLiveFrameSource(
             .buffer(Channel.CONFLATED)
             .retryWhen { cause, _ ->
                 if (cause !is LiveViewEndedException) return@retryWhen false
+                val intentionalRestart =
+                    synchronized(previewRequestLock) {
+                        if (intentionalRestartGeneration == cause.generation) {
+                            intentionalRestartGeneration = null
+                            true
+                        } else {
+                            false
+                        }
+                    }
+                if (!intentionalRestart) onFailurePhase("liveViewStalled")
                 delay(restartDelayMillis)
                 true
             }
@@ -664,6 +678,7 @@ class SwiftCoreLiveFrameSource(
                     is NativePumpState.Running -> {
                         activeStreamGeneration.compareAndSet(state.generation, 0L)
                         nativePumpState = NativePumpState.Stopping(state.generation)
+                        intentionalRestartGeneration = state.generation
                         stopGeneration = state.generation
                     }
                     is NativePumpState.Idle,

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/diagnostics/AndroidAppDiagnostics.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/diagnostics/AndroidAppDiagnostics.kt
@@ -103,7 +103,7 @@ internal class AndroidAppDiagnostics private constructor(
     }
 
     /**
-     * The opt-in anonymous-report activity log, reduced to closed event names.
+     * The opt-in anonymous-report activity log, reduced to closed event and incident codes.
      *
      * This is intentionally not [createReport]: it has no timestamps, Android
      * exit summaries, device details, or free-form local diagnostics content.

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/diagnostics/BugReport.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/diagnostics/BugReport.kt
@@ -205,7 +205,7 @@ internal data class BugReportPayload(
 /**
  * Exact v2 JSON part for an anonymous report with optional attachments.
  *
- * The activity log is intentionally only a closed list of event names. It
+ * The activity log is intentionally only a closed list of event and incident codes. It
  * never includes the timestamped local diagnostics report, free-form values,
  * device names, or Android process metadata.
  */
@@ -373,7 +373,7 @@ private val PNG_SIGNATURE: ByteArray =
         0x0A,
     )
 
-/** Only closed event names can be placed in a public anonymous attachment. */
+/** Only closed event and incident codes can be placed in a public anonymous attachment. */
 internal fun isPrivacyFilteredActivityLog(events: List<String>): Boolean =
     events.size <= BugReportAttachmentLimits.MAXIMUM_ACTIVITY_EVENTS &&
         events.all { event -> AndroidDiagnosticEvent.fromWireValue(event) != null }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/diagnostics/DiagnosticEventStore.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/diagnostics/DiagnosticEventStore.kt
@@ -18,11 +18,25 @@ internal enum class AndroidDiagnosticEvent(val wireValue: String) {
     GUIDE_COMPLETED("live-guide.completed"),
     GUIDE_SKIPPED("live-guide.skipped"),
     DIAGNOSTICS_EXPORTED("diagnostics.exported"),
+    CONNECTION_FAILED("error.connection.failed"),
+    CONNECTION_EVENT_CHANNEL_ENDED("error.connection.event-channel-ended"),
+    LIVE_VIEW_FAILED("error.live-view.failed"),
+    LIVE_VIEW_STALLED("warning.live-view.stalled"),
     ;
 
     companion object {
         fun fromWireValue(value: String): AndroidDiagnosticEvent? =
             entries.firstOrNull { it.wireValue == value }
+
+        /** Maps only closed failure phases; the accompanying free-form detail is discarded. */
+        fun fromFailurePhase(phase: String): AndroidDiagnosticEvent? =
+            when (phase) {
+                "failed" -> CONNECTION_FAILED
+                "eventChannelEnded" -> CONNECTION_EVENT_CHANNEL_ENDED
+                "liveViewFailed" -> LIVE_VIEW_FAILED
+                "liveViewStalled" -> LIVE_VIEW_STALLED
+                else -> null
+            }
     }
 }
 
@@ -123,7 +137,8 @@ internal class DiagnosticEventStore(
      * Timestamps, raw local file lines, and every diagnostic-report field are
      * deliberately left behind. A hand-edited value such as "Bob's iPhone"
      * cannot enter because [recentEvents] accepts only [AndroidDiagnosticEvent]
-     * wire values.
+     * wire values. Error and warning values are closed incident codes; the
+     * relay derives their fixed operational traces without receiving raw text.
      */
     @Synchronized
     fun privacyFilteredActivityLog(): List<String> =
@@ -192,7 +207,7 @@ internal object DiagnosticReportRenderer {
                 "names and network addresses, media names and paths, account identities and tokens,",
                 "credentials, camera frames, arbitrary exception text, and user-entered text.",
                 "No diagnostics are uploaded automatically by OpenZCine.",
-                "Anonymous reports can include only a separately selected privacy-filtered list of app-event names.",
+                "Anonymous reports can include only separately selected closed app-event and incident codes.",
                 "",
                 "Generated: ${isoTimestamp(metadata.generatedAtMillis)}",
                 "App: OpenZCine $version (build ${metadata.buildNumber.coerceAtLeast(0)})",

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/PairingExperience.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/PairingExperience.kt
@@ -120,8 +120,16 @@ public class PairingEnvironment(
     public val credentials: PairingCredentials,
 )
 
-/** Production [PairingEnvironment] over the real platform services. */
-public fun realPairingEnvironment(context: Context): PairingEnvironment {
+/**
+ * Production [PairingEnvironment] over the real platform services.
+ *
+ * [phaseLogger] receives progress and failure phases. Callers must discard or privately handle the
+ * detail value rather than placing it in an anonymous report.
+ */
+public fun realPairingEnvironment(
+    context: Context,
+    phaseLogger: (String, String) -> Unit = { _, _ -> },
+): PairingEnvironment {
     val joiner = CameraApJoiner(context.getSystemService(ConnectivityManager::class.java))
     val discovery =
         CameraDiscovery(AndroidNsdBrowser(context.getSystemService(NsdManager::class.java)))
@@ -130,13 +138,14 @@ public fun realPairingEnvironment(context: Context): PairingEnvironment {
         joinCameraAp = { ssid, passphrase -> joiner.join(ssid, passphrase) },
         releaseCameraAp = joiner::release,
         hotspotCameras = discovery.cameras(),
-        createSession = { host -> SwiftCoreCameraSession(host) },
+        createSession = { host -> SwiftCoreCameraSession(host, phaseLogger) },
         usbCameraSource = usbCameraSource,
         createUsbSession = { opened ->
             SwiftCoreCameraSession(
                 host = opened.hostKey,
                 cameraNameHint = opened.displayName,
                 usbTransport = opened.transport,
+                phaseLogger = phaseLogger,
             )
         },
         credentials = CameraWifiCredentialStore(context),

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/SwiftCoreLiveFrameSourceTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/SwiftCoreLiveFrameSourceTest.kt
@@ -299,6 +299,7 @@ class SwiftCoreLiveFrameSourceTest {
     fun `pump end restarts while a collector remains subscribed`() = runTest {
         var starts = 0
         var stops = 0
+        val failurePhases = mutableListOf<String>()
         lateinit var listener: SwiftCore.LiveFrameListener
         val source =
             SwiftCoreLiveFrameSource(
@@ -311,6 +312,7 @@ class SwiftCoreLiveFrameSourceTest {
                 configurePreview = { true },
                 sharingScope = backgroundScope,
                 restartDelayMillis = 0L,
+                onFailurePhase = failurePhases::add,
             )
         val frames = mutableListOf<LiveFrame>()
         val collector = launch { source.frames.collect { frames += it } }
@@ -321,6 +323,7 @@ class SwiftCoreLiveFrameSourceTest {
 
         assertEquals(2, starts)
         assertEquals(1, stops)
+        assertEquals(listOf("liveViewStalled"), failurePhases)
         listener.onFrame(byteArrayOf(9), 9L, true)
         runCurrent()
 
@@ -382,6 +385,7 @@ class SwiftCoreLiveFrameSourceTest {
         val configured = mutableListOf<SwiftLiveViewRequest>()
         var starts = 0
         var stops = 0
+        val failurePhases = mutableListOf<String>()
         lateinit var listener: SwiftCore.LiveFrameListener
         val source =
             SwiftCoreLiveFrameSource(
@@ -400,6 +404,7 @@ class SwiftCoreLiveFrameSourceTest {
                 },
                 sharingScope = backgroundScope,
                 restartDelayMillis = 0L,
+                onFailurePhase = failurePhases::add,
             )
         val collector = launch { source.frames.collect() }
         runCurrent()
@@ -413,6 +418,7 @@ class SwiftCoreLiveFrameSourceTest {
         )
         assertEquals(2, starts)
         assertEquals(1, stops)
+        assertEquals(emptyList(), failurePhases)
         assertEquals(SwiftLiveViewRequest.DEFAULT, source.appliedPreviewRequest)
         val rejected = assertIs<SwiftLiveViewPreviewState.Rejected>(source.previewState.value)
         assertEquals(rejectedRequest, rejected.requested)

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/diagnostics/BugReportTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/diagnostics/BugReportTest.kt
@@ -88,8 +88,9 @@ class BugReportTest {
     }
 
     @Test
-    fun `v2 activity log contains only closed event names and no device text`() {
-        val activityLog = listOf("app.launched", "live-view.started")
+    fun `v2 activity log contains only closed event and incident codes with no device text`() {
+        val activityLog =
+            listOf("app.launched", "live-view.started", "error.connection.failed")
         val payload =
             BugReportAttachmentPayload.from(
                 draft =
@@ -113,7 +114,7 @@ class BugReportTest {
                 "\"appVersion\":\"0.1.117\",\"buildNumber\":\"117\"," +
                 "\"osVersion\":\"Android 16 (API 36)\",\"deviceClass\":\"phone\"," +
                 "\"connection\":\"usb\"},\"activityLog\":[\"app.launched\"," +
-                "\"live-view.started\"]}",
+                "\"live-view.started\",\"error.connection.failed\"]}",
             payload.toJson(),
         )
         assertFalse(payload.toJson().contains("Bob's iPhone"))

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/diagnostics/DiagnosticEventStoreTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/diagnostics/DiagnosticEventStoreTest.kt
@@ -121,6 +121,23 @@ class DiagnosticEventStoreTest {
     }
 
     @Test
+    fun `closed failure phases become privacy-safe incident codes`() {
+        assertEquals(
+            AndroidDiagnosticEvent.CONNECTION_FAILED,
+            AndroidDiagnosticEvent.fromFailurePhase("failed"),
+        )
+        assertEquals(
+            AndroidDiagnosticEvent.CONNECTION_EVENT_CHANNEL_ENDED,
+            AndroidDiagnosticEvent.fromFailurePhase("eventChannelEnded"),
+        )
+        assertEquals(
+            AndroidDiagnosticEvent.LIVE_VIEW_STALLED,
+            AndroidDiagnosticEvent.fromFailurePhase("liveViewStalled"),
+        )
+        assertEquals(null, AndroidDiagnosticEvent.fromFailurePhase("Bob's iPhone"))
+    }
+
+    @Test
     fun `report includes only coarse process exits and explicit privacy notice`() {
         val report =
             DiagnosticReportRenderer.render(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -225,8 +225,10 @@ Problem** offers two public GitHub-issue paths: an anonymous in-app form and the
 form sends the report text the operator supplies plus a small, closed set of app/platform fields.
 It never ships a GitHub credential, installation identifier, raw diagnostics, arbitrary logs,
 camera identity, or network identifier. Operators can explicitly opt into a closed
-privacy-filtered activity-event snapshot or user-selected screenshots. The apps re-render selected
-screenshots with generic filenames and no embedded file metadata; a server-side canonicalizer
+privacy-filtered activity snapshot containing lifecycle events and allowlisted error/warning codes,
+or user-selected screenshots. The relay expands incident codes into fixed operational traces; it
+never receives raw runtime stacks, exception messages, paths, addresses, or timestamps. The apps
+re-render selected screenshots with generic filenames and no embedded file metadata; a server-side canonicalizer
 enforces that boundary again. Screenshot pixels may still contain sensitive information, so the UI
 requires a public-sharing warning and review. The signed-in route hands richer optional details and
 attachments directly to GitHub. Local diagnostics remain a separate user-reviewed share flow.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -286,7 +286,9 @@ Feature work tracked as its own tasks on the Kaneo board, outside the Phase 0–
   [signed-in GitHub issue](https://github.com/erik-sutton95/OpenZCine/issues/new?template=bug_report.yml) for richer
   optional details. Both create labelled public GitHub issues. The anonymous path has optional,
   user-selected screenshots re-rendered without embedded file metadata and a closed,
-  privacy-filtered app-activity snapshot; it never uploads raw diagnostics, arbitrary logs, device
+  privacy-filtered app-activity snapshot. Closed error/warning codes expand server-side into fixed
+  operational traces so failure order is visible without uploading raw stacks, exception text,
+  paths, addresses, or timestamps. It never uploads raw diagnostics, arbitrary logs, device
   names, camera/device identifiers, network identifiers, or original image bytes. Visible screenshot
   content remains the reporter's responsibility to review. Feature requests remain account-backed
   GitHub Discussions.

--- a/docs/testflight-ci.md
+++ b/docs/testflight-ci.md
@@ -109,9 +109,11 @@ privacy-filtered activity-event snapshot or selected screenshots, or choose a
 [signed-in GitHub issue](https://github.com/erik-sutton95/OpenZCine/issues/new?template=bug_report.yml) with richer
 optional details. Both create public GitHub issues. The anonymous route never uploads the local
 MetricKit report, raw breadcrumbs, arbitrary logs, original image bytes, or media. Its optional
-snapshot contains only closed event names; selected screenshots are re-rendered to remove embedded
-file metadata but their visible content remains public. Testers must not include passwords, pairing
-codes, private media, or security vulnerabilities in either route.
+snapshot contains only closed event and incident codes. The relay renders fixed operational traces
+for incidents without receiving raw stacks, exception messages, paths, addresses, or timestamps.
+Selected screenshots are re-rendered to remove embedded file metadata but their visible content
+remains public. Testers must not include passwords, pairing codes, private media, or security
+vulnerabilities in either route.
 
 ## GitHub Actions (fallback)
 

--- a/ios/Runner/AppDiagnostics.swift
+++ b/ios/Runner/AppDiagnostics.swift
@@ -25,6 +25,9 @@ enum AppDiagnosticEvent: String, Codable, Sendable {
     case monitorDismissed = "monitor.dismissed"
     case liveViewStarted = "live-view.started"
     case liveViewFailed = "live-view.failed"
+    case connectionFailed = "error.connection.failed"
+    case connectionEventChannelEnded = "error.connection.event-channel-ended"
+    case liveViewStalled = "warning.live-view.stalled"
     case recordingStarted = "recording.started"
     case recordingStopped = "recording.stopped"
     case guidePresented = "live-guide.presented"
@@ -337,7 +340,7 @@ final class AppDiagnostics: NSObject, MXMetricManagerSubscriber, @unchecked Send
         return url
     }
 
-    /// Returns a bounded, closed-vocabulary event snapshot suitable for an opted-in public report.
+    /// Returns a bounded, closed-vocabulary event and incident snapshot for an opted-in report.
     ///
     /// Unlike ``makeReport()``, this never includes timestamps, MetricKit data, or device metadata.
     func anonymousActivityLog() async -> [String] {

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -317,6 +317,12 @@ enum ExternalInternetLinkReturnPolicy {
     }
 }
 
+enum EventChannelDiagnosticPolicy {
+    static func shouldRecordUnexpectedEnd(isCancelled: Bool, ownsSession: Bool) -> Bool {
+        !isCancelled && ownsSession
+    }
+}
+
 @MainActor
 @Observable
 final class NativeAppModel {
@@ -1154,6 +1160,7 @@ final class NativeAppModel {
     }
 
     private func surfaceCameraWiFiJoinFailure(_ message: String) {
+        AppDiagnostics.shared.record(.connectionFailed)
         connectionProgressShowsFailure = true
         connectionPhase = .failed
         connectionMessage = message
@@ -1712,6 +1719,7 @@ final class NativeAppModel {
                 return
             } catch {
                 guard connectionGeneration == generation else { return }
+                AppDiagnostics.shared.record(.connectionFailed)
                 connection = .disconnected
                 connectionPhase = .failed
                 connectionProgressShowsFailure = true
@@ -1859,6 +1867,7 @@ final class NativeAppModel {
                     )
                     return
                 }
+                AppDiagnostics.shared.record(.connectionFailed)
                 connection = .disconnected
                 connectionPhase = .failed
                 connectionProgressShowsFailure = true
@@ -3166,6 +3175,7 @@ final class NativeAppModel {
                     connectToCamera(preservingMonitorSurface: true)
                     return
                 case .stalled(let reason):
+                    AppDiagnostics.shared.record(.liveViewStalled)
                     if streamedHealthily { stallAttempt = 0 }
                     if stallAttempt >= maxStallRestarts {
                         // The stream keeps dying right after each restart — escalate to a full
@@ -3381,8 +3391,22 @@ final class NativeAppModel {
                     }
                 } catch let error as NativeCameraSessionError {
                     if case .timeout = error { continue }
+                    guard
+                        EventChannelDiagnosticPolicy.shouldRecordUnexpectedEnd(
+                            isCancelled: Task.isCancelled,
+                            ownsSession: self.cameraSession === session
+                        )
+                    else { return }
+                    AppDiagnostics.shared.record(.connectionEventChannelEnded)
                     return
                 } catch {
+                    guard
+                        EventChannelDiagnosticPolicy.shouldRecordUnexpectedEnd(
+                            isCancelled: Task.isCancelled,
+                            ownsSession: self.cameraSession === session
+                        )
+                    else { return }
+                    AppDiagnostics.shared.record(.connectionEventChannelEnded)
                     return
                 }
             }

--- a/ios/RunnerTests/ExternalBetaReadinessTests.swift
+++ b/ios/RunnerTests/ExternalBetaReadinessTests.swift
@@ -76,6 +76,25 @@ struct ExternalBetaDiagnosticsTests {
         )
     }
 
+    @Test("Event-channel diagnostics ignore expected cancellation and stale sessions")
+    func eventChannelDiagnosticPolicy() {
+        #expect(
+            EventChannelDiagnosticPolicy.shouldRecordUnexpectedEnd(
+                isCancelled: false,
+                ownsSession: true
+            ))
+        #expect(
+            !EventChannelDiagnosticPolicy.shouldRecordUnexpectedEnd(
+                isCancelled: true,
+                ownsSession: true
+            ))
+        #expect(
+            !EventChannelDiagnosticPolicy.shouldRecordUnexpectedEnd(
+                isCancelled: false,
+                ownsSession: false
+            ))
+    }
+
     @Test("Internet route progress survives Settings and ignores stale completion")
     @MainActor
     func internetRouteProgress() {
@@ -220,11 +239,18 @@ struct AnonymousBugReportTests {
                 timestamp: Date(timeIntervalSince1970: 1_700_000_003),
                 event: AppDiagnosticEvent.liveViewStarted.rawValue
             ),
+            DiagnosticBreadcrumb(
+                timestamp: Date(timeIntervalSince1970: 1_700_000_004),
+                event: AppDiagnosticEvent.connectionFailed.rawValue
+            ),
         ]
 
         let snapshot = DiagnosticEventStore.anonymousActivityLog(events: events)
 
-        #expect(snapshot == ["connection.connected", "live-view.started"])
+        #expect(
+            snapshot == [
+                "connection.connected", "live-view.started", "error.connection.failed",
+            ])
         #expect(!snapshot.joined(separator: " ").contains("Bob"))
         #expect(snapshot.allSatisfy { AppDiagnosticEvent(rawValue: $0) != nil })
     }

--- a/services/bug-relay/README.md
+++ b/services/bug-relay/README.md
@@ -47,9 +47,11 @@ created by the relay are public and labelled `bug`, `needs-triage`, and `source:
 larger than 3,211,264 bytes; every screenshot is at most 1,048,576 bytes and must declare
 `image/png`.
 
-The optional `activityLog` JSON field is an array of at most 200 closed OpenZCine event names. It
-does not accept arbitrary log text, timestamps, device names, paths, network values, or identifiers.
-The relay rejects unknown event values.
+The optional `activityLog` JSON field is an array of at most 200 closed OpenZCine event and
+incident codes. Error/warning incident codes are rendered with fixed operational stages such as
+`connection.attempt → transport-or-handshake → connection.failure`; those stages are relay-owned
+and are not raw runtime stack frames. The field does not accept exception messages, arbitrary log text,
+timestamps, device names, paths, network values, or identifiers. The relay rejects unknown values.
 
 Each screenshot is parsed server-side before storage. It must be a 1–2560px, 8-bit RGBA,
 non-interlaced PNG with valid CRCs; the Worker writes a newly canonical PNG containing only `IHDR`,

--- a/services/bug-relay/src/worker.mjs
+++ b/services/bug-relay/src/worker.mjs
@@ -60,6 +60,47 @@ const ACTIVITY_EVENTS = new Set([
   "guide.completed",
   "guide.skipped",
   "diagnostics.exported",
+  "error.connection.failed",
+  "error.connection.event-channel-ended",
+  "error.live-view.failed",
+  "warning.live-view.stalled",
+]);
+const ACTIVITY_INCIDENTS = new Map([
+  [
+    "error.connection.failed",
+    {
+      severity: "ERROR",
+      trace: ["connection.attempt", "transport-or-handshake", "connection.failure"],
+    },
+  ],
+  [
+    "error.connection.event-channel-ended",
+    {
+      severity: "ERROR",
+      trace: ["connection.connected", "camera.event-channel", "channel.ended"],
+    },
+  ],
+  [
+    "live-view.failed",
+    {
+      severity: "ERROR",
+      trace: ["connection.connected", "live-view.start", "first-frame.unavailable"],
+    },
+  ],
+  [
+    "error.live-view.failed",
+    {
+      severity: "ERROR",
+      trace: ["connection.connected", "live-view.start", "first-frame.unavailable"],
+    },
+  ],
+  [
+    "warning.live-view.stalled",
+    {
+      severity: "WARNING",
+      trace: ["live-view.streaming", "frame-delivery.stalled", "live-view.restart"],
+    },
+  ],
 ]);
 const PNG_SIGNATURE = Uint8Array.of(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a);
 const PNG_IHDR = Uint8Array.of(0x49, 0x48, 0x44, 0x52);
@@ -544,9 +585,9 @@ function renderNormalizedIssue(safeReport, { screenshotURLs = [] } = {}) {
       "",
       "## Privacy-filtered app activity log",
       "",
-      "This list contains only closed app event names; it has no timestamps or free-form log text.",
+      "This list contains closed app event names plus privacy-safe error/warning codes. Incident traces are fixed operational stages, not raw stack traces or free-form log text; there are no timestamps.",
       "",
-      fencedText(safeReport.activityLog.join("\n")),
+      fencedText(renderActivityLog(safeReport.activityLog)),
     );
   }
 
@@ -561,6 +602,17 @@ function renderNormalizedIssue(safeReport, { screenshotURLs = [] } = {}) {
     title,
     body: sections.join("\n"),
   };
+}
+
+function renderActivityLog(events) {
+  return events
+    .map((event) => {
+      const incident = ACTIVITY_INCIDENTS.get(event);
+      if (!incident) return event;
+      const trace = incident.trace.map((frame) => `    at ${frame}`).join("\n");
+      return `[${incident.severity}] ${event}\n  operational trace:\n${trace}`;
+    })
+    .join("\n");
 }
 
 /**

--- a/services/bug-relay/test/worker.test.mjs
+++ b/services/bug-relay/test/worker.test.mjs
@@ -571,6 +571,30 @@ test("v2 relays only closed activity events with an opaque attachment contract",
   assert.equal(receivedSubmission.screenshots[0].slot, 1);
 });
 
+test("v2 accepts closed incidents and renders fixed privacy-safe operational traces", async () => {
+  const rendered = await renderV2Issue(
+    await v2Submission({
+      report: validV2Report({
+        activityLog: [
+          "connection.connected",
+          "warning.live-view.stalled",
+          "error.connection.event-channel-ended",
+          "connection.disconnected",
+        ],
+      }),
+    }),
+  );
+
+  assert.match(rendered.body, /\[WARNING\] warning\.live-view\.stalled/u);
+  assert.match(
+    rendered.body,
+    /at live-view\.streaming\n    at frame-delivery\.stalled\n    at live-view\.restart/u,
+  );
+  assert.match(rendered.body, /\[ERROR\] error\.connection\.event-channel-ended/u);
+  assert.equal(rendered.body.includes("exception message"), false);
+  assert.equal(rendered.body.includes("\/private\/"), false);
+});
+
 test("canonicalizes only a zlib-decoded RGBA image plane", async () => {
   const valid = await canonicalizePng(png());
   assert.deepEqual(pngChunkTypes(valid), ["IHDR", "IDAT", "IEND"]);
@@ -616,6 +640,13 @@ test("v2 rejects arbitrary activity text and oversized uploads after rate limiti
   assert.equal(state.relayCalls, 0);
   assert.throws(
     () => validateV2Report(validV2Report({ activityLog: ["not-a-closed-event"] })),
+    InvalidRequestError,
+  );
+  assert.throws(
+    () =>
+      validateV2Report(
+        validV2Report({ activityLog: ["error.connection.failed: Bob's iPhone"] }),
+      ),
     InvalidRequestError,
   );
 });


### PR DESCRIPTION
## Summary

- add closed error and warning incident codes at iOS and Android connection/live-view failure boundaries
- render those codes as fixed operational traces in anonymous GitHub reports
- reject free-form failure detail and preserve the existing no-timestamps/no-identifiers privacy contract
- suppress expected cancellation, session teardown, and intentional live-view restart false positives

## Verification

- just native-check
- just bug-relay-check
- just check
- just secrets
- just hygiene

No UI layout changed, so screenshot verification is not applicable.

Fixes #200