### PR TITLE
fix(ios): generalize Nikon Wi-Fi onboarding

### DIFF
--- a/Sources/OpenZCineCore/CameraWiFiSSID.swift
+++ b/Sources/OpenZCineCore/CameraWiFiSSID.swift
@@ -1,9 +1,12 @@
 import Foundation
 
-/// Nikon ZR camera access-point SSID derivation and join policy.
+/// Nikon Z camera access-point identification, ZR derivation, and join policy.
 public enum CameraWiFiSSID {
-    /// Prefix of the camera's Wi‑Fi hotspot SSID (e.g. `NIKON_ZR_01234`).
+    /// ZR-specific prefix retained for deriving an SSID from the ZR's PTP friendly name.
     public static let nikonAccessPointPrefix = "NIKON_ZR_"
+
+    /// Brand prefix shared by Nikon Z access-point names across camera models.
+    public static let nikonAccessPointBrandPrefix = "NIKON"
 
     /// Prefix of the PTP-IP friendly camera name (e.g. `ZR_6001234`).
     public static let ptpFriendlyNamePrefix = "ZR_"
@@ -28,10 +31,64 @@ public enum CameraWiFiSSID {
         return deriveSSID(fromCameraName: record.displayName)
     }
 
+    /// Whether an SSID has the conservative shape of a Nikon Z camera access point.
+    ///
+    /// Nikon bodies do not share the ZR's exact underscore/model/serial layout. The stable contract
+    /// is a Nikon brand prefix, a Z-series marker, at least one serial/model digit, and only the
+    /// ASCII characters camera-generated network names use. This intentionally does not reconstruct
+    /// an unfamiliar model name; exact scanned or stored SSIDs remain authoritative.
+    public static func isNikonZAccessPoint(_ rawSSID: String) -> Bool {
+        let ssid = rawSSID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard (8...32).contains(ssid.utf8.count) else { return false }
+        let uppercase = ssid.uppercased()
+        guard uppercase.hasPrefix(nikonAccessPointBrandPrefix) else { return false }
+
+        let suffix = uppercase.dropFirst(nikonAccessPointBrandPrefix.count)
+        guard suffix.contains("Z"), suffix.contains(where: \.isNumber) else { return false }
+        return suffix.unicodeScalars.allSatisfy { scalar in
+            scalar.value <= 0x7F
+                && (CharacterSet.alphanumerics.contains(scalar) || scalar == "_" || scalar == "-")
+        }
+    }
+
+    /// Normalizes an OCR token only enough to repair the Nikon brand, then validates its full shape.
+    ///
+    /// Model and serial characters are preserved rather than guessed, so a future body cannot be
+    /// silently joined under a synthesized SSID. Nikon camera SSIDs are emitted in uppercase.
+    static func normalizedScannedNikonZAccessPoint(_ rawSSID: String) -> String? {
+        let trimmed = rawSSID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count >= nikonAccessPointBrandPrefix.count else { return nil }
+
+        let uppercase = trimmed.uppercased()
+        let brandEnd = uppercase.index(
+            uppercase.startIndex,
+            offsetBy: nikonAccessPointBrandPrefix.count
+        )
+        let brand = String(uppercase[..<brandEnd])
+        guard correctedNikonBrand(brand) == nikonAccessPointBrandPrefix else { return nil }
+
+        let candidate = nikonAccessPointBrandPrefix + String(uppercase[brandEnd...])
+        guard isNikonZAccessPoint(candidate) else { return nil }
+        return candidate
+    }
+
     private static func serialSuffixForSSID(_ serial: String) -> String? {
         let digits = serial.filter(\.isNumber)
         guard digits.count >= 5 else { return nil }
         return String(digits.suffix(5))
+    }
+
+    private static func correctedNikonBrand(_ brand: String) -> String {
+        String(
+            brand.map { character -> Character in
+                switch character {
+                case "0": return "O"
+                case "1", "L": return "I"
+                case "5": return "S"
+                case "8": return "B"
+                default: return character
+                }
+            })
     }
 }
 
@@ -53,7 +110,7 @@ public enum CameraWiFiJoinPolicy {
         }
     }
 
-    /// Whether the phone is joined to a Nikon ZR camera Wi‑Fi hotspot.
+    /// Whether the phone is joined to a Nikon Z camera Wi‑Fi hotspot.
     ///
     /// Uses the connected SSID when available. Subnet-only matching is intentionally **not** used:
     /// `192.168.1.0/24` is a common home-router range and would false-positive when the camera AP
@@ -66,7 +123,7 @@ public enum CameraWiFiJoinPolicy {
         guard let ssid = connectedSSID?.trimmingCharacters(in: .whitespacesAndNewlines),
             !ssid.isEmpty
         else { return false }
-        return ssid.uppercased().hasPrefix(CameraWiFiSSID.nikonAccessPointPrefix.uppercased())
+        return CameraWiFiSSID.isNikonZAccessPoint(ssid)
     }
 
     /// Resolves the camera SSID without considering the current network.
@@ -132,8 +189,8 @@ public enum CameraWiFiJoinPolicy {
 
     /// Resolves a proactive join target when the phone is off the camera AP subnet.
     ///
-    /// Prefers a saved camera's SSID when available; otherwise matches any nearby Nikon ZR AP
-    /// via `NIKON_ZR_` prefix (no saved profile required).
+    /// Prefers a saved camera's exact SSID when available; otherwise matches a nearby Nikon Z AP
+    /// by its shared brand prefix (no saved profile required).
     public static func proactiveJoinTarget(
         localAddresses: [String],
         savedCameras: [PTPIPSavedCameraRecord],
@@ -152,7 +209,7 @@ public enum CameraWiFiJoinPolicy {
             }
         }
 
-        return .ssidPrefix(CameraWiFiSSID.nikonAccessPointPrefix)
+        return .ssidPrefix(CameraWiFiSSID.nikonAccessPointBrandPrefix)
     }
 
     /// Resolves which SSID or prefix should be used when looking up stored Wi‑Fi credentials.

--- a/Sources/OpenZCineCore/CameraWiFiScreenParser.swift
+++ b/Sources/OpenZCineCore/CameraWiFiScreenParser.swift
@@ -3,11 +3,10 @@ import Foundation
 /// Extracts Nikon camera access-point credentials from OCR text captured off the camera's
 /// on-screen **Connection wizard** (the screen showing `SSID:` and `Key:`).
 ///
-/// The wizard's format is tightly constrained — SSID is `NIKON_ZR_` + a 5-digit serial, and the
-/// key is 8 lowercase-hex characters — which is what makes screen OCR reliable: any character the
-/// recognizer confuses (`O`/`0`, `l`/`1`, `S`/`5`) can be corrected because only one interpretation
-/// is legal in each field. Returns credentials only when BOTH fields validate; otherwise `nil` and
-/// the caller falls back to manual entry.
+/// SSID layouts vary by Z body, so the parser validates the shared Nikon Z access-point shape and
+/// preserves unfamiliar model/serial segments instead of rebuilding them. The generated key remains
+/// an 8-character lowercase-hex value, which permits safe correction of common OCR confusions. The
+/// manual-entry path accepts the wider WPA passphrase contract when OCR cannot validate both fields.
 public enum CameraWiFiScreenParser {
     public struct Credentials: Equatable, Sendable {
         public let ssid: String
@@ -19,36 +18,79 @@ public enum CameraWiFiScreenParser {
         }
     }
 
+    /// Actionable outcome from one OCR frame.
+    public enum Result: Equatable, Sendable {
+        case credentials(Credentials)
+        case needsKey
+        case unsupportedSSID
+        case noCredentials
+    }
+
     /// Parses recognized text lines (e.g. one per `RecognizedItem.text` transcript).
     public static func parse(lines: [String]) -> Credentials? {
+        guard case .credentials(let credentials) = result(lines: lines) else { return nil }
+        return credentials
+    }
+
+    /// Classifies recognized text so the scanner can distinguish incomplete and unsupported frames.
+    public static func result(lines: [String]) -> Result {
         // Split on whitespace and the label separators the wizard uses ("SSID:", "Key:"), so a
-        // recognizer that merges label and value ("Key:a1b2c3d4") still yields clean tokens.
+        // recognizer that merges any localized label and value still yields clean tokens.
         let separators: Set<Character> = [" ", "\t", "\n", ":", "|", "\u{00A0}"]
         let tokens =
             lines
             .flatMap { $0.split(whereSeparator: { separators.contains($0) }) }
             .map(String.init)
-        guard let ssid = tokens.lazy.compactMap(correctedSSID).first else { return nil }
-        guard let key = tokens.lazy.compactMap(correctedKey).first else { return nil }
-        return Credentials(ssid: ssid, key: key)
+        guard let ssid = tokens.lazy.compactMap(correctedSSID).first else {
+            return tokens.contains(where: isUnsupportedNikonSSIDCandidate)
+                ? .unsupportedSSID : .noCredentials
+        }
+        guard let key = tokens.lazy.compactMap(correctedKey).first else { return .needsKey }
+        return .credentials(Credentials(ssid: ssid, key: key))
     }
 
     public static func parse(_ transcript: String) -> Credentials? {
         parse(lines: transcript.components(separatedBy: .newlines))
     }
 
-    /// A token that reads as `NIKON_<model>_<5 serial>` → the canonical camera AP SSID.
-    /// Anchors on the known prefix so only the 5 serial digits need OCR correction.
+    /// Validates credentials typed from the camera screen when OCR cannot read its format.
+    public static func manualCredentials(ssid rawSSID: String, key rawKey: String) -> Credentials? {
+        guard !rawSSID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            rawSSID.utf8.count <= 32
+        else { return nil }
+        guard (8...63).contains(rawKey.utf8.count) else { return nil }
+        guard rawKey.unicodeScalars.allSatisfy({ (0x20...0x7E).contains($0.value) }) else {
+            return nil
+        }
+        return Credentials(ssid: rawSSID, key: rawKey)
+    }
+
+    /// A token with a conservative Nikon Z access-point shape, preserving its model layout.
     static func correctedSSID(_ raw: String) -> String? {
         let token = raw.trimmingCharacters(in: Self.punctuation)
+        if let correctedZR = correctedLegacyZRSSID(token) { return correctedZR }
+        return CameraWiFiSSID.normalizedScannedNikonZAccessPoint(token)
+    }
+
+    /// Retains the ZR-specific OCR recovery shipped before other Z-body SSID formats were observed.
+    private static func correctedLegacyZRSSID(_ token: String) -> String? {
         let parts = token.split(separator: "_").map(String.init)
         guard parts.count >= 3 else { return nil }
         guard isNikonBrand(parts[0]) else { return nil }
         let model = correctModel(parts[1])
-        guard !model.isEmpty, model.allSatisfy({ $0.isLetter || $0.isNumber }) else { return nil }
+        guard model == "ZR" else { return nil }
         let serial = correctDigits(parts[parts.count - 1])
         guard serial.count == 5, serial.allSatisfy(\.isNumber) else { return nil }
         return "NIKON_\(model)_\(serial)"
+    }
+
+    private static func isUnsupportedNikonSSIDCandidate(_ raw: String) -> Bool {
+        let token = raw.trimmingCharacters(in: Self.punctuation).uppercased()
+        guard token.count >= 8 else { return false }
+        let prefix = String(token.prefix(5))
+        guard isNikonBrand(prefix) else { return false }
+        return token.contains("Z")
+            && token.contains(where: { $0.isNumber || "OILSBZG".contains($0) })
     }
 
     /// An 8-character token that reads as lowercase hex → the WPA key.

--- a/Tests/OpenZCineCoreTests/CameraWiFiSSIDTests.swift
+++ b/Tests/OpenZCineCoreTests/CameraWiFiSSIDTests.swift
@@ -13,6 +13,19 @@ import Testing
     #expect(CameraWiFiSSID.deriveSSID(fromCameraName: "PTP-IP Camera") == nil)
 }
 
+@Test func cameraWiFiSSIDRecognizesModelSpecificNikonZAccessPointShapes() {
+    #expect(CameraWiFiSSID.isNikonZAccessPoint("NIKON_ZR_01234"))
+    #expect(CameraWiFiSSID.isNikonZAccessPoint("NIKONZ_8_X12345"))
+    #expect(CameraWiFiSSID.isNikonZAccessPoint("nikon-z-9-98765"))
+}
+
+@Test func cameraWiFiSSIDRejectsUnrelatedOrMalformedNetworkNames() {
+    #expect(!CameraWiFiSSID.isNikonZAccessPoint("HomeNetwork"))
+    #expect(!CameraWiFiSSID.isNikonZAccessPoint("NIKON_CAMERA_12345"))
+    #expect(!CameraWiFiSSID.isNikonZAccessPoint("NIKONZ@8@12345"))
+    #expect(!CameraWiFiSSID.isNikonZAccessPoint("NIKONZ_CAMERA"))
+}
+
 @Test func cameraWiFiSSIDPrefersStoredSSIDOnSavedRecord() {
     let saved = PTPIPSavedCameraRecord(
         host: "192.168.1.1",
@@ -117,6 +130,12 @@ import Testing
         )
     )
     #expect(
+        CameraWiFiJoinPolicy.isOnCameraAccessPoint(
+            localAddresses: ["192.168.1.42"],
+            connectedSSID: "NIKONZ_8_X12345"
+        )
+    )
+    #expect(
         !CameraWiFiJoinPolicy.isOnCameraAccessPoint(
             localAddresses: ["192.168.1.42"],
             connectedSSID: "HomeNetwork"
@@ -181,7 +200,7 @@ import Testing
         savedCameras: [],
         connectedSSID: "HomeNetwork"
     )
-    #expect(target == .ssidPrefix("NIKON_ZR_"))
+    #expect(target == .ssidPrefix("NIKON"))
 }
 
 @Test func proactiveJoinTargetUsesPrefixWithNoSavedCameras() {
@@ -189,7 +208,7 @@ import Testing
         localAddresses: ["10.0.0.12"],
         savedCameras: []
     )
-    #expect(target == .ssidPrefix("NIKON_ZR_"))
+    #expect(target == .ssidPrefix("NIKON"))
 }
 
 @Test func proactiveJoinSessionPolicyRespectsPersistedUserDenied() {
@@ -230,13 +249,14 @@ import Testing
 }
 
 @Test func joinTargetCredentialLookupFallsBackToPrefix() {
-    let target = CameraWiFiJoinPolicy.JoinTarget(ssidPrefix: CameraWiFiSSID.nikonAccessPointPrefix)
+    let target = CameraWiFiJoinPolicy.JoinTarget(
+        ssidPrefix: CameraWiFiSSID.nikonAccessPointBrandPrefix)
     let lookup = CameraWiFiJoinPolicy.credentialLookupSSID(
         for: target,
         resolvedSSID: nil
     )
     #expect(lookup.ssid == nil)
-    #expect(lookup.prefix == CameraWiFiSSID.nikonAccessPointPrefix)
+    #expect(lookup.prefix == CameraWiFiSSID.nikonAccessPointBrandPrefix)
 }
 
 @Test func connectionProgressJoiningWiFiCopy() {

--- a/Tests/OpenZCineCoreTests/CameraWiFiScreenParserTests.swift
+++ b/Tests/OpenZCineCoreTests/CameraWiFiScreenParserTests.swift
@@ -53,3 +53,69 @@ import Testing
     let creds = CameraWiFiScreenParser.parse(lines: ["NIKON_2R_01234", "a1b2c3d4"])
     #expect(creds?.ssid == "NIKON_ZR_01234")
 }
+
+@Test func parsesLocalizedNonZRCameraScreenWithoutKnowingTheLabelLanguage() {
+    let creds = CameraWiFiScreenParser.parse(lines: [
+        "Verbindingswizard",
+        "SSID: NIKONZ_8_X12345",
+        "Sleutel: b4c5d6e7",
+    ])
+
+    #expect(
+        creds
+            == CameraWiFiScreenParser.Credentials(
+                ssid: "NIKONZ_8_X12345",
+                key: "b4c5d6e7"
+            )
+    )
+}
+
+@Test func preservesUnfamiliarNikonZModelSegmentsInsteadOfRebuildingTheSSID() {
+    let creds = CameraWiFiScreenParser.parse(lines: [
+        "SSID nikonz_9_pro123",
+        "Password 12ab34cd",
+    ])
+
+    #expect(creds?.ssid == "NIKONZ_9_PRO123")
+
+    let z8 = CameraWiFiScreenParser.parse(lines: [
+        "SSID NIKON_Z8_12345",
+        "Password 12ab34cd",
+    ])
+    #expect(z8?.ssid == "NIKON_Z8_12345")
+}
+
+@Test func reportsWhenAValidNikonSSIDStillNeedsItsKey() {
+    #expect(
+        CameraWiFiScreenParser.result(lines: ["SSID: NIKONZ_8_X12345"])
+            == .needsKey
+    )
+}
+
+@Test func reportsUnsupportedNikonSSIDShapeForManualFallback() {
+    #expect(
+        CameraWiFiScreenParser.result(lines: ["SSID: NIKONZ@MODEL42", "Key: b4c5d6e7"])
+            == .unsupportedSSID
+    )
+}
+
+@Test func manualCredentialsAcceptFutureSSIDLayoutsAndStandardWPAPassphrases() {
+    let creds = CameraWiFiScreenParser.manualCredentials(
+        ssid: "NIKON-Z-FUTURE-42",
+        key: " camera-passphrase "
+    )
+
+    #expect(creds?.ssid == "NIKON-Z-FUTURE-42")
+    #expect(creds?.key == " camera-passphrase ")
+}
+
+@Test func manualCredentialsRejectInvalidSSIDAndPassphraseLengths() {
+    #expect(CameraWiFiScreenParser.manualCredentials(ssid: "", key: "12345678") == nil)
+    #expect(CameraWiFiScreenParser.manualCredentials(ssid: "NIKONZ_8_X12345", key: "short") == nil)
+    #expect(
+        CameraWiFiScreenParser.manualCredentials(
+            ssid: String(repeating: "N", count: 33),
+            key: "12345678"
+        ) == nil
+    )
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -323,6 +323,10 @@ Feature work tracked as its own tasks on the Kaneo board, outside the Phase 0–
   links to it directly. Android stays presented as clearly unavailable until it ships.
 - **Landing-page camera compatibility** (in progress): identify the Nikon ZR, Z9, and Z5II as
   working, and the Z6, Z6II, Z6III, Zf, Z8, Z7, and Z7II as untested.
+- **Model-agnostic Nikon Z camera-AP onboarding** (OPE-105, in progress): recognize conservative
+  Nikon Z SSID shapes without rebuilding unknown model names, share that classifier across scanning
+  and reconnect policy, and provide exact manual SSID/key entry when OCR or a future body format
+  cannot be validated automatically. Synthetic fixtures only; real tester credentials remain local.
 
 ## Milestone Success Criteria
 

--- a/docs/flows/camera-ap-join.md
+++ b/docs/flows/camera-ap-join.md
@@ -44,25 +44,29 @@ flowchart TD
 ### PREPARE-01 — Prepare camera
 
 - **Status:** shipped
-- **Screen:** Numbered instruction cards for putting the ZR on its Connection wizard screen.
+- **Screen:** Numbered instruction cards for putting the Nikon Z camera on its Connection wizard
+  screen.
 - **Code:** `StartupWizardPrepareCards` / `StartupWizardContent.preparationSteps(for:)`.
 - 📝 Notes:
 
 ### SCAN-01 — OCR scanner
 
 - **Status:** shipped
-- **Screen:** VisionKit DataScanner reads SSID + key off the ZR's screen; parser self-corrects
-  OCR (O/0, l/1, S/5) because `NIKON_ZR_` + 5 digits and 8-hex-key are the only legal shapes.
+- **Screen:** VisionKit DataScanner reads SSID + key off the camera screen. The parser accepts the
+  conservative shape shared by Nikon Z access points while preserving unfamiliar model/serial
+  segments; the known ZR form retains its O/0, l/1, and S/5 recovery. Labels may be localized.
 - **Code:** `CameraWiFiScannerView.swift`, core `CameraWiFiScreenParser.swift` (+ tests).
-- **Detail:** Simulator has no DataScanner → manual fallback. Scan feeds the join popup via
-  `applyScannedCameraWiFi` — never a parallel join path.
+- **Detail:** **Enter manually** accepts the exact camera SSID and standard 8–63-character WPA key
+  when glare, unavailable scanning, or a future SSID layout prevents automatic capture. Scan and
+  manual entry both feed the same staged join popup and normal join pipeline.
 - 📝 Notes:
 
 ### JOIN-01 — Ready to join (white card)
 
 - **Status:** shipped
-- **Screen:** Light card (scanner-matching): SSID title, read-only monospaced key chip
-  ("Scanned from camera screen — check it matches."), Connect, Cancel. Wrong OCR ⇒ Cancel + rescan.
+- **Screen:** Light card (scanner-matching): SSID title, read-only monospaced key chip for OCR
+  results, source-appropriate verification copy, Connect, Cancel. Wrong OCR ⇒ Cancel + rescan or
+  enter the exact details manually.
 - **Code:** `ConnectionProgressSheet.swift` (single light card for ALL phases now).
 - 📝 Notes:
 

--- a/docs/flows/internet-hop.md
+++ b/docs/flows/internet-hop.md
@@ -63,8 +63,8 @@ flowchart TD
   `connectedSSID` (`NEHotspotNetwork.fetchCurrent`, debounced 2 s). Core
   `RedLUTDownloadPolicy.availability(hasInternetPath:isOnCameraAccessPoint:)` resolves three
   states: camera AP checked first (satisfied path but no WAN), then generic no-path, else
-  available. Camera-AP detection uses `CameraWiFiJoinPolicy.isOnCameraAccessPoint` on SSID
-  (`NIKON_ZR_` prefix).
+  available. Camera-AP detection uses `CameraWiFiJoinPolicy.isOnCameraAccessPoint` with the shared,
+  conservative Nikon Z SSID classifier rather than a model-specific prefix.
 - **Code:** `RedLUTDownloadPolicy.swift`, `InternetReachability.swift`,
   `CameraWiFiSSID.swift` (`CameraWiFiJoinPolicy`), `RedLUTDownloadPolicyTests.swift`.
 - 📝 Notes:

--- a/ios/Runner/AccessorySetupWiFiCoordinator.swift
+++ b/ios/Runner/AccessorySetupWiFiCoordinator.swift
@@ -6,8 +6,8 @@ import os
 
 /// Wi‑Fi camera pairing via Apple's AccessorySetupKit (iOS 18+).
 ///
-/// Presents the system accessory picker (product image + device name) for Nikon ZR hotspots
-/// matching `NIKON_ZR_`, then joins with `joinAccessoryHotspot` / `joinAccessoryHotspotWithoutSecurity`.
+/// Presents the system accessory picker (product image + device name) for Nikon Z hotspots, then
+/// joins with `joinAccessoryHotspot` / `joinAccessoryHotspotWithoutSecurity`.
 /// See WWDC24 session 10203 and ``ASAccessorySession``.
 @available(iOS 18.0, *)
 @MainActor
@@ -102,7 +102,7 @@ final class AccessorySetupWiFiCoordinator {
         }
         let descriptor = ASDiscoveryDescriptor()
         descriptor.ssid = ssid
-        return try await presentPicker(descriptor: descriptor, displayName: "Nikon ZR")
+        return try await presentPicker(descriptor: descriptor, displayName: "Nikon camera")
     }
 
     private func resolveAccessory(ssidPrefix: String) async throws -> ASAccessory {
@@ -112,7 +112,7 @@ final class AccessorySetupWiFiCoordinator {
         }
         let descriptor = ASDiscoveryDescriptor()
         descriptor.ssidPrefix = ssidPrefix
-        return try await presentPicker(descriptor: descriptor, displayName: "Nikon ZR")
+        return try await presentPicker(descriptor: descriptor, displayName: "Nikon camera")
     }
 
     private func authorizedAccessory(matchingSSID ssid: String) -> ASAccessory? {

--- a/ios/Runner/CameraWiFiScannerView.swift
+++ b/ios/Runner/CameraWiFiScannerView.swift
@@ -4,21 +4,42 @@ import VisionKit
 /// Apple-native modal that reads the camera's on-screen Connection wizard (SSID + Key) with the
 /// phone's rear camera and hands validated credentials back to the connect popup. VisionKit does
 /// the OCR; ``CameraWiFiScreenParser`` validates and self-corrects. A live viewfinder window is
-/// embedded in the card so the operator can frame the camera's wizard screen. Scanning is the sole
-/// path — Cancel is the only secondary action.
+/// embedded in the card so the operator can frame the camera's wizard screen. Manual entry remains
+/// available when glare, localization, or a future camera SSID format prevents automatic capture.
 struct CameraWiFiScannerScreen: View {
     let onCapture: (CameraWiFiScreenParser.Credentials) -> Void
+    let onManualEntry: (CameraWiFiScreenParser.Credentials) -> Void
     let onCancel: () -> Void
+
+    @State private var showsManualEntry: Bool
+    @State private var manualSSID = ""
+    @State private var manualKey = ""
+    @State private var manualSubmissionAttempted = false
+    @State private var scanIssue: CameraWiFiScreenParser.Result?
 
     private let cardCornerRadius: CGFloat = 24
     private let cardMaxWidth: CGFloat = 360
 
+    init(
+        onCapture: @escaping (CameraWiFiScreenParser.Credentials) -> Void,
+        onManualEntry: @escaping (CameraWiFiScreenParser.Credentials) -> Void,
+        onCancel: @escaping () -> Void,
+        startsInManualEntry: Bool = false
+    ) {
+        self.onCapture = onCapture
+        self.onManualEntry = onManualEntry
+        self.onCancel = onCancel
+        _showsManualEntry = State(initialValue: startsInManualEntry)
+    }
+
     var body: some View {
         GeometryReader { proxy in
             // The viewfinder is the flexible element in the vertical stack. Cap its height so the
-            // whole card (title + instruction + viewfinder + Cancel) fits within the short,
-            // landscape-locked (~402pt tall) canvas with comfortable margins and no clipping.
-            let viewfinderMaxHeight = max(132, min(240, proxy.size.height - 232))
+            // whole card (title + instruction + viewfinder + actions) fits within the short,
+            // ~402pt landscape canvas with comfortable margins and no clipping. Recognition help
+            // borrows height from the viewfinder rather than growing the card past an edge.
+            let fixedHeight: CGFloat = scanIssueMessage == nil ? 232 : 280
+            let viewfinderMaxHeight = max(112, min(240, proxy.size.height - fixedHeight))
 
             ZStack {
                 // Transparent full-screen tap target for dismiss. The *visible* blur backdrop is
@@ -44,9 +65,20 @@ struct CameraWiFiScannerScreen: View {
     private func card(viewfinderMaxHeight: CGFloat) -> some View {
         VStack(spacing: 16) {
             header
-            viewfinder
-                .frame(maxHeight: viewfinderMaxHeight)
-            cancelButton
+            if showsManualEntry {
+                manualEntryForm
+            } else {
+                viewfinder
+                    .frame(maxHeight: viewfinderMaxHeight)
+                if let scanIssueMessage {
+                    Text(scanIssueMessage)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                scanActions
+            }
         }
         .padding(24)
         .frame(maxWidth: .infinity)
@@ -62,27 +94,35 @@ struct CameraWiFiScannerScreen: View {
 
     private var header: some View {
         VStack(spacing: 8) {
-            Text("Scan Wi‑Fi Details")
+            Text(showsManualEntry ? "Enter Wi‑Fi Details" : "Scan Wi‑Fi Details")
                 .font(.title3.weight(.bold))
                 .foregroundStyle(.primary)
                 .multilineTextAlignment(.center)
 
-            Text(
-                "Point your phone at the camera's Connection wizard screen showing the SSID and key."
-            )
-            .font(.subheadline)
-            .foregroundStyle(.secondary)
-            .multilineTextAlignment(.center)
-            .fixedSize(horizontal: false, vertical: true)
+            Text(headerDetail)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
         }
         .frame(maxWidth: .infinity)
+    }
+
+    private var headerDetail: String {
+        if showsManualEntry {
+            return "Copy the SSID and key exactly as they appear on the camera screen."
+        }
+        return "Point your phone at the camera's Connection wizard screen showing the SSID and key."
     }
 
     /// Rounded viewfinder window holding the live scan feed (or a placeholder when unsupported).
     private var viewfinder: some View {
         ZStack {
             if DataScannerViewController.isSupported {
-                CameraWiFiScannerRepresentable(onCapture: onCapture)
+                CameraWiFiScannerRepresentable(
+                    onCapture: onCapture,
+                    onIssue: { scanIssue = $0 }
+                )
             } else {
                 unsupportedPlaceholder
             }
@@ -94,6 +134,17 @@ struct CameraWiFiScannerScreen: View {
             RoundedRectangle(cornerRadius: DesignTokens.cornerRadius, style: .continuous)
                 .strokeBorder(Color.black.opacity(0.12), lineWidth: 1)
         )
+    }
+
+    private var scanIssueMessage: String? {
+        switch scanIssue {
+        case .needsKey:
+            "SSID found. Keep the key in frame, or enter both details manually."
+        case .unsupportedSSID:
+            "Camera text found, but this SSID format wasn't recognized. Enter it manually."
+        case .credentials, .noCredentials, nil:
+            nil
+        }
     }
 
     private var unsupportedPlaceholder: some View {
@@ -112,15 +163,75 @@ struct CameraWiFiScannerScreen: View {
         }
     }
 
-    private var cancelButton: some View {
-        Button(role: .cancel, action: onCancel) {
-            Text("Cancel")
-                .font(.body.weight(.semibold))
-                .frame(maxWidth: .infinity)
+    private var scanActions: some View {
+        HStack(spacing: 12) {
+            Button("Enter manually") {
+                showsManualEntry = true
+            }
+            .accessibilityHint("Opens fields for the camera network name and key")
+
+            Button("Cancel", role: .cancel, action: onCancel)
+                .accessibilityHint("Closes the scanner without joining")
         }
+        .font(.body.weight(.semibold))
         .buttonStyle(.bordered)
         .controlSize(.large)
-        .accessibilityHint("Closes the scanner without joining")
+        .frame(maxWidth: .infinity)
+    }
+
+    private var manualEntryForm: some View {
+        VStack(spacing: 12) {
+            TextField("Camera Wi-Fi SSID", text: $manualSSID)
+                .textInputAutocapitalization(.characters)
+                .autocorrectionDisabled()
+                .textContentType(.none)
+                .accessibilityLabel("Camera Wi-Fi SSID")
+
+            SecureField("Camera Wi-Fi key", text: $manualKey)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .textContentType(.password)
+                .privacySensitive()
+                .accessibilityLabel("Camera Wi-Fi key")
+
+            if manualSubmissionAttempted, manualCredentials == nil {
+                Text("Enter the complete SSID and an 8–63 character Wi-Fi key.")
+                    .font(.caption)
+                    .foregroundStyle(Color(.systemRed))
+                    .multilineTextAlignment(.center)
+            }
+
+            Button("Use These Details") {
+                submitManualCredentials()
+            }
+            .font(.body.weight(.semibold))
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .frame(maxWidth: .infinity)
+
+            HStack(spacing: 12) {
+                Button("Back to scan") {
+                    manualSubmissionAttempted = false
+                    showsManualEntry = false
+                }
+                Button("Cancel", role: .cancel, action: onCancel)
+            }
+            .font(.body.weight(.semibold))
+            .buttonStyle(.bordered)
+            .controlSize(.large)
+            .frame(maxWidth: .infinity)
+        }
+        .textFieldStyle(.roundedBorder)
+    }
+
+    private var manualCredentials: CameraWiFiScreenParser.Credentials? {
+        CameraWiFiScreenParser.manualCredentials(ssid: manualSSID, key: manualKey)
+    }
+
+    private func submitManualCredentials() {
+        manualSubmissionAttempted = true
+        guard let manualCredentials else { return }
+        onManualEntry(manualCredentials)
     }
 }
 
@@ -128,6 +239,7 @@ struct CameraWiFiScannerScreen: View {
 /// valid Nikon SSID + key.
 private struct CameraWiFiScannerRepresentable: UIViewControllerRepresentable {
     let onCapture: (CameraWiFiScreenParser.Credentials) -> Void
+    let onIssue: (CameraWiFiScreenParser.Result) -> Void
 
     func makeUIViewController(context: Context) -> DataScannerViewController {
         let scanner = DataScannerViewController(
@@ -148,15 +260,21 @@ private struct CameraWiFiScannerRepresentable: UIViewControllerRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(onCapture: onCapture)
+        Coordinator(onCapture: onCapture, onIssue: onIssue)
     }
 
     final class Coordinator: NSObject, DataScannerViewControllerDelegate {
         private let onCapture: (CameraWiFiScreenParser.Credentials) -> Void
+        private let onIssue: (CameraWiFiScreenParser.Result) -> Void
         private var didCapture = false
+        private var lastIssue: CameraWiFiScreenParser.Result?
 
-        init(onCapture: @escaping (CameraWiFiScreenParser.Credentials) -> Void) {
+        init(
+            onCapture: @escaping (CameraWiFiScreenParser.Credentials) -> Void,
+            onIssue: @escaping (CameraWiFiScreenParser.Result) -> Void
+        ) {
             self.onCapture = onCapture
+            self.onIssue = onIssue
         }
 
         func dataScanner(
@@ -184,10 +302,19 @@ private struct CameraWiFiScannerRepresentable: UIViewControllerRepresentable {
                 if case .text(let text) = item { return text.transcript }
                 return nil
             }
-            guard let credentials = CameraWiFiScreenParser.parse(lines: lines) else { return }
-            didCapture = true
-            scanner.stopScanning()
-            onCapture(credentials)
+            let result = CameraWiFiScreenParser.result(lines: lines)
+            switch result {
+            case .credentials(let credentials):
+                didCapture = true
+                scanner.stopScanning()
+                onCapture(credentials)
+            case .needsKey, .unsupportedSSID:
+                guard lastIssue != result else { return }
+                lastIssue = result
+                onIssue(result)
+            case .noCredentials:
+                break
+            }
         }
     }
 }

--- a/ios/Runner/ConnectionProgressSheet.swift
+++ b/ios/Runner/ConnectionProgressSheet.swift
@@ -147,8 +147,8 @@ struct ConnectionProgressSheet: View {
     @ViewBuilder
     private var joinActions: some View {
         VStack(spacing: 12) {
-            if model.cameraWiFiJoinNeedsPassword, !model.cameraWiFiJoinKeyFromScan {
-                // First-time connect: scanning the camera's SSID + key is the sole path.
+            if model.cameraWiFiJoinNeedsPassword, !model.cameraWiFiJoinHasPasswordDraft {
+                // First-time connect: scan the camera screen, with manual entry available there.
                 Button {
                     model.presentCameraWiFiScanner()
                 } label: {
@@ -167,7 +167,6 @@ struct ConnectionProgressSheet: View {
             } else {
                 if model.cameraWiFiJoinKeyFromScan {
                     // Scanned key: shown read-only so a stray tap can't clear or mangle it.
-                    // If the OCR misread, Cancel and rescan — there's no manual edit path.
                     Text(model.cameraWiFiJoinPasswordDraft)
                         .font(.body.monospaced())
                         .foregroundStyle(.primary)
@@ -181,6 +180,11 @@ struct ConnectionProgressSheet: View {
                     Text("Scanned from camera screen — check it matches.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                } else if model.cameraWiFiJoinHasPasswordDraft {
+                    Text("Wi-Fi details entered manually — connect when they match the camera.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
                 }
                 connectButton
             }

--- a/ios/Runner/DemoHarness.swift
+++ b/ios/Runner/DemoHarness.swift
@@ -36,6 +36,8 @@ enum DemoHarness {
     /// `ZC_DEMO_CANVAS_SCOPES=1` forces the Canvas reference plots over the Metal trace
     /// rasterizer — the baseline for pixel-diff look-regression checks.
     static let canvasScopes = flag("ZC_DEMO_CANVAS_SCOPES")
+    /// `ZC_DEMO_WIFI_SCANNER=scan|manual` opens the Wi-Fi credential scanner for screenshots.
+    static let cameraWiFiScannerMode = value("ZC_DEMO_WIFI_SCANNER")
 
     // MARK: Environment access — Debug reads the process env; Release is hardwired inert.
 
@@ -404,6 +406,11 @@ enum DemoHarness {
                     model.connectionMessage =
                         "Couldn't reach the camera Wi‑Fi network. Make sure the camera is on and nearby, then try again."
                 }
+            }
+            if cameraWiFiScannerMode != nil {
+                // Demo/screenshot affordance: the real scanner is normally entered from the
+                // camera-connection flow and needs a physical camera screen to exercise.
+                model.isCameraWiFiScannerPresented = true
             }
         }
     }

--- a/ios/Runner/LinkExperience.swift
+++ b/ios/Runner/LinkExperience.swift
@@ -152,7 +152,11 @@ struct LinkExperience: View {
         .fullScreenCover(isPresented: Bindable(model).isCameraWiFiScannerPresented) {
             CameraWiFiScannerScreen(
                 onCapture: { model.applyScannedCameraWiFi(ssid: $0.ssid, key: $0.key) },
-                onCancel: { model.isCameraWiFiScannerPresented = false }
+                onManualEntry: {
+                    model.applyManualCameraWiFi(ssid: $0.ssid, key: $0.key)
+                },
+                onCancel: { model.isCameraWiFiScannerPresented = false },
+                startsInManualEntry: DemoHarness.cameraWiFiScannerMode == "manual"
             )
         }
     }

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -967,6 +967,11 @@ final class NativeAppModel {
         ) == nil
     }
 
+    /// Whether the current join already has a scanned or manually entered key ready to confirm.
+    var cameraWiFiJoinHasPasswordDraft: Bool {
+        !cameraWiFiJoinPasswordDraft.isEmpty
+    }
+
     /// Opens the on-screen credential scanner over the connect popup.
     func presentCameraWiFiScanner() {
         isCameraWiFiScannerPresented = true
@@ -975,10 +980,20 @@ final class NativeAppModel {
     /// Applies credentials scanned from the camera's Connection wizard: stages an exact-SSID join
     /// and pre-fills the key, so the popup's Connect button runs the normal join pipeline.
     func applyScannedCameraWiFi(ssid: String, key: String) {
+        stageCameraWiFiCredentials(ssid: ssid, key: key, cameFromScan: true)
+    }
+
+    /// Applies credentials copied manually from a camera screen when automatic OCR cannot validate
+    /// that body's SSID shape. The exact operator-entered SSID remains authoritative.
+    func applyManualCameraWiFi(ssid: String, key: String) {
+        stageCameraWiFiCredentials(ssid: ssid, key: key, cameFromScan: false)
+    }
+
+    private func stageCameraWiFiCredentials(ssid: String, key: String, cameFromScan: Bool) {
         isCameraWiFiScannerPresented = false
         pendingCameraWiFiJoinTarget = .specificSSID(ssid)
         cameraWiFiJoinPasswordDraft = key
-        cameraWiFiJoinKeyFromScan = true
+        cameraWiFiJoinKeyFromScan = cameFromScan
         connectionProgressDeviceName = ssid
         connectionProgressIsUSB = false
         connectionProgressShowsFailure = false
@@ -2408,7 +2423,7 @@ final class NativeAppModel {
     /// camera AP we paired over), else derive it from the camera's PTP name, else a saved record.
     private func cameraAccessPointSSID(host: String, displayName: String?) -> String? {
         if let ssid = connectedWiFiSSID?.trimmingCharacters(in: .whitespacesAndNewlines),
-            ssid.uppercased().hasPrefix(CameraWiFiSSID.nikonAccessPointPrefix.uppercased())
+            CameraWiFiSSID.isNikonZAccessPoint(ssid)
         {
             return ssid
         }
@@ -2466,7 +2481,7 @@ final class NativeAppModel {
             connection = .disconnected
             WiFiJoinCoordinator.shared.leaveCameraNetwork(ssid: ssid)
             // The cached SSID is what AP detection reads — clear it now, or a stale
-            // "NIKON_ZR_…" keeps isOnCameraAccessPoint true and the post-hop internet wait
+            // A cached Nikon Z SSID keeps isOnCameraAccessPoint true and the post-hop internet wait
             // spins its full timeout.
             connectedWiFiSSID = nil
         }

--- a/ios/RunnerTests/FirstPairWizardStepTests.swift
+++ b/ios/RunnerTests/FirstPairWizardStepTests.swift
@@ -99,4 +99,33 @@ struct FirstPairWizardStepTests {
 
         #expect(model.pairingDiscoveryCandidates == [rediscovered])
     }
+
+    @MainActor
+    @Test("Manual camera Wi-Fi details stage an exact join without claiming OCR")
+    func manualCameraWiFiDetails() {
+        let model = NativeAppModel()
+        model.isCameraWiFiScannerPresented = true
+
+        model.applyManualCameraWiFi(ssid: "NIKON-Z-FUTURE-42", key: "camera-passphrase")
+
+        #expect(model.pendingCameraWiFiJoinTarget == .specificSSID("NIKON-Z-FUTURE-42"))
+        #expect(model.cameraWiFiJoinPasswordDraft == "camera-passphrase")
+        #expect(model.cameraWiFiJoinHasPasswordDraft)
+        #expect(!model.cameraWiFiJoinKeyFromScan)
+        #expect(!model.isCameraWiFiScannerPresented)
+        #expect(model.connectionPhase == .readyToJoin)
+        #expect(model.isConnectionProgressPresented)
+    }
+
+    @MainActor
+    @Test("Scanned camera Wi-Fi details retain their verification source")
+    func scannedCameraWiFiDetails() {
+        let model = NativeAppModel()
+
+        model.applyScannedCameraWiFi(ssid: "NIKONZ_8_X12345", key: "b4c5d6e7")
+
+        #expect(model.pendingCameraWiFiJoinTarget == .specificSSID("NIKONZ_8_X12345"))
+        #expect(model.cameraWiFiJoinKeyFromScan)
+        #expect(model.cameraWiFiJoinHasPasswordDraft)
+    }
 }

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,14 +1,14 @@
 What's changed
 
 - Connecting to the camera over USB-C is now fast and reliable, even with a full memory card.
-- After plugging in, the camera row shows the card being prepared with a live percentage, and the Connect button switches from Preparing to ready the moment connecting will be instant.
+- After plugging in, the camera row shows the card being prepared with a live percentage, and the Connect button switches from Preparing to ready the moment connecting will be instant. The connection card explains progress and shows readable errors with technical details underneath.
 - Disconnecting inside the app and reconnecting over USB-C no longer re-reads the card, so reconnects are immediate.
 - Plugging in a USB-C camera only adds it to the camera list; connecting is always your tap.
-- While connecting, the progress card explains what is happening in plain language, and connection errors show a readable message with technical details underneath.
+- Wi-Fi setup now recognizes Nikon Z camera network names across models and localized camera menus. If scanning cannot validate the details, you can enter the camera's exact SSID and key manually.
 
 Please test
 
 - Plug the camera into the iPhone with USB-C, confirm it appears in the list without connecting on its own, wait for the row to show Ready, then tap Connect and confirm it connects almost instantly.
 - Tap Connect right after plugging in and confirm the progress card counts up while reading the camera's card instead of sitting on a plain spinner.
 - Disconnect from inside the app and reconnect over USB-C; confirm it connects immediately without re-reading the card. Then unplug and replug the cable and confirm the row walks through Preparing back to Ready.
-- Connect over Wi-Fi once and confirm that flow is unchanged.
+- Open the camera's Connection wizard and scan its Wi-Fi details. Confirm the app advances when both fields are visible. Also try Enter manually, copy the exact SSID and key from the camera, and confirm the same connection card appears before joining.


### PR DESCRIPTION
## Summary

- recognize conservative Nikon Z access-point shapes across camera models while preserving the exact scanned or stored SSID
- ignore localized Connection-wizard labels and retain safe ZR-specific OCR repair
- add exact manual SSID/key entry when OCR or an unfamiliar camera format cannot be validated
- share the classifier with reconnect and camera-AP detection policy

## Verification

- `just native-check`
- `just check`
- scanner and manual-entry cards visually verified on iPhone 15 Pro and the tighter iPhone SE landscape canvases

Tracks OPE-105.