### PR TITLE
ci(android): harden Play internal distribution

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,15 @@ For an internal-only build, say that there are no tester-facing app changes and 
 continue their normal camera workflow.
 -->
 
+## Google Play notes
+
+<!--
+If this PR changes the Android app/core or its build and release tooling, update
+Apps/Android/distribution/whatsnew/whatsnew-en-US with 1-5 short, tester-facing bullets.
+For internal-only work, say that there are no visible app changes and ask testers to continue
+their normal camera workflow.
+-->
+
 ## Checklist
 
 - [ ] `just check` passes.
@@ -22,4 +31,5 @@ continue their normal camera workflow.
 - [ ] No proprietary assets (`vendor/`, `ref/`) are included.
 - [ ] Docs/CHANGELOG updated if behavior or setup changed.
 - [ ] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy.
+- [ ] Play-triggering changes include reviewed `Apps/Android/distribution/whatsnew/whatsnew-en-US` copy.
 - [ ] iOS release PRs: bump `MARKETING_VERSION` in `ios/Config/Version.xcconfig` when appropriate.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
           ./scripts/ios-release-notes-check.sh
           ./scripts/ios-release-notes-test.sh
 
+      - name: Google Play notes
+        run: ./scripts/android-play-release-notes-check.sh
+
       - name: Require reviewed notes for TestFlight-triggering pull requests
         if: ${{ github.event_name == 'pull_request' }}
         env:
@@ -47,6 +50,19 @@ jobs:
           if grep -Eq '^(Sources/|Tests/|ios/|Package\.swift$|scripts/|justfile$)' <<< "$changed_files"; then
             if ! grep -Fxq 'ios/TestFlight/WhatToTest.en-US.txt' <<< "$changed_files"; then
               echo "Update ios/TestFlight/WhatToTest.en-US.txt with plain-language changes and test steps." >&2
+              exit 1
+            fi
+          fi
+
+      - name: Require reviewed notes for Play-triggering pull requests
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed_files="$(git diff --name-only "$BASE_SHA"...HEAD)"
+          if grep -Eq '^(Apps/Android/|Sources/OpenZCine(Core|AndroidFacade)/|Sources/CJNI/|scripts/android-|scripts/verify-android-|justfile$|\.github/workflows/play-internal\.yml$)' <<< "$changed_files"; then
+            if ! grep -Fxq 'Apps/Android/distribution/whatsnew/whatsnew-en-US' <<< "$changed_files"; then
+              echo "Update Apps/Android/distribution/whatsnew/whatsnew-en-US with plain-language changes for Play testers." >&2
               exit 1
             fi
           fi
@@ -123,7 +139,10 @@ jobs:
               - 'Package.swift'
               - 'Package.resolved'
               - 'scripts/android-*.sh'
+              - 'scripts/verify-android-*.sh'
               - 'justfile'
+              # Changing the Play build or upload path must re-run the Android job.
+              - '.github/workflows/play-internal.yml'
             bug_relay:
               - 'services/bug-relay/**'
               - 'justfile'

--- a/.github/workflows/play-internal.yml
+++ b/.github/workflows/play-internal.yml
@@ -27,13 +27,22 @@ env:
 jobs:
   play-internal:
     name: Build & upload
-    if: github.repository == 'erik-sutton95/openzcine'
+    if: >-
+      ${{ github.repository == 'erik-sutton95/openzcine' &&
+          vars.PLAY_UPLOAD_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     environment: play
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          fetch-depth: 0
           persist-credentials: false
+
+      - name: Validate release ref and version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+        run: ./scripts/android-play-release-guard.sh
 
       - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
@@ -67,15 +76,44 @@ jobs:
         run: |
           echo "version_code=$(( ANDROID_VERSION_CODE_OFFSET + GITHUB_RUN_NUMBER ))" >> "$GITHUB_OUTPUT"
 
-      - name: Decode upload keystore
+      - name: Validate release credentials
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
         run: |
-          if [ -z "$ANDROID_KEYSTORE_BASE64" ]; then
-            echo "::error::ANDROID_KEYSTORE_BASE64 is not set — add it to the 'play' environment (docs/android-distribution.md)."
+          missing=()
+          for name in ANDROID_KEYSTORE_BASE64 ANDROID_KEYSTORE_PASSWORD ANDROID_KEY_ALIAS ANDROID_KEY_PASSWORD PLAY_SERVICE_ACCOUNT_JSON; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            echo "::error::Missing 'play' environment secrets: ${missing[*]} (docs/android-distribution.md)."
             exit 1
           fi
+          if ! jq -e '
+            .type == "service_account" and
+            (.client_email | type == "string" and length > 0) and
+            (.private_key | type == "string" and length > 0)
+          ' >/dev/null <<< "$PLAY_SERVICE_ACCOUNT_JSON"; then
+            echo "::error::PLAY_SERVICE_ACCOUNT_JSON is not a valid service-account JSON key."
+            exit 1
+          fi
+
+      - name: Decode and inspect upload keystore
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
           printf '%s' "$ANDROID_KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/upload-keystore.jks"
+          keytool -list \
+            -keystore "$RUNNER_TEMP/upload-keystore.jks" \
+            -storepass "$ANDROID_KEYSTORE_PASSWORD" \
+            -alias "$ANDROID_KEY_ALIAS" >/dev/null
 
       - name: Build and verify signed release packages
         working-directory: Apps/Android
@@ -88,6 +126,16 @@ jobs:
           SWIFT_ANDROID_SDK_ID: swift-6.3.3-RELEASE_android
         run: ./gradlew :app:verifyReleaseNativeLibraries :wear:verifyWearReleaseArtifact "-PversionCode=$VERSION_CODE"
 
+      - name: Verify bundle signatures
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ runner.temp }}/upload-keystore.jks
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        run: |
+          ./scripts/verify-android-bundle-signing.sh \
+            Apps/Android/app/build/outputs/bundle/release/app-release.aab \
+            Apps/Android/wear/build/outputs/bundle/release/wear-release.aab
+
       # r0adkll/upload-google-play over alternatives: Google publishes no official
       # GitHub Action for Play uploads (its official paths are Gradle Play Publisher
       # or the raw Publishing API), and this action is the de-facto standard — most
@@ -99,8 +147,10 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.opencapture.openzcine
           releaseFiles: Apps/Android/app/build/outputs/bundle/release/app-release.aab
-          track: internal
+          tracks: internal
           status: completed
+          whatsNewDirectory: Apps/Android/distribution/whatsnew
+          mappingFile: Apps/Android/app/build/outputs/mapping/release/mapping.txt
 
       - name: Upload to Wear OS internal track
         uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1.1.5
@@ -108,8 +158,10 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.opencapture.openzcine
           releaseFiles: Apps/Android/wear/build/outputs/bundle/release/wear-release.aab
-          track: wear:qa
+          tracks: wear:qa
           status: completed
+          whatsNewDirectory: Apps/Android/distribution/whatsnew
+          mappingFile: Apps/Android/wear/build/outputs/mapping/release/mapping.txt
 
       - name: Summary
         run: |

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,0 +1,3 @@
+- Internal preview of OpenZCine for Nikon Z cameras.
+- Connect to a camera, monitor live view, control recording, and use the Wear OS companion.
+- Please report connection, control, or display issues from your camera setup.

--- a/docs/android-distribution.md
+++ b/docs/android-distribution.md
@@ -3,19 +3,20 @@
 Signed phone and Wear OS Android App Bundles are built and uploaded to their Google Play
 **internal testing** tracks by [`play-internal.yml`](../.github/workflows/play-internal.yml).
 Releases are deliberate: the workflow runs on manual dispatch or an `android-v*` tag, never on
-plain merges.
+plain merges. The repository variable `PLAY_UPLOAD_ENABLED` is an emergency/bootstrap switch; it
+must be exactly `true` or the upload job is skipped.
 
 ## Flow
 
 ```text
 feature PR → CI (Gradle build + tests + lint) → merge to main
-→ tag android-v* (or Actions → Play Internal → Run workflow)
+→ tag android-v<openzcine.versionName> (or run Play Internal from main)
 → signed phone + Wear .aab files → Play phone + Wear internal tracks
 ```
 
 The track goes live only after the [one-time Play console setup](#one-time-play-console-setup)
-below, including Google's rule that the **first** `.aab` reaches the track through a manual console
-upload.
+below. Keep `PLAY_UPLOAD_ENABLED=false` until the app, upload key, service account, and first manual
+phone/Wear releases all exist.
 
 ## Version numbers
 
@@ -40,7 +41,9 @@ stream ever falls below the highest phone version code already in the Play conso
 Erik's checklist, in order:
 
 1. **Create the app** — [Play Console](https://play.google.com/console) → **Create app**, package
-   name `com.opencapture.openzcine` (must match `applicationId`; it is permanent).
+   name `com.opencapture.openzcine` (must match `applicationId`; it is permanent). Complete any
+   dashboard setup tasks that block testing releases, including app access, ads, content rating,
+   target audience, Data safety, and the privacy-policy/store-listing fields Play requests.
 2. **Generate the upload keystore** — locally, `just android-keystore`. It writes
    `.local/android/upload-keystore.jks` (gitignored) and prints the follow-up steps. Back up the
    file and password; enroll in **Play App Signing** (the default) so this is only the *upload*
@@ -48,18 +51,21 @@ Erik's checklist, in order:
 3. **Service account for the API** — in [Google Cloud Console](https://console.cloud.google.com):
    create (or pick) a project, enable the **Google Play Android Developer API**, create a service
    account, and download its **JSON key**. Then in Play Console → **Users and permissions** →
-   invite the service account's email and grant it release permissions (release-manager level:
-   "Release apps to testing tracks" and app access for OpenZCine).
+   invite the service account's email and grant app-scoped access to OpenZCine plus **Release apps
+   to testing tracks**. Do not grant account-wide administration.
 4. **Enable Wear OS** — in Play Console, opt the app into the Wear OS form factor. The phone and
    watch use the same package and upload/app-signing identity, but remain separate artifacts with
    unique version codes.
-5. **First uploads are manual** — Google requires the first bundle on a track to be uploaded
-   through the console. Build locally ([Local signed build](#local-signed-build)), then create the
-   phone internal release with `app-release.aab` and the Wear OS internal release with
-   `wear-release.aab`. Add the same internal-tester email list to both tracks.
-6. **Create the GitHub environment** — repo **Settings → Environments → New environment** named
-   `play` (mirrors the `testflight` environment), with the secrets below. Optionally restrict it
-   to `main` and tags, or require approval.
+5. **First uploads are manual** — build locally ([Local signed build](#local-signed-build)), then
+   create the first phone internal release with `app-release.aab` and the first Wear OS internal
+   release with `wear-release.aab`. This registers both artifact streams before the Publishing API
+   takes over. Add the same internal-tester email list to both tracks and verify both opt-in links.
+6. **Populate the GitHub environment** — the repo already has a `play` environment restricted to
+   `main` and `android-v*` tags. Add the five secrets below. Add required reviewers in the GitHub
+   UI if uploads should require a human approval after the job starts.
+7. **Activate automation last** — verify the manual phone and Wear releases install, then change
+   the repository variable `PLAY_UPLOAD_ENABLED` from `false` to `true`. Run **Play Internal** from
+   `main` once; leave tag-driven releases for reviewed version bumps.
 
 ## GitHub `play` environment secrets
 
@@ -74,16 +80,22 @@ Erik's checklist, in order:
 No keystore, password, or service-account JSON is ever committed — `.gitignore` blocks `*.jks`,
 `*.keystore`, and `.local/`, and `just check` runs gitleaks over history.
 
+`PLAY_SERVICE_ACCOUNT_JSON` is the only long-lived cloud credential. Prefer a dedicated service
+account and rotate its key if it is exposed. Migrating this workflow to Google Workload Identity
+Federation is the follow-up path when the Play publisher tooling and GitHub identity are provisioned.
+
 ## Running the workflow
 
-- **Tag release** — `git tag android-v0.1.0 && git push origin android-v0.1.0` (any `android-v*`
-  tag).
-- **Manual** — **Actions → Play Internal → Run workflow**.
+- **Tag release** — if `openzcine.versionName=0.1.0`, use
+  `git tag android-v0.1.0 && git push origin android-v0.1.0`. The workflow rejects a tag whose
+  version differs from `Apps/Android/gradle.properties` or whose commit is not on `main`.
+- **Manual** — **Actions → Play Internal → Run workflow**, selecting `main`.
 
 Either way the workflow runs Gradle tests + lint, computes both unique version codes, decodes the
 keystore secret to a runner temp file, builds both `bundleRelease` outputs signed via the same
-`ANDROID_KEYSTORE_*` environment variables, verifies the package/signing/capability pair, and
-uploads to the phone `internal` and Wear `wear:qa` tracks with
+`ANDROID_KEYSTORE_*` environment variables, verifies both AAB signatures against the configured
+upload-key alias, and uploads the bundles, R8 mapping files, and reviewed notes from
+`Apps/Android/distribution/whatsnew/` to the phone `internal` and Wear `wear:qa` tracks with
 [r0adkll/upload-google-play](https://github.com/r0adkll/upload-google-play) (pinned by digest;
 Google publishes no official Play-upload action, and this is the best-maintained community one).
 
@@ -98,6 +110,10 @@ export ANDROID_KEY_PASSWORD='...'
 cd Apps/Android && ./gradlew :app:bundleRelease :wear:bundleRelease :wear:verifyWearReleaseArtifact
 # → app/build/outputs/bundle/release/app-release.aab
 # → wear/build/outputs/bundle/release/wear-release.aab
+cd ../..
+scripts/verify-android-bundle-signing.sh \
+  Apps/Android/app/build/outputs/bundle/release/app-release.aab \
+  Apps/Android/wear/build/outputs/bundle/release/wear-release.aab
 ```
 
 With the `ANDROID_KEYSTORE_*` variables unset, both `bundleRelease` tasks still succeed and
@@ -110,8 +126,9 @@ unsigned or both carry the same signing certificate. The debug path (`just andro
 
 | Symptom | Likely cause |
 | --- | --- |
-| Workflow skipped | Fork — it only runs on `erik-sutton95/openzcine` |
-| `ANDROID_KEYSTORE_BASE64 is not set` | `play` environment or its secrets missing |
+| Workflow skipped | Fork, or repository variable `PLAY_UPLOAD_ENABLED` is not `true` |
+| Release-ref guard fails | Manual run did not select `main`, or tag/version/main ancestry do not match |
+| Missing `play` environment secrets | One or more of the five required values above is absent |
 | Upload fails with 403 / "not found" | Service account lacks release permission, or the app was never created in the console |
 | "Package not found" on first CI upload | The mandatory manual first uploads (step 5) haven't happened yet |
 | "Version code already used" | Raise `ANDROID_VERSION_CODE_OFFSET`, or explicitly set a collision-free `-PwearVersionCode` for a recovery build |

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,13 +1,7 @@
 What's changed
 
-- Live view keeps updating while you record (from the app or the camera body) and after you stop — the feed should not freeze for the whole take.
-- Downloading RED IPP2 look tables is more reliable: the archive imports cleanly, slight float rounding from RED no longer rejects every LUT, and Close leaves the download screen immediately.
-- After a download that left the camera network for internet, the monitor shows clear reconnect progress instead of a bare “No camera” while the app searches and rejoins.
-- Joining the camera’s Wi‑Fi network is faster and more reliable after pairing Confirm, including when the system network picker needs a short search.
+- There are no tester-facing iPhone or Apple Watch changes in this build.
 
 Please test
 
-- Start and stop recording from the app and from the camera body. Confirm live view keeps moving through the take and recovers cleanly when you stop.
-- From the LUT picker, run RED download: accept terms, download, confirm LUTs appear under RED, then Close and reconnect to the camera if you hopped off its Wi‑Fi.
-- Pair or reconnect over the camera’s Wi‑Fi after Confirm; the app should reach live view without hanging on Connecting.
-- Drag analysis scopes in landscape and confirm they move freely except at the side control rails.
+- Continue your normal camera connection, monitoring, and recording routine and report any unexpected regressions.

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ setup:
 
 # ── Meta checks (run today; mirrored in CI) ─────────────────────────────────
 # Run every repository quality check.
-check: hygiene site-check testflight-notes-check typos lint-md check-links check-editorconfig lint-actions secrets bug-relay-check check-demo-isolation swift-lint swift-test
+check: hygiene site-check testflight-notes-check play-notes-check typos lint-md check-links check-editorconfig lint-actions secrets bug-relay-check check-demo-isolation swift-lint swift-test
 
 # Reject tracked proprietary, secret-bearing, generated, or machine-specific files.
 hygiene:
@@ -29,6 +29,10 @@ site-check:
 testflight-notes-check:
     ./scripts/ios-release-notes-check.sh
     ./scripts/ios-release-notes-test.sh
+
+# Validate the reviewed Google Play tester-facing release notes.
+play-notes-check:
+    ./scripts/android-play-release-notes-check.sh
 
 # Spell-check the repository.
 typos:

--- a/scripts/android-play-release-guard.sh
+++ b/scripts/android-play-release-guard.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Reject ambiguous or off-main Play releases before signing starts.
+set -euo pipefail
+
+version_file="Apps/Android/gradle.properties"
+version_name="$(sed -n 's/^openzcine\.versionName=//p' "$version_file")"
+
+fail() {
+  printf 'Play release guard failed: %s\n' "$1" >&2
+  exit 1
+}
+
+[[ -n "$version_name" ]] || fail "missing openzcine.versionName in ${version_file}"
+
+case "${EVENT_NAME:-}" in
+  workflow_dispatch)
+    [[ "${REF_NAME:-}" == "main" ]] || fail "manual releases must run from main, not ${REF_NAME:-an unknown ref}"
+    ;;
+  push)
+    expected_tag="android-v${version_name}"
+    [[ "${REF_NAME:-}" == "$expected_tag" ]] || fail "tag must be ${expected_tag}, not ${REF_NAME:-an unknown ref}"
+    git merge-base --is-ancestor HEAD origin/main || fail "release tag commit is not on main"
+    ;;
+  *)
+    fail "unsupported event ${EVENT_NAME:-unknown}"
+    ;;
+esac
+
+printf 'Play release ref accepted: %s (version %s).\n' "${REF_NAME:-}" "$version_name"

--- a/scripts/android-play-release-notes-check.sh
+++ b/scripts/android-play-release-notes-check.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Validate concise, reviewed Google Play release notes.
+set -euo pipefail
+
+notes_path="${1:-Apps/Android/distribution/whatsnew/whatsnew-en-US}"
+max_characters=500
+
+fail() {
+  printf 'Play release notes check failed: %s\n' "$1" >&2
+  exit 1
+}
+
+[[ -f "$notes_path" ]] || fail "missing ${notes_path}"
+
+character_count="$(wc -m < "$notes_path" | tr -d '[:space:]')"
+((character_count > 0)) || fail "${notes_path} is empty"
+((character_count <= max_characters)) ||
+  fail "${notes_path} is ${character_count} characters; Google Play allows ${max_characters}"
+
+if ! awk '
+  BEGIN { bullets = 0; invalid = 0 }
+  /^[[:space:]]*$/ { next }
+  /^- .+/ { bullets++; next }
+  { invalid = 1 }
+  END { if (invalid || bullets < 1 || bullets > 5) exit 1 }
+' "$notes_path"; then
+  fail "use 1-5 plain-text bullet points"
+fi
+
+if grep -Eiq '^- (feat|fix|perf|refactor|chore|build|test|style)(\([^)]+\))?!?:' "$notes_path"; then
+  fail "contains a Conventional Commit title instead of tester-facing copy"
+fi
+
+if grep -Eq '#[0-9]+|(^|[[:space:](])[0-9a-f]{7,40}([[:space:])]|$)|\.(swift|kt|kts|sh|yml|yaml)([^[:alpha:]]|$)' "$notes_path"; then
+  fail "contains an issue, commit, or source-file reference"
+fi
+
+printf 'Play release notes check passed (%s characters).\n' "$character_count"

--- a/scripts/verify-android-bundle-signing.sh
+++ b/scripts/verify-android-bundle-signing.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Require both Play bundles to be signed by the configured upload-key alias.
+set -euo pipefail
+
+fail() {
+  printf 'Android bundle signing check failed: %s\n' "$1" >&2
+  exit 1
+}
+
+[[ $# -ge 1 ]] || fail "pass at least one .aab path"
+: "${ANDROID_KEYSTORE_PATH:?ANDROID_KEYSTORE_PATH is required}"
+: "${ANDROID_KEYSTORE_PASSWORD:?ANDROID_KEYSTORE_PASSWORD is required}"
+: "${ANDROID_KEY_ALIAS:?ANDROID_KEY_ALIAS is required}"
+
+fingerprint_from_keystore="$({
+  keytool -list -v \
+    -keystore "$ANDROID_KEYSTORE_PATH" \
+    -storepass "$ANDROID_KEYSTORE_PASSWORD" \
+    -alias "$ANDROID_KEY_ALIAS"
+} | sed -n 's/^[[:space:]]*SHA256: //p' | tr -d ':')"
+
+[[ -n "$fingerprint_from_keystore" ]] || fail "could not read the upload-key SHA-256 fingerprint"
+
+for bundle_path in "$@"; do
+  [[ -f "$bundle_path" ]] || fail "missing ${bundle_path}"
+  jarsigner -verify "$bundle_path" >/dev/null || fail "${bundle_path} has an invalid JAR signature"
+
+  fingerprint_from_bundle="$({ keytool -printcert -jarfile "$bundle_path"; } |
+    sed -n 's/^[[:space:]]*SHA256: //p' | tr -d ':')"
+  [[ -n "$fingerprint_from_bundle" ]] || fail "could not read the signer for ${bundle_path}"
+  [[ "$fingerprint_from_bundle" == "$fingerprint_from_keystore" ]] ||
+    fail "${bundle_path} is not signed by alias ${ANDROID_KEY_ALIAS}"
+
+  printf 'Verified %s (signer SHA-256 %s).\n' "$bundle_path" "$fingerprint_from_bundle"
+done

--- a/scripts/verify-android-bundle-signing.sh
+++ b/scripts/verify-android-bundle-signing.sh
@@ -7,13 +7,30 @@ fail() {
   exit 1
 }
 
+resolve_java_tool() {
+  local tool_name="$1"
+  local java_home
+
+  for java_home in "${JAVA_HOME:-}" /opt/homebrew/opt/openjdk /usr/local/opt/openjdk; do
+    if [[ -n "$java_home" && -x "$java_home/bin/$tool_name" ]]; then
+      printf '%s\n' "$java_home/bin/$tool_name"
+      return
+    fi
+  done
+
+  command -v "$tool_name" || fail "could not locate ${tool_name}; set JAVA_HOME to a JDK"
+}
+
 [[ $# -ge 1 ]] || fail "pass at least one .aab path"
 : "${ANDROID_KEYSTORE_PATH:?ANDROID_KEYSTORE_PATH is required}"
 : "${ANDROID_KEYSTORE_PASSWORD:?ANDROID_KEYSTORE_PASSWORD is required}"
 : "${ANDROID_KEY_ALIAS:?ANDROID_KEY_ALIAS is required}"
 
+keytool_path="$(resolve_java_tool keytool)"
+jarsigner_path="$(resolve_java_tool jarsigner)"
+
 fingerprint_from_keystore="$({
-  keytool -list -v \
+  "$keytool_path" -list -v \
     -keystore "$ANDROID_KEYSTORE_PATH" \
     -storepass "$ANDROID_KEYSTORE_PASSWORD" \
     -alias "$ANDROID_KEY_ALIAS"
@@ -23,9 +40,10 @@ fingerprint_from_keystore="$({
 
 for bundle_path in "$@"; do
   [[ -f "$bundle_path" ]] || fail "missing ${bundle_path}"
-  jarsigner -verify "$bundle_path" >/dev/null || fail "${bundle_path} has an invalid JAR signature"
+  "$jarsigner_path" -verify "$bundle_path" >/dev/null ||
+    fail "${bundle_path} has an invalid JAR signature"
 
-  fingerprint_from_bundle="$({ keytool -printcert -jarfile "$bundle_path"; } |
+  fingerprint_from_bundle="$({ "$keytool_path" -printcert -jarfile "$bundle_path"; } |
     sed -n 's/^[[:space:]]*SHA256: //p' | tr -d ':')"
   [[ -n "$fingerprint_from_bundle" ]] || fail "could not read the signer for ${bundle_path}"
   [[ "$fingerprint_from_bundle" == "$fingerprint_from_keystore" ]] ||


### PR DESCRIPTION
## What & why

Hardens the existing phone + Wear OS Google Play internal-testing workflow so it can be activated safely once Play Console and signing credentials are provisioned.

- gates uploads behind the disabled-by-default `PLAY_UPLOAD_ENABLED` repository variable
- rejects manual runs outside `main`, mismatched `android-v<version>` tags, and tag commits not on `main`
- preflights every signing/Play credential and validates both AAB certificates against the configured upload-key alias
- replaces the deprecated `track` action input, uploads R8 mappings, and adds reviewed Play release notes
- makes Play workflow/release-tool changes exercise Android CI and documents the exact bootstrap/activation sequence

This is intentionally Android-only packaging/distribution infrastructure; it does not change product behavior or create an iOS parity obligation.

Relates to #81 / OPE-38. The PR remains draft until the external Play Console app, upload key, service account, first manual phone/Wear releases, and tester opt-in links are verified.

## Google Play notes

No tester-visible behavior changes. The initial internal-track notes ask testers to exercise their normal camera, recording, live-view, and Wear workflows.

## Verification

- `just android-check`
- `just android-release-check`
- `just check` (clean sequential run)
- `actionlint .github/workflows/play-internal.yml .github/workflows/ci.yml`
- `shellcheck` on the three new shell scripts
- release-ref guard positive/negative cases
- bundle-signature verifier exercised with two temporary signed AAB-shaped JARs

## External setup status

- [x] GitHub `play` environment created and restricted to `main` plus `android-v*` tags
- [x] `PLAY_UPLOAD_ENABLED=false` repository variable created
- [x] Play Console app and Wear form factor configured
- [ ] Upload key generated and enrolled with Play App Signing; encrypted backup confirmation pending
- [x] Android Publisher API service account granted app-scoped testing-release access
- [x] First signed phone and Wear AABs uploaded manually
- [x] Internal tester lists and opt-in links verified
- [x] Five `play` environment secrets populated
- [ ] Upload switch enabled and first automated run verified