### PR TITLE
fix(ios): fast, reliable USB-C connections to the ZR

### DIFF
--- a/Sources/OpenZCineCore/PTPOperation.swift
+++ b/Sources/OpenZCineCore/PTPOperation.swift
@@ -44,6 +44,10 @@ public enum PTPOperationCode: UInt16, Sendable {
     case getPairingInfo = 0x952B
     case confirmPairing = 0x935A
     case changeApplicationMode = 0x9435
+    // p1 0 PC-camera mode / 1 remote mode. Over USB the ZR boots into
+    // PC-camera mode and denies vendor app-control until remote mode is set;
+    // Wi-Fi smart-device sessions arrive already trusted. [verify-on-HW]
+    case changeCameraMode = 0x90C2
 
     // Properties. 2-byte `0xDxxx` props use the standard PIMA 15740 ops (0x1015/0x1016); the `Ex`
     // ops serve the 4-byte `0x0001_Dxxx` extended props. Ex-writing a 2-byte recording-format

--- a/ios/Runner/ConnectionProgressSheet.swift
+++ b/ios/Runner/ConnectionProgressSheet.swift
@@ -93,6 +93,13 @@ struct ConnectionProgressSheet: View {
 
     private var detail: String {
         if phase == .failed { return failureDetail }
+        // Live establishment step (safe to read, unlike `connectionMessage` — only the connect
+        // machinery writes it): real progress ("Reading the camera's card… 40%") beats a static
+        // phase title while a step is grinding.
+        let stage = model.connectionStageDetail
+        if !stage.isEmpty, phase != .connected, phase != .readyToJoin {
+            return stage
+        }
         return ConnectionProgressCopy.statusDetail(
             phase: phase,
             deviceName: deviceName,

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -2831,9 +2831,19 @@ final class NativeAppModel {
             // that's how the USB hang was pinned down); everything else is the failure trace.
             if summary.hasPrefix("stage:") {
                 let stage = String(summary.dropFirst("stage:".count))
+                // Operator-friendly wording; the technical stage ids stay in the failure trace.
+                let friendly =
+                    switch stage {
+                    case "pairing": "Pairing with the camera…"
+                    case "app-control switch", "remote-mode fallback":
+                        "Taking control of the camera…"
+                    case "device info": "Almost connected…"
+                    default:
+                        stage.hasPrefix("first command") ? "Starting the session…" : "Connecting…"
+                    }
                 Task { @MainActor in
                     guard let self, self.connectionPhase != .failed else { return }
-                    self.connectionStageDetail = "Step: \(stage)…"
+                    self.connectionStageDetail = friendly
                 }
             } else {
                 diagnosticBox.withLock { $0 = summary }
@@ -2974,7 +2984,7 @@ final class NativeAppModel {
             // fails its first command with a raw ICC error. Recycle the session once — real close,
             // fresh open, full retry — before surfacing a failure. (establish() already closed the
             // failed transport, which parks the device; the recycle open un-parks it cleanly.)
-            connectionStageDetail = "USB session was stale — restarting it…"
+            connectionStageDetail = "Refreshing the connection…"
             connectionLogger.info(
                 "USB establish failed once, recycling session: \(error.localizedDescription, privacy: .private(mask: .hash))"
             )

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -531,6 +531,10 @@ final class NativeAppModel {
     /// read the live `connectionMessage` for this — the discovery loop overwrites that field on
     /// every iteration, which put stale copy ("Found 1 camera.") on the failed card.
     var connectionFailureDetail = ""
+    /// Live establishment step ("Reading the camera's card… 40%", "Step: app-control switch…"),
+    /// written ONLY by the connect machinery — unlike `connectionMessage`, which the discovery loop
+    /// overwrites — so the progress sheet can show real progress instead of a frozen "Connecting".
+    var connectionStageDetail = ""
     @ObservationIgnored private var connectionProgressShowsFailure = false
     var cameraHost = "192.168.1.1"
     var connectionMessage = "Join your camera's Wi‑Fi network, then come back here to connect."
@@ -1882,7 +1886,16 @@ final class NativeAppModel {
                     knownMatchedHost: knownMatchedHost,
                     host: host
                 )
-                connectionFailureDetail = connectionMessage
+                // The friendly copy flattens every cause to one line; append the raw error and the
+                // establishment trace so a field failure names its exact step. Skip the raw error
+                // when the friendly pass had no mapping and echoed it verbatim (no doubled lines).
+                let establishmentTrace = establishmentDiagnostic.withLock { $0 }
+                var failureParts = [connectionMessage]
+                if !baseError.isEmpty, baseError != connectionMessage {
+                    failureParts.append(baseError)
+                }
+                if !establishmentTrace.isEmpty { failureParts.append(establishmentTrace) }
+                connectionFailureDetail = failureParts.joined(separator: "\n")
                 logConnection("failed host=\(host) \(self.connectionMessage)")
                 startDiscoveryLoop(resetResults: false)
             }
@@ -2156,9 +2169,6 @@ final class NativeAppModel {
     @ObservationIgnored private var pendingPairedReconnectSSID: String?
     /// Throttle for the paired-reconnect Wi‑Fi re-apply so it isn't fired every discovery cycle.
     @ObservationIgnored private var lastPairedRejoinAttemptAt: Date?
-    /// Saved USB cameras that already got their one silent auto-reconnect attempt for the current
-    /// plug-in. A key re-arms when the camera disappears from discovery (unplug).
-    @ObservationIgnored private var attemptedUSBAutoReconnectHostKeys: Set<String> = []
     private(set) var cameraPropertySnapshot = PTPCameraPropertySnapshot()
     private var propertyPollIndex = 0
     /// The `LiveViewImageSize` byte last written to the camera, so a thermal/warning step-down only
@@ -2636,28 +2646,9 @@ final class NativeAppModel {
             }
         }
 
-        // A saved USB-C camera reconnects silently the moment it is plugged in. One attempt per
-        // plug-in: an attempted host key re-arms only after the camera disappears (unplug), so a
-        // body that keeps failing to connect doesn't spin in a reconnect loop.
-        let attachedUSBHostKeys = Set(
-            cameras.filter(\.isUSB).compactMap { PTPIPPairedHosts.normalizedHost($0.ip) })
-        attemptedUSBAutoReconnectHostKeys.formIntersection(attachedUSBHostKeys)
-        if !isConnected, startupMode == .savedCameras,
-            let usbMatch = cameras.first(where: { camera in
-                guard camera.isUSB,
-                    let hostKey = PTPIPPairedHosts.normalizedHost(camera.ip),
-                    !attemptedUSBAutoReconnectHostKeys.contains(hostKey)
-                else { return false }
-                return CameraStartupPolicy.savedCamera(forDiscovered: camera, in: savedCameras)
-                    != nil
-            }),
-            let usbMatchHostKey = PTPIPPairedHosts.normalizedHost(usbMatch.ip)
-        {
-            attemptedUSBAutoReconnectHostKeys.insert(usbMatchHostKey)
-            connectionMessage = "Camera detected on USB-C. Reconnecting…"
-            connectToCamera(usbMatch)
-            return
-        }
+        // Plugging in a USB-C camera only LISTS it — connecting is always the operator's tap.
+        // (An auto-reconnect-on-plug used to live here; removed by request, it fought the
+        // deliberate connect flow now that USB establishment is fast.)
 
         guard !cameras.isEmpty else {
             if !isConnected {
@@ -2833,9 +2824,20 @@ final class NativeAppModel {
         guid: Data,
         strategy: CameraConnectionStrategy
     ) async throws -> (session: NativeCameraSession, requestedPairing: Bool) {
+        connectionStageDetail = ""
         let diagnosticBox = establishmentDiagnostic
-        let recordEstablishmentDiagnostic: @Sendable (String) -> Void = { summary in
-            diagnosticBox.withLock { $0 = summary }
+        let recordEstablishmentDiagnostic: @Sendable (String) -> Void = { [weak self] summary in
+            // "stage:" strings are live progress (shown so a stuck connect names its step —
+            // that's how the USB hang was pinned down); everything else is the failure trace.
+            if summary.hasPrefix("stage:") {
+                let stage = String(summary.dropFirst("stage:".count))
+                Task { @MainActor in
+                    guard let self, self.connectionPhase != .failed else { return }
+                    self.connectionStageDetail = "Step: \(stage)…"
+                }
+            } else {
+                diagnosticBox.withLock { $0 = summary }
+            }
         }
         switch strategy {
         case .savedProfile:
@@ -2937,21 +2939,68 @@ final class NativeAppModel {
                 "The camera isn't plugged in. Connect it to this device with a USB-C cable, then try again."
             )
         }
+        // The long pole over USB is ImageCaptureCore's card scan (pre-warmed at plug-in); show its
+        // live progress instead of a dead spinner while the session-open ack waits it out.
+        connectionStageDetail = "Reading the camera's card…"
+        let scanTicker = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                let percent = device.contentCatalogPercentCompleted
+                if percent > 0 {
+                    self?.connectionStageDetail = "Reading the camera's card… \(percent)%"
+                }
+                try? await Task.sleep(for: .milliseconds(700))
+            }
+        }
         let usbTransport = USBCameraTransport(device: device)
         do {
             try await usbTransport.open()
         } catch {
+            scanTicker.cancel()
             usbTransport.close()
             throw error
         }
-        return try await NativeCameraSession.establish(
-            transport: usbTransport,
-            host: host,
-            cameraName: device.name,
-            requestPairing: requestPairing,
-            onPairingChallenge: onPairingChallenge,
-            onEstablishmentDiagnostic: onEstablishmentDiagnostic
-        )
+        scanTicker.cancel()
+        do {
+            return try await NativeCameraSession.establish(
+                transport: usbTransport,
+                host: host,
+                cameraName: device.name,
+                requestPairing: requestPairing,
+                onPairingChallenge: onPairingChallenge,
+                onEstablishmentDiagnostic: onEstablishmentDiagnostic
+            )
+        } catch {
+            // An adopted warm session can be a stale corpse (camera slept, ICC housekeeping) that
+            // fails its first command with a raw ICC error. Recycle the session once — real close,
+            // fresh open, full retry — before surfacing a failure. (establish() already closed the
+            // failed transport, which parks the device; the recycle open un-parks it cleanly.)
+            connectionStageDetail = "USB session was stale — restarting it…"
+            connectionLogger.info(
+                "USB establish failed once, recycling session: \(error.localizedDescription, privacy: .private(mask: .hash))"
+            )
+            let retryTransport = USBCameraTransport(device: device)
+            do {
+                try await retryTransport.open(recycleFirst: true)
+            } catch let openError {
+                retryTransport.close()
+                throw openError
+            }
+            return try await NativeCameraSession.establish(
+                transport: retryTransport,
+                host: host,
+                cameraName: device.name,
+                requestPairing: requestPairing,
+                onPairingChallenge: onPairingChallenge,
+                onEstablishmentDiagnostic: onEstablishmentDiagnostic
+            )
+        }
+    }
+
+    /// Card-scan state for a discovered USB camera (nil for Wi-Fi rows): drives the row's
+    /// "Preparing card… N%" → "Ready" pill so the operator knows when a tap connects instantly.
+    func usbCardScan(for camera: DiscoveredCamera) -> (ready: Bool, percent: Int)? {
+        guard camera.isUSB else { return nil }
+        return USBCameraDeviceBrowser.shared.cardScanProgress(forHostKey: camera.ip)
     }
 
     private func isRejectedInitiator(_ error: Error) -> Bool {

--- a/ios/Runner/NativeCameraSession.swift
+++ b/ios/Runner/NativeCameraSession.swift
@@ -381,7 +381,8 @@ final class NativeCameraSession: @unchecked Sendable {
         do {
             return try await session.openAndIdentify(
                 requestPairing: requestPairing,
-                onPairingChallenge: onPairingChallenge
+                onPairingChallenge: onPairingChallenge,
+                onStage: { onEstablishmentDiagnostic?("stage:\($0)") }
             )
         } catch {
             if !session.establishmentSummary.isEmpty {
@@ -416,7 +417,14 @@ final class NativeCameraSession: @unchecked Sendable {
     /// [verify-on-HW: confirm CloseSession-then-close makes the ZR release the slot and accept the
     /// next Init without the timeout→retry dance the logs show today.]
     func shutdown() async {
-        _ = try? await transact(operationCode: .closeSession, deadline: .seconds(2))
+        // Over USB, ImageCaptureCore owns the PTP session (it opened it — that's why OpenSession
+        // tolerates Session_Already_Open). Closing it behind ICC's back leaves the parked warm
+        // session pointing at a dead PTP session, and the next adopt fails its first command
+        // (ICC -21400). Wi-Fi keeps the graceful CloseSession — a wedged ZR slot otherwise
+        // rejects the next Init. [verify-on-HW: USB disconnect → reconnect]
+        if transport.kind != .usb {
+            _ = try? await transact(operationCode: .closeSession, deadline: .seconds(2))
+        }
         transport.close()
     }
 
@@ -902,12 +910,19 @@ final class NativeCameraSession: @unchecked Sendable {
 
     private func openAndIdentify(
         requestPairing: Bool,
-        onPairingChallenge: NativePairingChallengeHandler?
+        onPairingChallenge: NativePairingChallengeHandler?,
+        onStage: (@Sendable (String) -> Void)? = nil
     ) async throws -> NativeCameraSession {
+        // Over USB the first transaction can sit behind ImageCaptureCore's own card enumeration,
+        // which scales with card fullness (thousands of stills = minutes, not seconds) — the 15 s
+        // wedge backstop would mistake that wait for a dead camera. Wi-Fi keeps the short deadline.
+        // [verify-on-HW: ZR over USB-C with a full card]
+        onStage?("first command (OpenSession)")
         let open = try await transact(
             operationCode: .openSession,
             transactionID: 0,
-            parameters: [1]
+            parameters: [1],
+            deadline: transport.kind == .usb ? .seconds(180) : Self.commandTransactionTimeout
         )
         // `Session_Already_Open` is success: over USB, ImageCaptureCore opens the PTP session
         // itself before handing the device to the app. [VERIFY-ON-HW] on the ZR over USB-C.
@@ -921,16 +936,19 @@ final class NativeCameraSession: @unchecked Sendable {
         // the trust boundary. [verify-on-HW: ZR over USB-C]
         let isUSB = transport.kind == .usb
         if requestPairing, !isUSB {
+            onStage?("pairing")
             try await completePairing(onPairingChallenge: onPairingChallenge)
         } else {
             establishmentSummary += isUSB ? "pairing=usb " : "pairing=skipped "
         }
+        onStage?("app-control switch")
         var appModeResponse = try await enableCameraControl()
         if isUSB, appModeResponse != .ok {
             // Over USB the ZR boots into PC-camera mode and denies the vendor app-control switch
             // that Wi-Fi sessions get for free. Remote mode is accepted and unlocks control, though
             // the camera body stays on its "Connected to computer" screen.
             // [verify-on-HW: ZR over USB-C, 2026-07-17 — connects, streams, full metadata]
+            onStage?("remote-mode fallback")
             let remote = try await transact(operationCode: .changeCameraMode, parameters: [1])
             let remoteResponse = remote.operationResponse.responseCode
             establishmentSummary += "remoteMode=0x\(String(remoteResponse.rawValue, radix: 16)) "
@@ -946,6 +964,7 @@ final class NativeCameraSession: @unchecked Sendable {
             }
         }
 
+        onStage?("device info")
         let infoResult = try await transact(operationCode: .getDeviceInfo, dataPhase: .dataIn)
         guard infoResult.operationResponse.responseCode == .ok else {
             throw NativeCameraSessionError.operationRejected(

--- a/ios/Runner/NativeCameraSession.swift
+++ b/ios/Runner/NativeCameraSession.swift
@@ -916,12 +916,26 @@ final class NativeCameraSession: @unchecked Sendable {
             throw NativeCameraSessionError.operationRejected(.openSession, openResponse)
         }
 
-        if requestPairing {
+        // USB has no pairing surface: GetPairingInfo/ConfirmPairing are absent from the camera's
+        // USB OperationsSupported, so polling them only times the connect out — the cable itself is
+        // the trust boundary. [verify-on-HW: ZR over USB-C]
+        let isUSB = transport.kind == .usb
+        if requestPairing, !isUSB {
             try await completePairing(onPairingChallenge: onPairingChallenge)
         } else {
-            establishmentSummary += "pairing=skipped "
+            establishmentSummary += isUSB ? "pairing=usb " : "pairing=skipped "
         }
-        let appModeResponse = try await enableCameraControl()
+        var appModeResponse = try await enableCameraControl()
+        if isUSB, appModeResponse != .ok {
+            // Over USB the ZR boots into PC-camera mode and denies the vendor app-control switch
+            // that Wi-Fi sessions get for free. Remote mode is accepted and unlocks control, though
+            // the camera body stays on its "Connected to computer" screen.
+            // [verify-on-HW: ZR over USB-C, 2026-07-17 — connects, streams, full metadata]
+            let remote = try await transact(operationCode: .changeCameraMode, parameters: [1])
+            let remoteResponse = remote.operationResponse.responseCode
+            establishmentSummary += "remoteMode=0x\(String(remoteResponse.rawValue, radix: 16)) "
+            if remoteResponse == .ok { appModeResponse = .ok }
+        }
         if !requestPairing {
             guard
                 PTPIPSavedProfileProbePolicy.resolve(

--- a/ios/Runner/StartupDesign.swift
+++ b/ios/Runner/StartupDesign.swift
@@ -582,23 +582,27 @@ struct StartupCameraListRow: View {
     var isRecoveryTarget: Bool = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .center, spacing: 8) {
-                Text(title)
-                    .font(.system(size: 16, weight: .semibold, design: .rounded))
-                    .foregroundStyle(StartupColors.ink)
+        // Ticks once a second so the card-scan state (pill %, dimmed Preparing… button, subtitle)
+        // stays live between discovery passes — the scan progresses outside observable state.
+        TimelineView(.periodic(from: .now, by: 1)) { _ in
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .center, spacing: 8) {
+                    Text(title)
+                        .font(.system(size: 16, weight: .semibold, design: .rounded))
+                        .foregroundStyle(StartupColors.ink)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.85)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    statusPill
+                    connectButton
+                    optionsMenu
+                }
+                Text(subtitle)
+                    .font(.system(size: 13, weight: .regular, design: .rounded))
+                    .foregroundStyle(StartupColors.muted)
                     .lineLimit(1)
-                    .minimumScaleFactor(0.85)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                statusPill
-                connectButton
-                optionsMenu
+                    .minimumScaleFactor(0.75)
             }
-            Text(subtitle)
-                .font(.system(size: 13, weight: .regular, design: .rounded))
-                .foregroundStyle(StartupColors.muted)
-                .lineLimit(1)
-                .minimumScaleFactor(0.75)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
@@ -658,8 +662,18 @@ struct StartupCameraListRow: View {
         }
     }
 
+    /// True while the plugged-in camera's card scan is still running — the window where a tap
+    /// would sit in "Reading the camera's card…" instead of connecting instantly.
+    private var isPreparingCard: Bool {
+        if let usbScan { return !usbScan.ready }
+        return false
+    }
+
     @ViewBuilder private var connectButton: some View {
-        if isPrimary {
+        // While the card scan runs, the button dims and says so — but stays tappable: a scan that
+        // silently failed would otherwise strand the row disabled forever, and an early tap still
+        // works (the progress sheet narrates the remaining scan).
+        if isPrimary, !isPreparingCard {
             Button {
                 connect()
             } label: {
@@ -671,26 +685,23 @@ struct StartupCameraListRow: View {
             Button {
                 connect()
             } label: {
-                Text(buttonLabel).fixedSize()
+                Text(isPreparingCard ? "Preparing…" : buttonLabel).fixedSize()
             }
             .buttonStyle(StartupOutlineButtonStyle())
+            .opacity(isPreparingCard ? 0.55 : 1)
             .disabled(isBusy)
         }
     }
 
     private var statusPill: some View {
-        // Ticks once a second while a USB card scan is running so the pill's percent/readiness
-        // stays live between discovery passes.
-        TimelineView(.periodic(from: .now, by: 1)) { _ in
-            Text(statusText)
-                .font(.system(size: 11, weight: .semibold, design: .rounded))
-                .foregroundStyle(statusColor)
-                .lineLimit(1)
-                .fixedSize()
-                .padding(.horizontal, 10)
-                .padding(.vertical, 5)
-                .overlay(Capsule().stroke(statusColor.opacity(0.5), lineWidth: 1))
-        }
+        Text(statusText)
+            .font(.system(size: 11, weight: .semibold, design: .rounded))
+            .foregroundStyle(statusColor)
+            .lineLimit(1)
+            .fixedSize()
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .overlay(Capsule().stroke(statusColor.opacity(0.5), lineWidth: 1))
     }
 
     /// USB card-scan state for this row's discovered camera; nil for Wi-Fi rows or once absent.
@@ -763,6 +774,9 @@ struct StartupCameraListRow: View {
     }
 
     private var subtitle: String {
+        if isPreparingCard {
+            return "USB-C · getting the card ready — connect will be instant once it's done"
+        }
         var parts: [String] = []
         if camera.isUSBTransport {
             parts.append("USB-C")

--- a/ios/Runner/StartupDesign.swift
+++ b/ios/Runner/StartupDesign.swift
@@ -7,6 +7,11 @@ enum StartupConnectionCopy {
         guard !trimmed.isEmpty else { return trimmed }
 
         let lower = trimmed.lowercased()
+        if lower.contains("imagecapturecore") {
+            // Raw ICC error (e.g. -21400 on a stale USB session): the app retries with a session
+            // recycle automatically, so reaching the operator means even that failed.
+            return "The USB link got stuck. Unplug the cable, plug it back in, and try again."
+        }
         if lower.contains("ptp-ip") || lower.contains("ptp ip") {
             if lower.contains("no") && (lower.contains("service") || lower.contains("answered")) {
                 return "Couldn't reach the camera. Check Wi‑Fi and try again."
@@ -674,14 +679,24 @@ struct StartupCameraListRow: View {
     }
 
     private var statusPill: some View {
-        Text(statusText)
-            .font(.system(size: 11, weight: .semibold, design: .rounded))
-            .foregroundStyle(statusColor)
-            .lineLimit(1)
-            .fixedSize()
-            .padding(.horizontal, 10)
-            .padding(.vertical, 5)
-            .overlay(Capsule().stroke(statusColor.opacity(0.5), lineWidth: 1))
+        // Ticks once a second while a USB card scan is running so the pill's percent/readiness
+        // stays live between discovery passes.
+        TimelineView(.periodic(from: .now, by: 1)) { _ in
+            Text(statusText)
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .foregroundStyle(statusColor)
+                .lineLimit(1)
+                .fixedSize()
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .overlay(Capsule().stroke(statusColor.opacity(0.5), lineWidth: 1))
+        }
+    }
+
+    /// USB card-scan state for this row's discovered camera; nil for Wi-Fi rows or once absent.
+    private var usbScan: (ready: Bool, percent: Int)? {
+        guard case .available(let discovered) = availability else { return nil }
+        return model.usbCardScan(for: discovered)
     }
 
     /// Discoverable rename / remove, mirroring the long-press context menu.
@@ -712,7 +727,11 @@ struct StartupCameraListRow: View {
         if isRecoveryTarget { return "Waiting for hotspot" }
         switch availability {
         case .connected: return "Connected"
-        case .available: return "Online"
+        case .available:
+            if let usbScan {
+                return usbScan.ready ? "Ready" : "Preparing card… \(usbScan.percent)%"
+            }
+            return "Online"
         case .offline: return "Offline"
         }
     }
@@ -720,7 +739,9 @@ struct StartupCameraListRow: View {
     private var statusColor: Color {
         if isRecoveryTarget { return StartupColors.accent }
         switch availability {
-        case .connected, .available: return StartupColors.ready
+        case .connected, .available:
+            if let usbScan, !usbScan.ready { return StartupColors.accent }
+            return StartupColors.ready
         case .offline: return StartupColors.dim
         }
     }

--- a/ios/Runner/USBCameraTransport.swift
+++ b/ios/Runner/USBCameraTransport.swift
@@ -12,12 +12,57 @@ private let usbLogger = Logger(
 /// so plugging a camera in surfaces it on the next pass (effectively instantly).
 // SAFETY: `@unchecked Sendable` — `devices` and `authorizationStatus` are guarded by `lock`
 // (`NSLock`); ICDeviceBrowser delegate callbacks and readers never touch them off it.
+/// Delegate for the attach-time pre-warm window, before a transport adopts the device: absorbs the
+/// required callbacks and vetoes ICC's proactive per-item thumbnail/metadata fetches (the default
+/// with no veto is to request both for EVERY item during cataloging — the bulk of a full card's
+/// connect delay). The transport repeats the vetoes once it takes the delegate over.
+private final class USBPrewarmDelegate: NSObject, ICCameraDeviceDelegate, @unchecked Sendable {
+    func device(_ device: ICDevice, didOpenSessionWithError error: (any Error)?) {
+        USBCameraDeviceBrowser.shared.prewarmOpenCompleted(for: device, error: error)
+    }
+    func device(_ device: ICDevice, didCloseSessionWithError error: (any Error)?) {}
+    func didRemove(_ device: ICDevice) {}
+    func deviceDidBecomeReady(withCompleteContentCatalog device: ICCameraDevice) {}
+    func cameraDevice(_ camera: ICCameraDevice, didReceivePTPEvent eventData: Data) {}
+    func cameraDevice(_ camera: ICCameraDevice, didAdd items: [ICCameraItem]) {}
+    func cameraDevice(_ camera: ICCameraDevice, didRemove items: [ICCameraItem]) {}
+    func cameraDevice(
+        _ camera: ICCameraDevice,
+        didReceiveThumbnail thumbnail: CGImage?,
+        for item: ICCameraItem,
+        error: (any Error)?
+    ) {}
+    func cameraDevice(
+        _ camera: ICCameraDevice,
+        didReceiveMetadata metadata: [AnyHashable: Any]?,
+        for item: ICCameraItem,
+        error: (any Error)?
+    ) {}
+    func cameraDevice(_ camera: ICCameraDevice, didRenameItems items: [ICCameraItem]) {}
+    func cameraDevice(_ camera: ICCameraDevice, didCompleteDeleteFilesWithError error: (any Error)?)
+    {}
+    func cameraDeviceDidChangeCapability(_ camera: ICCameraDevice) {}
+    func cameraDeviceDidRemoveAccessRestriction(_ device: ICDevice) {}
+    func cameraDeviceDidEnableAccessRestriction(_ device: ICDevice) {}
+    func cameraDevice(_ camera: ICCameraDevice, shouldGetThumbnailOf item: ICCameraItem) -> Bool {
+        false
+    }
+    func cameraDevice(_ camera: ICCameraDevice, shouldGetMetadataOf item: ICCameraItem) -> Bool {
+        false
+    }
+}
+
 final class USBCameraDeviceBrowser: NSObject, ICDeviceBrowserDelegate, @unchecked Sendable {
     static let shared = USBCameraDeviceBrowser()
 
     private let browser = ICDeviceBrowser()
+    private let prewarmDelegate = USBPrewarmDelegate()
     private let lock = NSLock()
     private var devices: [ICCameraDevice] = []
+    /// Host keys whose attach-time `requestOpenSession` has not completed yet. The transport must
+    /// not issue a second open while one is in flight — ICC swallows the duplicate and the reply
+    /// for the first goes to the pre-warm delegate, so a connect started in that window would hang.
+    private var prewarmOpensInFlight: Set<String> = []
     private var isStarted = false
     private var authorizationStatus: ICAuthorizationStatus = .notDetermined
 
@@ -102,6 +147,16 @@ final class USBCameraDeviceBrowser: NSObject, ICDeviceBrowserDelegate, @unchecke
             devices.append(camera)
         }
         lock.unlock()
+        // Pre-warm: open the ICC session at attach time. ICC refuses passthrough commands until its
+        // whole-card content enumeration finishes (minutes on a full card, verified on the ZR), so
+        // start that clock at plug-in rather than when the operator taps Connect. The pre-warm
+        // delegate vetoes per-item thumbnail/metadata fetches from the first item; the transport
+        // takes the delegate (and the open session) over at connect time.
+        if !camera.hasOpenSession {
+            lock.withLock { _ = prewarmOpensInFlight.insert(Self.hostKey(for: camera)) }
+            camera.delegate = prewarmDelegate
+            camera.requestOpenSession()
+        }
         usbLogger.info(
             "USB camera attached: \(device.name ?? "unnamed", privacy: .private(mask: .hash))")
     }
@@ -109,9 +164,41 @@ final class USBCameraDeviceBrowser: NSObject, ICDeviceBrowserDelegate, @unchecke
     func deviceBrowser(_ browser: ICDeviceBrowser, didRemove device: ICDevice, moreGoing: Bool) {
         lock.lock()
         devices.removeAll { $0 === device }
+        prewarmOpensInFlight.remove(Self.hostKey(for: device))
         lock.unlock()
         usbLogger.info(
             "USB camera detached: \(device.name ?? "unnamed", privacy: .private(mask: .hash))")
+    }
+
+    /// Pre-warm open finished (delegate callback relay). Clears the in-flight marker so a connect
+    /// can proceed; the error, if any, is only logged — the connect path does its own fresh open.
+    fileprivate func prewarmOpenCompleted(for device: ICDevice, error: (any Error)?) {
+        lock.withLock { _ = prewarmOpensInFlight.remove(Self.hostKey(for: device)) }
+        if let error {
+            usbLogger.info(
+                "USB pre-warm open failed: \(error.localizedDescription, privacy: .private(mask: .hash))"
+            )
+        }
+    }
+
+    /// Whether the attach-time session open for this device is still in flight.
+    func isPrewarmOpenInFlight(for device: ICDevice) -> Bool {
+        lock.withLock { prewarmOpensInFlight.contains(Self.hostKey(for: device)) }
+    }
+
+    /// Reclaims delegate duties for a device whose transport is done with it, leaving the ICC
+    /// session open — the warm catalog makes the next connect adopt instantly instead of paying
+    /// the enumeration sweep again. The session ends with the cable, not the app-level connect.
+    fileprivate func parkSession(for device: ICDevice) {
+        device.delegate = prewarmDelegate
+    }
+
+    /// Card-scan readiness for a USB camera row. `ready` (the session-open ack) is the moment a
+    /// connect stops having to wait — measured on the ZR, the whole per-plug cost sits in front of
+    /// it; `percent` is ICC's own catalog progress for the countdown.
+    func cardScanProgress(forHostKey hostKey: String) -> (ready: Bool, percent: Int)? {
+        guard let device = device(forHostKey: hostKey) else { return nil }
+        return (device.hasOpenSession, device.contentCatalogPercentCompleted)
     }
 }
 
@@ -147,6 +234,10 @@ final class USBCameraTransport: NSObject, CameraTransport, ICCameraDeviceDelegat
     private var openContinuation: CheckedContinuation<Void, Error>?
     private var didOpenSession = false
     private var didBecomeReady = false
+    // Recycle state (see open(recycleFirst:)): a deliberate session close that must not be
+    // mistaken for a teardown by the didCloseSession delegate callback.
+    private var recycleCloseContinuation: CheckedContinuation<Void, Never>?
+    private var recycleCloseInFlight = false
     // Events are pushed by delegate callbacks and pulled by the session's drain loop (a single
     // consumer), buffered so a sparse reader never loses a record start/stop notification.
     private var eventStreamIterator: AsyncStream<PTPEvent>.AsyncIterator
@@ -156,8 +247,32 @@ final class USBCameraTransport: NSObject, CameraTransport, ICCameraDeviceDelegat
     /// deliberately NOT waiting for the content-catalog "ready" signal, which for the ZR is the slow
     /// part of USB connect. ImageCaptureCore still enumerates the catalog in the background; the app
     /// ignores it.
-    func open(timeout: Duration = .seconds(30)) async throws {
+    func open(timeout: Duration = .seconds(30), recycleFirst: Bool = false) async throws {
         device.delegate = self
+        // If the attach-time pre-warm's open is still in flight, wait it out instead of issuing a
+        // duplicate requestOpenSession — ICC swallows the duplicate, so a connect started in that
+        // window used to hang for the full timeout.
+        let waitStart = ContinuousClock.now
+        while !device.hasOpenSession,
+            USBCameraDeviceBrowser.shared.isPrewarmOpenInFlight(for: device),
+            ContinuousClock.now - waitStart < timeout
+        {
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        if recycleFirst, device.hasOpenSession {
+            // Retry path: the adopted session just failed its first command — it went stale while
+            // parked (camera sleep, ICC housekeeping). Close it for real, await the ack (bounded),
+            // and fall through to a fresh open. Costs a new card scan; correctness over speed here.
+            await recycleStaleSession()
+        }
+        // Adopt an already-open session (attach-time pre-warm, or a previous connect that parked
+        // it warm). The passthrough gate, if ICC's catalog pass is still running, is waited out by
+        // the first transaction's long USB deadline — a close→reopen "abort" was tried here and
+        // did NOT skip the gate on the ZR; it only risks restarting a mostly-done pass.
+        if device.hasOpenSession {
+            lock.withLock { didOpenSession = true }
+            return
+        }
         let timeoutTask = Task { [weak self] in
             try? await Task.sleep(for: timeout)
             guard !Task.isCancelled else { return }
@@ -249,8 +364,37 @@ final class USBCameraTransport: NSObject, CameraTransport, ICCameraDeviceDelegat
         guard !alreadyClosed else { return }
         eventContinuation.finish()
         resumeOpen(throwing: NativeCameraSessionError.connectionClosed)
-        device.requestCloseSession()
-        device.delegate = nil
+        // Keep the ICC session warm instead of closing it: requestCloseSession discards the
+        // finished card catalog, so the next connect would pay the whole enumeration sweep again.
+        // Park the delegate back on the browser; the session dies with the cable (didRemove), not
+        // with an app-level disconnect. [verify-on-HW: ZR reconnect-after-disconnect over USB-C]
+        USBCameraDeviceBrowser.shared.parkSession(for: device)
+    }
+
+    /// Closes a stale adopted session and waits (bounded) for ICC's ack so a fresh open can
+    /// follow — the recovery half of the stale-session retry.
+    private func recycleStaleSession() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            lock.withLock {
+                recycleCloseContinuation = continuation
+                recycleCloseInFlight = true
+            }
+            Task { [weak self] in
+                try? await Task.sleep(for: .seconds(5))
+                self?.resumeRecycleClose()
+            }
+            device.requestCloseSession()
+        }
+    }
+
+    private func resumeRecycleClose() {
+        let continuation = lock.withLock {
+            () -> CheckedContinuation<Void, Never>? in
+            let stored = recycleCloseContinuation
+            recycleCloseContinuation = nil
+            return stored
+        }
+        continuation?.resume()
     }
 
     /// Identifies which completion blob is the response container and decodes the pair.
@@ -307,6 +451,9 @@ final class USBCameraTransport: NSObject, CameraTransport, ICCameraDeviceDelegat
     // MARK: - ICDeviceDelegate
 
     func device(_ device: ICDevice, didOpenSessionWithError error: (any Error)?) {
+        // A pre-warm open completing after this transport took the delegate over lands here, not
+        // on the pre-warm delegate — clear the browser's in-flight marker either way.
+        USBCameraDeviceBrowser.shared.prewarmOpenCompleted(for: device, error: nil)
         if let error {
             usbLogger.error(
                 "USB session open failed: \(error.localizedDescription, privacy: .private(mask: .hash))"
@@ -330,6 +477,18 @@ final class USBCameraTransport: NSObject, CameraTransport, ICCameraDeviceDelegat
     }
 
     func device(_ device: ICDevice, didCloseSessionWithError error: (any Error)?) {
+        // A close we asked for (stale-session recycle) resumes the waiting open; only an
+        // unsolicited close is a teardown.
+        let wasRecycle = lock.withLock {
+            () -> Bool in
+            let was = recycleCloseInFlight
+            recycleCloseInFlight = false
+            return was
+        }
+        if wasRecycle {
+            resumeRecycleClose()
+            return
+        }
         close()
     }
 
@@ -360,6 +519,19 @@ final class USBCameraTransport: NSObject, CameraTransport, ICCameraDeviceDelegat
     func cameraDevice(_ camera: ICCameraDevice, didAdd items: [ICCameraItem]) {}
 
     func cameraDevice(_ camera: ICCameraDevice, didRemove items: [ICCameraItem]) {}
+
+    // Veto ICC's proactive per-item fetches: without these, cataloging issues a thumbnail AND a
+    // metadata request to the camera for EVERY item on the card — thousands of round-trips this
+    // app never reads (its media listing is its own PTP GetObjectHandles). The catalog sweep
+    // itself can't be suppressed, but starving it of per-item traffic is the difference between
+    // minutes and seconds on a full card. [verify-on-HW: ZR, full CFexpress]
+    func cameraDevice(_ camera: ICCameraDevice, shouldGetThumbnailOf item: ICCameraItem) -> Bool {
+        false
+    }
+
+    func cameraDevice(_ camera: ICCameraDevice, shouldGetMetadataOf item: ICCameraItem) -> Bool {
+        false
+    }
 
     func cameraDevice(
         _ camera: ICCameraDevice,

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -8,9 +8,7 @@ What's changed
 
 Please test
 
-- Plug the camera into the iPhone with USB-C, wait for the camera row to show Ready, then tap Connect and confirm it connects almost instantly.
+- Plug the camera into the iPhone with USB-C, confirm it appears in the list without connecting on its own, wait for the row to show Ready, then tap Connect and confirm it connects almost instantly.
 - Tap Connect right after plugging in and confirm the progress card counts up while reading the camera's card instead of sitting on a plain spinner.
-- Disconnect from inside the app and reconnect over USB-C; confirm it connects immediately without re-reading the card.
-- Unplug the cable and plug it back in; confirm the row walks through Preparing back to Ready and then connects.
-- Confirm plugging in the camera does not start a connection on its own.
+- Disconnect from inside the app and reconnect over USB-C; confirm it connects immediately without re-reading the card. Then unplug and replug the cable and confirm the row walks through Preparing back to Ready.
 - Connect over Wi-Fi once and confirm that flow is unchanged.

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,14 +1,16 @@
 What's changed
 
-- Report a Problem in Operator Setup > System now lets you choose an anonymous public report or the signed-in GitHub bug form.
-- The anonymous form can optionally include a privacy-filtered app activity log or selected screenshots; attachments are public.
-- Feature requests still open the community discussion where you sign in.
-- On the camera's Wi-Fi access point, Support, Report a Problem, and Request a Feature now ask before switching networks, show progress while internet reconnects, then open the selected destination directly without reopening Settings.
-- Sharing Diagnostics remains a separate review-before-sharing option.
+- Connecting to the camera over USB-C is now fast and reliable, even with a full memory card.
+- After plugging in, the camera row shows the card being prepared with a live percentage, and the Connect button switches from Preparing to ready the moment connecting will be instant.
+- Disconnecting inside the app and reconnecting over USB-C no longer re-reads the card, so reconnects are immediate.
+- Plugging in a USB-C camera only adds it to the camera list; connecting is always your tap.
+- While connecting, the progress card explains what is happening in plain language, and connection errors show a readable message with technical details underneath.
 
 Please test
 
-- In Operator Setup > System, open Report a Problem and confirm both choices say that reports become public GitHub issues.
-- Choose Report Anonymously, enter a non-sensitive real bug, and confirm it completes without a GitHub sign-in screen before you return to System.
-- In the anonymous form, toggle each optional attachment control. Confirm the warning explains that screenshot pixels can still contain sensitive information even after file metadata is removed.
-- Reopen Report a Problem and choose Continue with GitHub, then open Request a Feature. On the camera's Wi-Fi access point, confirm Support, Report a Problem, and Request a Feature each show the network-switch warning, Cancel stays connected, and Continue shows a destination-specific progress prompt before opening the selected destination without reopening Settings or prompting to rejoin immediately. Confirm the camera reconnect prompt appears only after returning from a web page, submitting a report, or closing the report flow.
+- Plug the camera into the iPhone with USB-C, wait for the camera row to show Ready, then tap Connect and confirm it connects almost instantly.
+- Tap Connect right after plugging in and confirm the progress card counts up while reading the camera's card instead of sitting on a plain spinner.
+- Disconnect from inside the app and reconnect over USB-C; confirm it connects immediately without re-reading the card.
+- Unplug the cable and plug it back in; confirm the row walks through Preparing back to Ready and then connects.
+- Confirm plugging in the camera does not start a connection on its own.
+- Connect over Wi-Fi once and confirm that flow is unchanged.


### PR DESCRIPTION
USB-C connects to the ZR failed or crawled, and got worse as cards filled. Three root causes, all found on hardware with a ZR and a full CFexpress card:

1. **Establishment**: over USB the ZR exposes no pairing operations (first-time connects timed out polling `GetPairingInfo`) and boots into PC-camera mode, denying the app-control switch (saved reconnects failed into the dead pairing path). Fix: skip pairing over USB — the cable is the trust boundary — and fall back to remote mode (`0x90C2`) when app mode is refused. Protocol matches the Android facade's USB establishment (`feat/android-port-refinement`; the `PTPOperation` hunk is byte-identical so the branches merge cleanly).
2. **The catalog tax**: ImageCaptureCore won't service passthrough until it privately catalogs the entire card, and by default fetches a **thumbnail + metadata for every object** — minutes on a full card, which the 15 s command deadline mistook for a dead camera. Fix: veto the per-item fetches (the sweep drops to seconds), pre-open the session at plug-in, give the first USB command a card-scale deadline, and show the scan live ("Preparing card… N%" → "Ready" on the camera row, with the Connect button dimmed to "Preparing…" until then; live plain-language steps on the progress sheet).
3. **Self-poisoning on disconnect**: we sent PTP CloseSession over USB — closing the session **ICC owns** — then kept that poisoned session warm, so the next connect adopted a corpse (raw ICC −21400). Fix: never CloseSession over USB (Wi-Fi keeps it — the wedge fix), keep the session warm across app-level disconnects (catalog paid once per cable), and recycle + retry once when an establish still fails.

Also: plugging in now only lists the camera — connecting is always the operator's tap (the silent auto-reconnect-on-plug is removed by request), and failure alerts show a human message with the technical establishment trace beneath it instead of doubled raw ICC errors.

Verified on device (iPhone 16 Pro Max + ZR, thousands of stills across two cards): connect went from failing / minutes to seconds on first plug and near-instant on in-app reconnects — operator's words, "crazy fast". `just ios-build` + `just swift-lint` green; remaining `[verify-on-HW]` markers cover the Wi-Fi-side CloseSession behavior, unchanged here.

Part of #56 (OPE-14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)