### PR TITLE
feat: playback desqueeze (1.6x/custom) and Auto ISO On/Off

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ clean, exemplary engineering standards.
 - **Jetpack Compose / Kotlin** — production Android app shell and Android platform adapters.
 - **Swift SDK for Android** — production bridge path for the shared Swift core. Keep the facade/JNI
   boundary small and verify build, packaging, and runtime behavior through the Android gates.
+  Camera-control writes: core/facade encode and confirm; Kotlin maps failures only — see
+  `docs/android-control-writes.md`.
 - **Flutter / Dart** — archived prototype reference only; not part of production tooling.
 - **just** — the single entry point for all repository tasks. Run `just` to list recipes.
 - **swift-format / swift test / xcodebuild** — production formatting, tests, and iOS build checks.
@@ -34,7 +36,8 @@ Install local tooling with `just setup` (macOS / Homebrew).
 - `ref/` — **gitignored** local reference material.
 - `docs/` — engineering references: `commit-hygiene.md` (what must never be committed),
   `nikon-mtp.md` (protocol sourcing and maintenance policy), `nikon-sdk.md` (no-vendor-SDK policy),
-  `PROJECT-MANAGEMENT.md` (Kaneo board conventions + agent sync contract).
+  `android-control-writes.md` (Android control write authority — no soft second-guess after
+  native accept), `PROJECT-MANAGEMENT.md` (Kaneo board conventions + agent sync contract).
 - `docs/design/` — design specs, implementation plans, and archived browser prototypes.
 - `docs/investigations/` — resolved or pending engineering investigations and debugging records.
 - `site/` — deploy-ready GitHub Pages landing page; no raw design sources.

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/AssistToolbar.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/AssistToolbar.kt
@@ -649,11 +649,10 @@ fun AssistToolbar(
                                     if (capBlocked) {
                                         onScopeLimitReached()
                                     } else {
-                                        if (hapticsEnabled) {
-                                            view.performHapticFeedback(
-                                                HapticFeedbackConstants.LONG_PRESS,
-                                            )
-                                        }
+                                        view.performOperatorHaptic(
+                                            HapticFeedbackConstants.LONG_PRESS,
+                                            enabled = hapticsEnabled,
+                                        )
                                         onLongPressToolAnchored?.invoke(
                                             tool,
                                             toolbarBounds ?: anchor,
@@ -675,7 +674,7 @@ fun AssistToolbar(
                             return@AssistToolCell
                         }
                         if (hapticsEnabled) {
-                            view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                            view.performOperatorHaptic(HapticFeedbackConstants.KEYBOARD_TAP)
                         }
                     }
                 }
@@ -781,7 +780,7 @@ internal fun PortraitFillAssistRail(
                     ) {
                         { anchor ->
                             if (hapticsEnabled) {
-                                view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                                view.performOperatorHaptic(HapticFeedbackConstants.LONG_PRESS)
                             }
                             onLongPressToolAnchored?.invoke(tool, anchor)
                                 ?: onLongPressTool?.invoke(tool)
@@ -796,7 +795,7 @@ internal fun PortraitFillAssistRail(
                     state.toggle(tool)
                 }
                 if (hapticsEnabled) {
-                    view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                    view.performOperatorHaptic(HapticFeedbackConstants.KEYBOARD_TAP)
                 }
             }
         }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/CommandMonitor.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/CommandMonitor.kt
@@ -547,22 +547,23 @@ internal fun commandDashboardPresentation(
                 run {
                     val isoValue = snapshot.iso?.takeIf { it > 0 }?.toString()
                     val cameraIso = capabilities.options(CameraControl.ISO)
-                    // Capture bar always uses IsoPickerPolicy ladders; keep the command
-                    // tile writable with the same union when the body has not yet named
-                    // a dual-base circuit (otherwise ISO padlocks with "wait for base").
+                    // Always keep the policy ladder available so Auto ISO codecs never
+                    // padlock the drum — operators exit auto by choosing a value.
                     val isoOptions =
                         cameraIso.ifEmpty {
-                            when {
-                                codec == null -> emptyList()
-                                IsoPickerPolicy.showsDualBaseCircuits(codec) ->
-                                    IsoPickerPolicy.unifiedOptions
-                                else -> IsoPickerPolicy.unifiedOptions
-                            }
+                            if (codec == null) emptyList() else IsoPickerPolicy.unifiedOptions
                         }
+                    val displayValue =
+                        isoValue
+                            ?: if (IsoPickerPolicy.isAutoISOActive(snapshot.exposureMode)) {
+                                "Auto"
+                            } else {
+                                null
+                            }
                     editable(
                         kind = CommandTileKind.ISO,
                         title = strings.resolve(R.string.command_title_iso),
-                        value = isoValue,
+                        value = displayValue,
                         control = CameraControl.ISO,
                         options = isoOptions,
                         writable = !isoLockedDuringRecording && isoOptions.isNotEmpty(),

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/CommandMonitor.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/CommandMonitor.kt
@@ -554,12 +554,10 @@ internal fun commandDashboardPresentation(
                             if (codec == null) emptyList() else IsoPickerPolicy.unifiedOptions
                         }
                     val displayValue =
-                        isoValue
-                            ?: if (IsoPickerPolicy.isAutoISOActive(snapshot.exposureMode)) {
-                                "Auto"
-                            } else {
-                                null
-                            }
+                        when {
+                            IsoPickerPolicy.isAutoISOActive(snapshot.isoAuto) -> "Auto"
+                            else -> isoValue
+                        }
                     editable(
                         kind = CommandTileKind.ISO,
                         title = strings.resolve(R.string.command_title_iso),
@@ -952,6 +950,11 @@ internal fun cameraPropertyConfirmsSelection(
 ): Boolean =
     when (control) {
         CameraControl.ISO -> snapshot.iso?.toString() == label
+        CameraControl.ISO_AUTO ->
+            snapshot.isoAuto?.let { auto ->
+                (if (auto) IsoPickerPolicy.AUTO_ISO_ON_LABEL else IsoPickerPolicy.AUTO_ISO_OFF_LABEL) ==
+                    label
+            } == true
         CameraControl.SHUTTER ->
             when (snapshot.shutterMode) {
                 CameraShutterMode.ANGLE -> snapshot.shutterAngle == label

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/CommandMonitor.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/CommandMonitor.kt
@@ -555,7 +555,9 @@ internal fun commandDashboardPresentation(
                         }
                     val displayValue =
                         when {
-                            IsoPickerPolicy.isAutoISOActive(snapshot.isoAuto) -> "Auto"
+                            // Show the body's working ISO while Auto is on (drum is locked).
+                            IsoPickerPolicy.isAutoISOActive(snapshot.isoAuto) ->
+                                isoValue?.let { "A$it" } ?: "Auto"
                             else -> isoValue
                         }
                     editable(

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/FramingAssists.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/FramingAssists.kt
@@ -85,7 +85,7 @@ internal fun localFramingRenderPlan(
         localDesqueezePresentationRect(
             feed = feed,
             enabled = configuration.desqueezeEnabled,
-            ratio = configuration.desqueezeRatio,
+            factor = configuration.desqueezeFactor,
             orientation = configuration.desqueezeOrientation,
         )
     val guideFrames =
@@ -138,13 +138,14 @@ internal fun localFramingRenderPlan(
 internal fun localDesqueezePresentationRect(
     feed: FramingAssistRect,
     enabled: Boolean,
-    ratio: LocalDesqueezeRatio,
+    factor: Float,
     orientation: LocalDesqueezeOrientation,
 ): FramingAssistRect {
-    if (!enabled || ratio.factor <= 1f || feed.width <= 0f || feed.height <= 0f) return feed
+    val squeeze = factor.coerceAtLeast(1f)
+    if (!enabled || squeeze <= 1f || feed.width <= 0f || feed.height <= 0f) return feed
     return when (orientation) {
         LocalDesqueezeOrientation.HORIZONTAL -> {
-            val width = feed.width / ratio.factor
+            val width = feed.width / squeeze
             FramingAssistRect(
                 left = feed.centerX - width / 2f,
                 top = feed.top,
@@ -153,7 +154,7 @@ internal fun localDesqueezePresentationRect(
             )
         }
         LocalDesqueezeOrientation.VERTICAL -> {
-            val height = feed.height / ratio.factor
+            val height = feed.height / squeeze
             FramingAssistRect(
                 left = feed.left,
                 top = feed.centerY - height / 2f,
@@ -342,10 +343,12 @@ private fun localFramingAssistAccessibilitySummary(
                 )
             val ratio =
                 stringResource(
-                    when (configuration.desqueezeRatio) {
+                    when (LocalDesqueezeRatio.matching(configuration.desqueezeFactor)
+                        ?: configuration.desqueezeRatio) {
                         LocalDesqueezeRatio.X100 -> R.string.desqueeze_1
                         LocalDesqueezeRatio.X133 -> R.string.desqueeze_133
                         LocalDesqueezeRatio.X150 -> R.string.desqueeze_15
+                        LocalDesqueezeRatio.X160 -> R.string.desqueeze_16
                         LocalDesqueezeRatio.X165 -> R.string.desqueeze_165
                         LocalDesqueezeRatio.X180 -> R.string.desqueeze_18
                         LocalDesqueezeRatio.X200 -> R.string.desqueeze_2

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/IsoPickerPolicy.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/IsoPickerPolicy.kt
@@ -4,8 +4,7 @@ package com.opencapture.openzcine
  * ISO picker layout and recording-lock rules for Nikon ZR dual-base sensitivity.
  *
  * 1:1 with `Sources/OpenZCineCore/ISOPickerPolicy.swift`. R3D NE exposes separate
- * low/high base ISO circuits; other codecs keep dual-base hardware but
- * auto-switch, so the operator sees one drum with native-base markers.
+ * low/high base ISO circuits; other codecs use Auto On/Off plus a unified drum.
  */
 internal object IsoPickerPolicy {
     /** Low-base ISO steps (200–3200). */
@@ -50,6 +49,12 @@ internal object IsoPickerPolicy {
     /** Native high-base ISO flagged in the drum. */
     const val HIGH_BASE_MARKER: String = "6400"
 
+    /** Exposure mode that enables camera-managed ISO. */
+    const val AUTO_ISO_ON_EXPOSURE_MODE: String = "Auto"
+
+    /** Exposure mode that releases ISO for the drum. */
+    const val AUTO_ISO_OFF_EXPOSURE_MODE: String = "M"
+
     /** Single-drum ISO steps for codecs that auto-switch base circuits. */
     val unifiedOptions: List<String> =
         (lowBaseOptions + highBaseOptions).distinct()
@@ -60,7 +65,6 @@ internal object IsoPickerPolicy {
             codec
                 .trim()
                 .let { raw ->
-                    // Match MonitorTextFormat.codecShortLabel for R3D NE detection.
                     when {
                         raw.contains("R3D", ignoreCase = true) &&
                             raw.contains("NE", ignoreCase = true) -> "R3D NE"
@@ -70,8 +74,25 @@ internal object IsoPickerPolicy {
         return short == "R3D NE"
     }
 
-    /** R3D NE keeps separate LOW/HIGH base drums; every other codec uses a unified drum. */
+    /** R3D NE keeps separate LOW/HIGH base drums. */
     fun showsDualBaseCircuits(codec: String): Boolean = isR3DNECodec(codec)
+
+    /** Non-R3D NE codecs use Auto On/Off tabs. */
+    fun showsAutoISOControl(codec: String): Boolean = !showsDualBaseCircuits(codec)
+
+    /** Exposure modes where the body typically owns ISO. */
+    fun isAutoISOActive(exposureMode: String?): Boolean {
+        val mode = exposureMode?.trim().orEmpty()
+        if (mode.isEmpty()) return false
+        return when (mode) {
+            "Auto", "P", "A", "S" -> true
+            else -> mode.contains("auto", ignoreCase = true)
+        }
+    }
+
+    /** Active Auto tab: 0 = Auto On, 1 = Auto Off. */
+    fun autoISOModeIndex(exposureMode: String?): Int =
+        if (isAutoISOActive(exposureMode)) 0 else 1
 
     /** ISO cannot be changed while recording in R3D NE. */
     fun blocksISOChangeWhileRecording(codec: String, isRecording: Boolean): Boolean =
@@ -91,27 +112,48 @@ internal object IsoPickerPolicy {
 
     /** Subtitle shown under the ISO picker header. */
     fun pickerSubtitle(codec: String): String =
-        if (showsDualBaseCircuits(codec)) "Sensitivity · dual base" else "Sensitivity"
+        when {
+            showsDualBaseCircuits(codec) -> "Sensitivity · dual base"
+            showsAutoISOControl(codec) -> "Sensitivity · auto / manual"
+            else -> "Sensitivity"
+        }
 
-    /** Mode tabs for the ISO picker. Empty when the unified drum is shown. */
+    /** Mode tabs for the ISO picker. */
     fun pickerModes(codec: String): List<IsoPickerMode> =
-        if (!showsDualBaseCircuits(codec)) {
-            emptyList()
-        } else {
-            listOf(
-                IsoPickerMode(
-                    title = "Low Base",
-                    detail = "$LOW_BASE_MARKER · 200-3200",
-                    options = lowBaseOptions,
-                    base = LOW_BASE_MARKER,
-                ),
-                IsoPickerMode(
-                    title = "High Base",
-                    detail = "$HIGH_BASE_MARKER · 1600-25600",
-                    options = highBaseOptions,
-                    base = HIGH_BASE_MARKER,
-                ),
-            )
+        when {
+            showsDualBaseCircuits(codec) ->
+                listOf(
+                    IsoPickerMode(
+                        title = "Low Base",
+                        detail = "$LOW_BASE_MARKER · 200-3200",
+                        options = lowBaseOptions,
+                        base = LOW_BASE_MARKER,
+                    ),
+                    IsoPickerMode(
+                        title = "High Base",
+                        detail = "$HIGH_BASE_MARKER · 1600-25600",
+                        options = highBaseOptions,
+                        base = HIGH_BASE_MARKER,
+                    ),
+                )
+            showsAutoISOControl(codec) ->
+                listOf(
+                    IsoPickerMode(
+                        title = "Auto On",
+                        detail = "Camera controls ISO",
+                        options = unifiedOptions,
+                        base = LOW_BASE_MARKER,
+                        activatesAutoISO = true,
+                    ),
+                    IsoPickerMode(
+                        title = "Auto Off",
+                        detail = "Manual ISO",
+                        options = unifiedOptions,
+                        base = LOW_BASE_MARKER,
+                        activatesAutoISO = false,
+                    ),
+                )
+            else -> emptyList()
         }
 
     /** Options for the active ISO layout and mode tab. */
@@ -125,10 +167,11 @@ internal object IsoPickerPolicy {
     }
 }
 
-/** One segmented mode under the ISO picker (LOW/HIGH base for R3D NE). */
+/** One segmented mode under the ISO picker (LOW/HIGH base or Auto On/Off). */
 internal data class IsoPickerMode(
     val title: String,
     val detail: String?,
     val options: List<String>,
     val base: String,
+    val activatesAutoISO: Boolean? = null,
 )

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/IsoPickerPolicy.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/IsoPickerPolicy.kt
@@ -5,6 +5,7 @@ package com.opencapture.openzcine
  *
  * 1:1 with `Sources/OpenZCineCore/ISOPickerPolicy.swift`. R3D NE exposes separate
  * low/high base ISO circuits; other codecs use Auto On/Off plus a unified drum.
+ * Auto Off / manual ISO is only offered in exposure mode **M**.
  */
 internal object IsoPickerPolicy {
     /** Low-base ISO steps (200–3200). */
@@ -86,9 +87,43 @@ internal object IsoPickerPolicy {
      */
     fun isAutoISOActive(isoAuto: Boolean?): Boolean = isoAuto == true
 
-    /** Active Auto tab: 0 = Auto On, 1 = Auto Off. */
-    fun autoISOModeIndex(isoAuto: Boolean?): Int =
-        if (isAutoISOActive(isoAuto)) 0 else 1
+    /**
+     * Whether the operator may write a manual movie ISO for this codec / mode.
+     *
+     * - **R3D NE**: always manual dual-base (even in A/S/P).
+     * - **Other codecs**: only exposure mode **M** (Auto Off + drum). Fail closed when unknown.
+     */
+    fun allowsManualISO(codec: String, exposureMode: String?): Boolean =
+        if (showsDualBaseCircuits(codec)) true else exposureMode == "M"
+
+    /**
+     * True when the ISO value drum is camera-owned (Auto On, or non-R3D mode is not M).
+     * Always false for R3D NE dual-base (recording lock is separate).
+     */
+    fun isISOValueCameraOwned(
+        codec: String,
+        isoAuto: Boolean?,
+        exposureMode: String?,
+    ): Boolean =
+        if (showsDualBaseCircuits(codec)) {
+            false
+        } else {
+            isAutoISOActive(isoAuto) || !allowsManualISO(codec, exposureMode)
+        }
+
+    /** Active Auto tab: 0 = Auto On, 1 = Auto Off (when M allows manual on non-R3D). */
+    fun autoISOModeIndex(
+        codec: String,
+        isoAuto: Boolean?,
+        exposureMode: String? = null,
+    ): Int =
+        if (!allowsManualISO(codec, exposureMode)) {
+            0
+        } else if (isAutoISOActive(isoAuto)) {
+            0
+        } else {
+            1
+        }
 
     /** ISO cannot be changed while recording in R3D NE. */
     fun blocksISOChangeWhileRecording(codec: String, isRecording: Boolean): Boolean =
@@ -107,15 +142,17 @@ internal object IsoPickerPolicy {
         }
 
     /** Subtitle shown under the ISO picker header. */
-    fun pickerSubtitle(codec: String): String =
+    fun pickerSubtitle(codec: String, exposureMode: String? = null): String =
         when {
             showsDualBaseCircuits(codec) -> "Sensitivity · dual base"
-            showsAutoISOControl(codec) -> "Sensitivity · auto / manual"
+            showsAutoISOControl(codec) && allowsManualISO(codec, exposureMode) ->
+                "Sensitivity · auto / manual"
+            showsAutoISOControl(codec) -> "Sensitivity · auto (M mode for manual)"
             else -> "Sensitivity"
         }
 
-    /** Mode tabs for the ISO picker. */
-    fun pickerModes(codec: String): List<IsoPickerMode> =
+    /** Mode tabs for the ISO picker. Auto Off only when exposure mode is M (non-R3D). */
+    fun pickerModes(codec: String, exposureMode: String? = null): List<IsoPickerMode> =
         when {
             showsDualBaseCircuits(codec) ->
                 listOf(
@@ -133,33 +170,60 @@ internal object IsoPickerPolicy {
                     ),
                 )
             showsAutoISOControl(codec) ->
-                listOf(
-                    IsoPickerMode(
-                        title = "Auto On",
-                        detail = "Camera controls ISO",
-                        options = unifiedOptions,
-                        base = LOW_BASE_MARKER,
-                        activatesAutoISO = true,
-                    ),
-                    IsoPickerMode(
-                        title = "Auto Off",
-                        detail = "Manual ISO",
-                        options = unifiedOptions,
-                        base = LOW_BASE_MARKER,
-                        activatesAutoISO = false,
-                    ),
-                )
+                buildList {
+                    add(
+                        IsoPickerMode(
+                            title = "Auto On",
+                            detail = "Camera controls ISO",
+                            options = unifiedOptions,
+                            base = LOW_BASE_MARKER,
+                            activatesAutoISO = true,
+                        ),
+                    )
+                    if (allowsManualISO(codec, exposureMode)) {
+                        add(
+                            IsoPickerMode(
+                                title = "Auto Off",
+                                detail = "Manual ISO",
+                                options = unifiedOptions,
+                                base = LOW_BASE_MARKER,
+                                activatesAutoISO = false,
+                            ),
+                        )
+                    }
+                }
             else -> emptyList()
         }
 
-    /** Options for the active ISO layout and mode tab. */
-    fun options(codec: String, modeIndex: Int): List<String> {
+    /**
+     * Options for the active ISO layout and mode tab.
+     * Injects [includingLiveISO] when Auto is outside the fixed ladder (e.g. 51200).
+     */
+    fun options(
+        codec: String,
+        modeIndex: Int,
+        includingLiveISO: String? = null,
+    ): List<String> {
         val modes = pickerModes(codec)
-        return if (modes.isEmpty() || modeIndex !in modes.indices) {
-            unifiedOptions
-        } else {
-            modes[modeIndex].options
+        val base =
+            if (modes.isEmpty() || modeIndex !in modes.indices) {
+                unifiedOptions
+            } else {
+                modes[modeIndex].options
+            }
+        val live = includingLiveISO?.trim().orEmpty()
+        if (live.isEmpty() || !live.all { it.isDigit() } || live in base) {
+            return base
         }
+        val liveValue = live.toLongOrNull() ?: return base + live
+        val mutable = base.toMutableList()
+        val insertAt = mutable.indexOfFirst { (it.toLongOrNull() ?: Long.MAX_VALUE) > liveValue }
+        if (insertAt < 0) {
+            mutable.add(live)
+        } else {
+            mutable.add(insertAt, live)
+        }
+        return mutable
     }
 }
 

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/IsoPickerPolicy.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/IsoPickerPolicy.kt
@@ -49,11 +49,11 @@ internal object IsoPickerPolicy {
     /** Native high-base ISO flagged in the drum. */
     const val HIGH_BASE_MARKER: String = "6400"
 
-    /** Exposure mode that enables camera-managed ISO. */
-    const val AUTO_ISO_ON_EXPOSURE_MODE: String = "Auto"
+    /** Label written for Auto On (`MovISOAutoControl` UINT8 = 1). */
+    const val AUTO_ISO_ON_LABEL: String = "ON"
 
-    /** Exposure mode that releases ISO for the drum. */
-    const val AUTO_ISO_OFF_EXPOSURE_MODE: String = "M"
+    /** Label written for Auto Off (`MovISOAutoControl` UINT8 = 0). */
+    const val AUTO_ISO_OFF_LABEL: String = "OFF"
 
     /** Single-drum ISO steps for codecs that auto-switch base circuits. */
     val unifiedOptions: List<String> =
@@ -80,19 +80,15 @@ internal object IsoPickerPolicy {
     /** Non-R3D NE codecs use Auto On/Off tabs. */
     fun showsAutoISOControl(codec: String): Boolean = !showsDualBaseCircuits(codec)
 
-    /** Exposure modes where the body typically owns ISO. */
-    fun isAutoISOActive(exposureMode: String?): Boolean {
-        val mode = exposureMode?.trim().orEmpty()
-        if (mode.isEmpty()) return false
-        return when (mode) {
-            "Auto", "P", "A", "S" -> true
-            else -> mode.contains("auto", ignoreCase = true)
-        }
-    }
+    /**
+     * Whether movie ISO auto is active (`MovISOAutoControl` 0xD0AD).
+     * Independent of exposure-program Auto (P/A/S/M). Unpolled (`null`) → manual.
+     */
+    fun isAutoISOActive(isoAuto: Boolean?): Boolean = isoAuto == true
 
     /** Active Auto tab: 0 = Auto On, 1 = Auto Off. */
-    fun autoISOModeIndex(exposureMode: String?): Int =
-        if (isAutoISOActive(exposureMode)) 0 else 1
+    fun autoISOModeIndex(isoAuto: Boolean?): Int =
+        if (isAutoISOActive(isoAuto)) 0 else 1
 
     /** ISO cannot be changed while recording in R3D NE. */
     fun blocksISOChangeWhileRecording(codec: String, isRecording: Boolean): Boolean =

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/IsoPickerPolicy.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/IsoPickerPolicy.kt
@@ -78,8 +78,15 @@ internal object IsoPickerPolicy {
     /** R3D NE keeps separate LOW/HIGH base drums. */
     fun showsDualBaseCircuits(codec: String): Boolean = isR3DNECodec(codec)
 
-    /** Non-R3D NE codecs use Auto On/Off tabs. */
-    fun showsAutoISOControl(codec: String): Boolean = !showsDualBaseCircuits(codec)
+    /**
+     * Non-R3D NE codecs use Auto On/Off tabs.
+     * Empty/unknown codec stays closed until the body reports a real file type.
+     */
+    fun showsAutoISOControl(codec: String): Boolean {
+        val trimmed = codec.trim()
+        if (trimmed.isEmpty()) return false
+        return !showsDualBaseCircuits(trimmed)
+    }
 
     /**
      * Whether movie ISO auto is active (`MovISOAutoControl` 0xD0AD).

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/LiveFeedView.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/LiveFeedView.kt
@@ -842,7 +842,7 @@ internal fun FalseColorReferenceOverlay(
                     onDragStart = {
                         isDragging = true
                         if (hapticsEnabled) {
-                            view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                            view.performOperatorHaptic(HapticFeedbackConstants.LONG_PRESS)
                         }
                     },
                     onDragEnd = {
@@ -868,7 +868,7 @@ internal fun FalseColorReferenceOverlay(
                     if (cell != hapticCell) {
                         hapticCell = cell
                         if (hapticsEnabled) {
-                            view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                            view.performOperatorHaptic(HapticFeedbackConstants.KEYBOARD_TAP)
                         }
                     }
                     frame = snapped

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
@@ -183,6 +184,9 @@ class MainActivity : ComponentActivity() {
             // branded splash is LaunchSplashOverlay (rounded logo + wordmark).
             SideEffect { composeFirstFrameDrawn.set(true) }
             OpenZCineTheme {
+                val operatorHaptics =
+                    rememberOperatorHaptics { operatorSettings.hapticsEnabled.value }
+                CompositionLocalProvider(LocalOperatorHaptics provides operatorHaptics) {
                 Box(Modifier.fillMaxSize()) {
                 var monitorSession by remember { mutableStateOf(debugSession) }
                 // A monitor reached from a saved card retains that exact
@@ -758,8 +762,9 @@ class MainActivity : ComponentActivity() {
                     )
                 }
                 } // app-root Box
-            }
-        }
+                } // LocalOperatorHaptics
+            } // OpenZCineTheme
+        } // setContent
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean =

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorCameraControls.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorCameraControls.kt
@@ -247,6 +247,8 @@ internal fun monitorCaptureSettings(
     shutterLockedOnCamera: Boolean? = null,
     /** Movie ISO auto (`MovISOAutoControl`); drives Auto On/Off tab for non-R3D NE. */
     isoAuto: Boolean? = null,
+    /** Exposure program mode (M/P/A/S/…); Auto Off / manual ISO only in M. */
+    exposureMode: String? = null,
 ): List<MonitorCaptureSettingPresentation> {
     val primary = dashboard.tiles.associateBy(CommandTilePresentation::kind)
     val focus =
@@ -339,6 +341,7 @@ internal fun monitorCaptureSettings(
             codec = codec,
             baseIsoTile = exposure.getOrNull(0),
             isoAuto = isoAuto,
+            exposureMode = exposureMode,
             strings = strings,
         )
     val shutterPresentation =
@@ -773,6 +776,7 @@ internal fun shutterPickerPresentation(
  *
  * - R3D NE: Low Base / High Base tabs with full ladders + base-ISO activate.
  * - Other codecs: Auto On / Auto Off tabs + unified drum (exit auto by picking ISO).
+ * - Auto Off / manual drum only when [exposureMode] is **M**.
  * Options always come from the policy (not a partial camera enum).
  */
 internal fun isoPickerPresentation(
@@ -780,6 +784,7 @@ internal fun isoPickerPresentation(
     codec: String,
     baseIsoTile: CommandTilePresentation?,
     isoAuto: Boolean?,
+    exposureMode: String?,
     strings: PhoneStringResolver,
 ): MonitorPickerPresentation? {
     // Prefer live ISO. Auto-mode tiles may read "A3200" / "Auto" — strip the Auto prefix for the drum.
@@ -797,14 +802,27 @@ internal fun isoPickerPresentation(
     val dual = IsoPickerPolicy.showsDualBaseCircuits(codec)
     val autoControl = IsoPickerPolicy.showsAutoISOControl(codec)
     val title = strings.resolve(R.string.camera_label_iso)
-    val subtitle = IsoPickerPolicy.pickerSubtitle(codec)
-    val options = IsoPickerPolicy.unifiedOptions
-    val current = live?.takeIf { it in options } ?: options.firstOrNull() ?: return null
+    val subtitle = IsoPickerPolicy.pickerSubtitle(codec, exposureMode)
+    val ladder = IsoPickerPolicy.unifiedOptions
+    // Inject Auto-driven values outside the fixed ladder (e.g. 51200).
+    val options =
+        if (live != null && live !in ladder) {
+            IsoPickerPolicy.options(codec, 0, includingLiveISO = live)
+        } else {
+            ladder
+        }
+    val current = live?.takeIf { it in options } ?: live ?: options.firstOrNull() ?: return null
 
     if (autoControl) {
         val modes =
-            IsoPickerPolicy.pickerModes(codec).map { mode ->
+            IsoPickerPolicy.pickerModes(codec, exposureMode).map { mode ->
                 val activatesAuto = mode.activatesAutoISO == true
+                val modeOptions =
+                    IsoPickerPolicy.options(
+                        codec = codec,
+                        modeIndex = 0,
+                        includingLiveISO = live,
+                    )
                 MonitorPickerModePresentation(
                     label = mode.title,
                     detail = mode.detail,
@@ -813,7 +831,7 @@ internal fun isoPickerPresentation(
                             title = title,
                             control = CameraControl.ISO,
                             currentValue = current,
-                            options = mode.options,
+                            options = modeOptions,
                         ),
                     activateRequest =
                         CommandControlRequest(
@@ -831,23 +849,31 @@ internal fun isoPickerPresentation(
                                     IsoPickerPolicy.AUTO_ISO_OFF_LABEL,
                                 ),
                         ),
-                    // Auto On does not write ISO; Auto Off writes the drum after manual.
-                    applyValueOnActivate = mode.activatesAutoISO != true,
+                    // Auto On: only MovISOAutoControl. Auto Off: turn auto off; do not
+                    // immediately re-write the live Auto value (it may sit outside the
+                    // manual ladder, e.g. 51200) — the operator picks a manual step next.
+                    applyValueOnActivate = false,
                     markedValues = IsoPickerPolicy.markedValues(codec, 0),
                 )
             }
-        val autoOn = IsoPickerPolicy.isAutoISOActive(isoAuto)
+        val cameraOwned =
+            IsoPickerPolicy.isISOValueCameraOwned(codec, isoAuto, exposureMode)
         return MonitorPickerPresentation(
             kind = MonitorPickerKind.ISO,
             title = title,
             subtitle = subtitle,
             modes = modes,
-            initialModeIndex = IsoPickerPolicy.autoISOModeIndex(isoAuto),
-            // Drum is camera-owned while Auto ISO is on; Auto On/Off tabs stay usable.
-            drumInteractionLocked = autoOn,
+            initialModeIndex =
+                IsoPickerPolicy.autoISOModeIndex(codec, isoAuto, exposureMode),
+            // Drum is camera-owned while Auto is on or (non-R3D) mode is not M.
+            drumInteractionLocked = cameraOwned,
             drumLockBanner =
-                if (autoOn) {
-                    strings.resolve(R.string.iso_auto_drum_locked)
+                if (cameraOwned) {
+                    if (IsoPickerPolicy.allowsManualISO(codec, exposureMode)) {
+                        strings.resolve(R.string.iso_auto_drum_locked)
+                    } else {
+                        strings.resolve(R.string.iso_manual_requires_m_mode)
+                    }
                 } else {
                     null
                 },
@@ -905,6 +931,7 @@ internal fun isoPickerPresentation(
                 markedValues = IsoPickerPolicy.markedValues(codec, index),
             )
         }
+    // R3D NE dual-base is always manual ISO (even in A/S/P) — never gate on exposure mode.
     return MonitorPickerPresentation(
         kind = MonitorPickerKind.ISO,
         title = title,

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorCameraControls.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorCameraControls.kt
@@ -239,6 +239,8 @@ internal fun monitorCaptureSettings(
     strings: PhoneStringResolver,
     /** Authoritative camera TV-lock when known; dims the shutter drum like iOS. */
     shutterLockedOnCamera: Boolean? = null,
+    /** Movie ISO auto (`MovISOAutoControl`); drives Auto On/Off tab for non-R3D NE. */
+    isoAuto: Boolean? = null,
 ): List<MonitorCaptureSettingPresentation> {
     val primary = dashboard.tiles.associateBy(CommandTilePresentation::kind)
     val focus =
@@ -325,15 +327,12 @@ internal fun monitorCaptureSettings(
             shutterTile?.unavailableReason != null &&
             shutterTile.value != "—" &&
             shutterTile.unavailableReason.contains("locked", ignoreCase = true)
-    val exposureMode =
-        primary[CommandTileKind.MODE]?.value?.takeIf { it != "—" }
-            ?: exposure.getOrNull(0)?.value?.takeIf { it != "—" }
     val isoPresentation =
         isoPickerPresentation(
             isoTile = isoTile,
             codec = codec,
             baseIsoTile = exposure.getOrNull(0),
-            exposureMode = exposureMode,
+            isoAuto = isoAuto,
             strings = strings,
         )
     val shutterPresentation =
@@ -774,7 +773,7 @@ internal fun isoPickerPresentation(
     isoTile: CommandTilePresentation?,
     codec: String,
     baseIsoTile: CommandTilePresentation?,
-    exposureMode: String?,
+    isoAuto: Boolean?,
     strings: PhoneStringResolver,
 ): MonitorPickerPresentation? {
     // Prefer live ISO; when Auto is driving ISO the body may report "—"/Auto — still open the drum.
@@ -808,28 +807,21 @@ internal fun isoPickerPresentation(
                         ),
                     activateRequest =
                         CommandControlRequest(
-                            title = strings.resolve(R.string.command_title_mode),
-                            control = CameraControl.EXPOSURE_MODE,
+                            title = title,
+                            control = CameraControl.ISO_AUTO,
                             currentValue =
                                 if (activatesAuto) {
-                                    IsoPickerPolicy.AUTO_ISO_ON_EXPOSURE_MODE
+                                    IsoPickerPolicy.AUTO_ISO_ON_LABEL
                                 } else {
-                                    IsoPickerPolicy.AUTO_ISO_OFF_EXPOSURE_MODE
+                                    IsoPickerPolicy.AUTO_ISO_OFF_LABEL
                                 },
                             options =
                                 listOf(
-                                    IsoPickerPolicy.AUTO_ISO_ON_EXPOSURE_MODE,
-                                    IsoPickerPolicy.AUTO_ISO_OFF_EXPOSURE_MODE,
-                                    "P",
-                                    "A",
-                                    "S",
-                                    "M",
-                                    "U1",
-                                    "U2",
-                                    "U3",
+                                    IsoPickerPolicy.AUTO_ISO_ON_LABEL,
+                                    IsoPickerPolicy.AUTO_ISO_OFF_LABEL,
                                 ),
                         ),
-                    // Auto On does not write ISO; Auto Off writes the drum after M.
+                    // Auto On does not write ISO; Auto Off writes the drum after manual.
                     applyValueOnActivate = mode.activatesAutoISO != true,
                     markedValues = IsoPickerPolicy.markedValues(codec, 0),
                 )
@@ -839,7 +831,7 @@ internal fun isoPickerPresentation(
             title = title,
             subtitle = subtitle,
             modes = modes,
-            initialModeIndex = IsoPickerPolicy.autoISOModeIndex(exposureMode),
+            initialModeIndex = IsoPickerPolicy.autoISOModeIndex(isoAuto),
         )
     }
 
@@ -1689,7 +1681,7 @@ private fun PickerPanelBody(
                                 // circuits (WB Kelvin↔Preset, ISO bases). Skip Tint
                                 // (pad only), Focus (independent tabs), Shutter
                                 // (mode write is activateRequest only), Auto ISO On
-                                // (exposure mode only — no ISO write while camera owns ISO).
+                                // (ISO auto only — no ISO write while camera owns ISO).
                                 val isTint =
                                     candidate.request.control == CameraControl.WHITE_BALANCE_TINT
                                 val skipApply =

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorCameraControls.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorCameraControls.kt
@@ -793,14 +793,18 @@ internal fun isoPickerPresentation(
             ?.takeIf { it != "—" }
             ?.removePrefix("A")
             ?.takeIf { !it.equals("Auto", ignoreCase = true) }
-    val canWrite = isoTile?.request != null || IsoPickerPolicy.showsAutoISOControl(codec)
-    if (!canWrite && isoTile?.unavailableReason == null && live == null &&
-        !IsoPickerPolicy.showsAutoISOControl(codec)
+    val dual = IsoPickerPolicy.showsDualBaseCircuits(codec)
+    val autoControl = IsoPickerPolicy.showsAutoISOControl(codec)
+    // Empty / non-writable ISO tile must not invent a unified drum. Require a live
+    // value, a camera-backed request, or a known Auto/dual-base codec layout.
+    if (
+        live == null &&
+            isoTile?.request == null &&
+            !autoControl &&
+            !dual
     ) {
         return null
     }
-    val dual = IsoPickerPolicy.showsDualBaseCircuits(codec)
-    val autoControl = IsoPickerPolicy.showsAutoISOControl(codec)
     val title = strings.resolve(R.string.camera_label_iso)
     val subtitle = IsoPickerPolicy.pickerSubtitle(codec, exposureMode)
     val ladder = IsoPickerPolicy.unifiedOptions

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorCameraControls.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorCameraControls.kt
@@ -112,9 +112,15 @@ internal data class MonitorPickerModePresentation(
     val detail: String? = null,
     /**
      * Optional write fired when this tab becomes active (iOS dual-base ISO
-     * switches `movieBaseISO` before the circuit's ISO drum is used).
+     * switches `movieBaseISO` before the circuit's ISO drum is used; Auto ISO
+     * switches exposure mode).
      */
     val activateRequest: CommandControlRequest? = null,
+    /**
+     * When false, activating the tab runs [activateRequest] only (Auto On).
+     * When true (default), also applies the drum [request] after activate.
+     */
+    val applyValueOnActivate: Boolean = true,
     /** Drum star markers for this tab (native base ISOs). */
     val markedValues: Set<String> = emptySet(),
 )
@@ -319,7 +325,17 @@ internal fun monitorCaptureSettings(
             shutterTile?.unavailableReason != null &&
             shutterTile.value != "—" &&
             shutterTile.unavailableReason.contains("locked", ignoreCase = true)
-    val isoPresentation = isoPickerPresentation(isoTile, codec, exposure.getOrNull(0), strings)
+    val exposureMode =
+        primary[CommandTileKind.MODE]?.value?.takeIf { it != "—" }
+            ?: exposure.getOrNull(0)?.value?.takeIf { it != "—" }
+    val isoPresentation =
+        isoPickerPresentation(
+            isoTile = isoTile,
+            codec = codec,
+            baseIsoTile = exposure.getOrNull(0),
+            exposureMode = exposureMode,
+            strings = strings,
+        )
     val shutterPresentation =
         shutterPickerPresentation(
             shutterTile = shutterTile,
@@ -748,29 +764,86 @@ internal fun shutterPickerPresentation(
 
 /**
  * Projects the ISO capture-bar picker from [IsoPickerPolicy] (iOS
- * `ISOPickerPolicy` / `PickerPanel` dual-base vs unified).
+ * `ISOPickerPolicy` / `PickerPanel`).
  *
  * - R3D NE: Low Base / High Base tabs with full ladders + base-ISO activate.
- * - Other codecs: single unified drum, no mode bar.
+ * - Other codecs: Auto On / Auto Off tabs + unified drum (exit auto by picking ISO).
  * Options always come from the policy (not a partial camera enum).
  */
 internal fun isoPickerPresentation(
     isoTile: CommandTilePresentation?,
     codec: String,
     baseIsoTile: CommandTilePresentation?,
+    exposureMode: String?,
     strings: PhoneStringResolver,
 ): MonitorPickerPresentation? {
-    val live = isoTile?.value?.takeIf { it != "—" } ?: return null
-    // Writable when the command tile still has a request; locked-while-recording
-    // still opens the drum dimmed via controlLocked / unavailableReason.
-    val canWrite = isoTile.request != null
-    if (!canWrite && isoTile.unavailableReason == null) return null
+    // Prefer live ISO; when Auto is driving ISO the body may report "—"/Auto — still open the drum.
+    val live = isoTile?.value?.takeIf { it != "—" && !it.equals("Auto", ignoreCase = true) }
+    val canWrite = isoTile?.request != null || IsoPickerPolicy.showsAutoISOControl(codec)
+    if (!canWrite && isoTile?.unavailableReason == null && live == null &&
+        !IsoPickerPolicy.showsAutoISOControl(codec)
+    ) {
+        return null
+    }
     val dual = IsoPickerPolicy.showsDualBaseCircuits(codec)
+    val autoControl = IsoPickerPolicy.showsAutoISOControl(codec)
     val title = strings.resolve(R.string.camera_label_iso)
     val subtitle = IsoPickerPolicy.pickerSubtitle(codec)
+    val options = IsoPickerPolicy.unifiedOptions
+    val current = live?.takeIf { it in options } ?: options.firstOrNull() ?: return null
+
+    if (autoControl) {
+        val modes =
+            IsoPickerPolicy.pickerModes(codec).map { mode ->
+                val activatesAuto = mode.activatesAutoISO == true
+                MonitorPickerModePresentation(
+                    label = mode.title,
+                    detail = mode.detail,
+                    request =
+                        CommandControlRequest(
+                            title = title,
+                            control = CameraControl.ISO,
+                            currentValue = current,
+                            options = mode.options,
+                        ),
+                    activateRequest =
+                        CommandControlRequest(
+                            title = strings.resolve(R.string.command_title_mode),
+                            control = CameraControl.EXPOSURE_MODE,
+                            currentValue =
+                                if (activatesAuto) {
+                                    IsoPickerPolicy.AUTO_ISO_ON_EXPOSURE_MODE
+                                } else {
+                                    IsoPickerPolicy.AUTO_ISO_OFF_EXPOSURE_MODE
+                                },
+                            options =
+                                listOf(
+                                    IsoPickerPolicy.AUTO_ISO_ON_EXPOSURE_MODE,
+                                    IsoPickerPolicy.AUTO_ISO_OFF_EXPOSURE_MODE,
+                                    "P",
+                                    "A",
+                                    "S",
+                                    "M",
+                                    "U1",
+                                    "U2",
+                                    "U3",
+                                ),
+                        ),
+                    // Auto On does not write ISO; Auto Off writes the drum after M.
+                    applyValueOnActivate = mode.activatesAutoISO != true,
+                    markedValues = IsoPickerPolicy.markedValues(codec, 0),
+                )
+            }
+        return MonitorPickerPresentation(
+            kind = MonitorPickerKind.ISO,
+            title = title,
+            subtitle = subtitle,
+            modes = modes,
+            initialModeIndex = IsoPickerPolicy.autoISOModeIndex(exposureMode),
+        )
+    }
+
     if (!dual) {
-        val options = IsoPickerPolicy.unifiedOptions
-        val current = if (live in options) live else options.first()
         return MonitorPickerPresentation(
             kind = MonitorPickerKind.ISO,
             title = title,
@@ -797,7 +870,7 @@ internal fun isoPickerPresentation(
         IsoPickerPolicy.pickerModes(codec).mapIndexed { index, mode ->
             val circuitCurrent =
                 when {
-                    live in mode.options -> live
+                    live != null && live in mode.options -> live
                     else -> mode.base
                 }
             val baseValue = if (index == 0) "Low" else "High"
@@ -1615,11 +1688,13 @@ private fun PickerPanelBody(
                                 // iOS: apply the mode's landed value when switching
                                 // circuits (WB Kelvin↔Preset, ISO bases). Skip Tint
                                 // (pad only), Focus (independent tabs), Shutter
-                                // (mode write is activateRequest only).
+                                // (mode write is activateRequest only), Auto ISO On
+                                // (exposure mode only — no ISO write while camera owns ISO).
                                 val isTint =
                                     candidate.request.control == CameraControl.WHITE_BALANCE_TINT
                                 val skipApply =
-                                    isTint ||
+                                    !candidate.applyValueOnActivate ||
+                                        isTint ||
                                         picker.kind == MonitorPickerKind.FOCUS ||
                                         picker.kind == MonitorPickerKind.SHUTTER
                                 if (!skipApply) {

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorCameraControls.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorCameraControls.kt
@@ -139,6 +139,12 @@ internal data class MonitorPickerPresentation(
      */
     val interactionLocked: Boolean = false,
     val lockBanner: String? = null,
+    /**
+     * Dim/disable only the value drum (Auto ISO On). Mode tabs stay interactive so the
+     * operator can switch to Auto Off / Manual.
+     */
+    val drumInteractionLocked: Boolean = false,
+    val drumLockBanner: String? = null,
 )
 
 /** One readout in the live monitor's capture strip. */
@@ -776,8 +782,12 @@ internal fun isoPickerPresentation(
     isoAuto: Boolean?,
     strings: PhoneStringResolver,
 ): MonitorPickerPresentation? {
-    // Prefer live ISO; when Auto is driving ISO the body may report "—"/Auto — still open the drum.
-    val live = isoTile?.value?.takeIf { it != "—" && !it.equals("Auto", ignoreCase = true) }
+    // Prefer live ISO. Auto-mode tiles may read "A3200" / "Auto" — strip the Auto prefix for the drum.
+    val live =
+        isoTile?.value
+            ?.takeIf { it != "—" }
+            ?.removePrefix("A")
+            ?.takeIf { !it.equals("Auto", ignoreCase = true) }
     val canWrite = isoTile?.request != null || IsoPickerPolicy.showsAutoISOControl(codec)
     if (!canWrite && isoTile?.unavailableReason == null && live == null &&
         !IsoPickerPolicy.showsAutoISOControl(codec)
@@ -826,12 +836,21 @@ internal fun isoPickerPresentation(
                     markedValues = IsoPickerPolicy.markedValues(codec, 0),
                 )
             }
+        val autoOn = IsoPickerPolicy.isAutoISOActive(isoAuto)
         return MonitorPickerPresentation(
             kind = MonitorPickerKind.ISO,
             title = title,
             subtitle = subtitle,
             modes = modes,
             initialModeIndex = IsoPickerPolicy.autoISOModeIndex(isoAuto),
+            // Drum is camera-owned while Auto ISO is on; Auto On/Off tabs stay usable.
+            drumInteractionLocked = autoOn,
+            drumLockBanner =
+                if (autoOn) {
+                    strings.resolve(R.string.iso_auto_drum_locked)
+                } else {
+                    null
+                },
         )
     }
 
@@ -1385,7 +1404,10 @@ private fun PickerPanelBody(
             mode.label.equals("Kelvin", ignoreCase = true)
     // Keep the drum scrollable while a write is in flight (iOS). Pending applies
     // coalesce in MonitorScreen; freezing the wheel dropped rapid settles.
-    val drumInteractive = controlsEnabled && !picker.interactionLocked
+    // Full interaction lock (shutter control lock / R3D recording) freezes mode tabs too.
+    // Auto ISO only freezes the value drum so Auto Off remains reachable.
+    val modeInteractive = controlsEnabled && !picker.interactionLocked
+    val drumInteractive = modeInteractive && !picker.drumInteractionLocked
     // Ignore drum-settles briefly after a ±10 nudge so scroll snap cannot
     // overwrite the fine-tuned value with a neighbouring dial step.
     var suppressDrumSettleUntil by remember(picker.kind) { mutableStateOf(0L) }
@@ -1481,7 +1503,7 @@ private fun PickerPanelBody(
                 maxLines = 2,
             )
         }
-        picker.lockBanner?.let { banner ->
+        (picker.drumLockBanner ?: picker.lockBanner)?.let { banner ->
             Row(
                 Modifier
                     .fillMaxWidth()
@@ -1646,7 +1668,6 @@ private fun PickerPanelBody(
         if (picker.modes.size > 1) {
             // Fixed-height mode bar (never in the weight slot) — preserves full
             // KELVIN/PRESET/TINT hit targets when the Tint pad is tall.
-            val modeInteractive = drumInteractive
             Row(
                 Modifier.fillMaxWidth().wrapContentHeight(),
                 horizontalArrangement = Arrangement.spacedBy(10.dp),

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorChrome.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorChrome.kt
@@ -75,13 +75,18 @@ fun Modifier.chromeClickable(onClick: () -> Unit): Modifier =
 
 /** Disabled chrome controls keep their visual state but reject touch input. */
 @Composable
-fun Modifier.chromeClickable(enabled: Boolean, onClick: () -> Unit): Modifier =
-    clickable(
+fun Modifier.chromeClickable(enabled: Boolean, onClick: () -> Unit): Modifier {
+    val haptics = LocalOperatorHaptics.current
+    return clickable(
         enabled = enabled,
         interactionSource = remember { MutableInteractionSource() },
         indication = null,
-        onClick = onClick,
+        onClick = {
+            haptics.selection()
+            onClick()
+        },
     )
+}
 
 /**
  * iOS `.zcTapTarget` press feedback: while pressed the control drops to 60%
@@ -90,6 +95,7 @@ fun Modifier.chromeClickable(enabled: Boolean, onClick: () -> Unit): Modifier =
  */
 @Composable
 fun Modifier.chromePressable(onClick: () -> Unit): Modifier {
+    val haptics = LocalOperatorHaptics.current
     val interaction = remember { MutableInteractionSource() }
     val pressed by interaction.collectIsPressedAsState()
     val alpha by
@@ -113,7 +119,10 @@ fun Modifier.chromePressable(onClick: () -> Unit): Modifier {
             enabled = true,
             interactionSource = interaction,
             indication = null,
-            onClick = onClick,
+            onClick = {
+                haptics.selection()
+                onClick()
+            },
         )
 }
 

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
@@ -673,7 +673,15 @@ internal fun MonitorScreen(
                                 desiredLabel,
                             )
                         // Only surface failures. iOS does not flash "set to …" on every snap.
-                        if (!confirmed && desiredControlWrites[control] == null) {
+                        // ISO is already byte-confirmed on MovieExposureIndex / MovieISOSensitivity
+                        // inside the shared core; a lagging dual-property refresh must not flash
+                        // a false "did not confirm" after a successful body write.
+                        val softConfirmSkips =
+                            control == CameraControl.ISO || control == CameraControl.ISO_AUTO
+                        if (!confirmed &&
+                            !softConfirmSkips &&
+                            desiredControlWrites[control] == null
+                        ) {
                             commandControlFeedback =
                                 CommandControlFeedback(
                                     appContext.getString(

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
@@ -708,6 +708,30 @@ internal fun MonitorScreen(
     val applyCameraControl: (CommandControlRequest, String) -> Unit =
         applyCameraControl@{ request, label ->
             if (!commandControlsEnabled) return@applyCameraControl
+            // Exit Auto ISO by choosing a drum value: switch exposure to M first so the
+            // body accepts movie ISO writes (non-R3D NE codecs).
+            if (
+                request.control == CameraControl.ISO &&
+                    IsoPickerPolicy.isAutoISOActive(cameraProperties.exposureMode)
+            ) {
+                desiredControlWrites[CameraControl.EXPOSURE_MODE] =
+                    CommandControlRequest(
+                        title = "MODE",
+                        control = CameraControl.EXPOSURE_MODE,
+                        currentValue = IsoPickerPolicy.AUTO_ISO_OFF_EXPOSURE_MODE,
+                        options =
+                            listOf(
+                                "Auto",
+                                "P",
+                                "A",
+                                "S",
+                                "M",
+                                "U1",
+                                "U2",
+                                "U3",
+                            ),
+                    ) to IsoPickerPolicy.AUTO_ISO_OFF_EXPOSURE_MODE
+            }
             desiredControlWrites[request.control] = request to label
             commandControlFeedback = null
             if (activeCommandControl?.control == request.control) {

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
@@ -593,12 +593,14 @@ internal fun MonitorScreen(
             stringResolver,
             effectiveShutterLocked,
             cameraProperties.isoAuto,
+            cameraProperties.exposureMode,
         ) {
             monitorCaptureSettings(
                 commandPresentation,
                 stringResolver,
                 shutterLockedOnCamera = effectiveShutterLocked,
                 isoAuto = cameraProperties.isoAuto,
+                exposureMode = cameraProperties.exposureMode,
             )
         }
     val topPillPickers =
@@ -661,37 +663,11 @@ internal fun MonitorScreen(
                     }
                     pendingCommandControl = control
                     try {
+                        // Facade applyControl already confirms the write on the wire. Do not
+                        // soft-fail from a lagging property poll (see docs/android-control-writes.md).
                         session.applyControl(control, desiredLabel)
-                        // Property poll will also catch up; one refresh keeps tiles/bar honest
-                        // after the native confirm without freezing the drum (settles still
-                        // enqueue into desiredControlWrites while this runs).
+                        // One refresh keeps tiles/bar honest; settles still enqueue while this runs.
                         session.refreshProperties()
-                        val confirmed =
-                            cameraPropertyConfirmsSelection(
-                                session.cameraProperties.value,
-                                control,
-                                desiredLabel,
-                            )
-                        // Only surface failures. iOS does not flash "set to …" on every snap.
-                        // ISO is already byte-confirmed on MovieExposureIndex / MovieISOSensitivity
-                        // inside the shared core; a lagging dual-property refresh must not flash
-                        // a false "did not confirm" after a successful body write.
-                        val softConfirmSkips =
-                            control == CameraControl.ISO || control == CameraControl.ISO_AUTO
-                        if (!confirmed &&
-                            !softConfirmSkips &&
-                            desiredControlWrites[control] == null
-                        ) {
-                            commandControlFeedback =
-                                CommandControlFeedback(
-                                    appContext.getString(
-                                        R.string.control_confirmation_failed,
-                                        req.title,
-                                        desiredLabel,
-                                    ),
-                                    isError = true,
-                                )
-                        }
                     } catch (error: CameraControlException) {
                         if (desiredControlWrites[control] == null) {
                             commandControlFeedback =
@@ -724,6 +700,30 @@ internal fun MonitorScreen(
             if (!commandControlsEnabled) return@applyCameraControl
             // Exit movie ISO auto by choosing a drum value: write MovISOAutoControl Off first
             // so the body accepts the manual ISO write (non-R3D NE codecs).
+            // Manual ISO / Auto Off: R3D NE always; other codecs only in M.
+            val codecForISO =
+                (cameraProperties.codecSelection ?: cameraProperties.codec)
+                    ?.takeIf { it != "—" }
+                    .orEmpty()
+            if (
+                request.control == CameraControl.ISO &&
+                    !IsoPickerPolicy.allowsManualISO(
+                        codecForISO,
+                        cameraProperties.exposureMode,
+                    )
+            ) {
+                return@applyCameraControl
+            }
+            if (
+                request.control == CameraControl.ISO_AUTO &&
+                    label.equals(IsoPickerPolicy.AUTO_ISO_OFF_LABEL, ignoreCase = true) &&
+                    !IsoPickerPolicy.allowsManualISO(
+                        codecForISO,
+                        cameraProperties.exposureMode,
+                    )
+            ) {
+                return@applyCameraControl
+            }
             if (
                 request.control == CameraControl.ISO &&
                     IsoPickerPolicy.isAutoISOActive(cameraProperties.isoAuto)

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
@@ -588,11 +588,17 @@ internal fun MonitorScreen(
             )
         }
     val captureSettings =
-        remember(commandPresentation, stringResolver, effectiveShutterLocked) {
+        remember(
+            commandPresentation,
+            stringResolver,
+            effectiveShutterLocked,
+            cameraProperties.isoAuto,
+        ) {
             monitorCaptureSettings(
                 commandPresentation,
                 stringResolver,
                 shutterLockedOnCamera = effectiveShutterLocked,
+                isoAuto = cameraProperties.isoAuto,
             )
         }
     val topPillPickers =
@@ -708,29 +714,23 @@ internal fun MonitorScreen(
     val applyCameraControl: (CommandControlRequest, String) -> Unit =
         applyCameraControl@{ request, label ->
             if (!commandControlsEnabled) return@applyCameraControl
-            // Exit Auto ISO by choosing a drum value: switch exposure to M first so the
-            // body accepts movie ISO writes (non-R3D NE codecs).
+            // Exit movie ISO auto by choosing a drum value: write MovISOAutoControl Off first
+            // so the body accepts the manual ISO write (non-R3D NE codecs).
             if (
                 request.control == CameraControl.ISO &&
-                    IsoPickerPolicy.isAutoISOActive(cameraProperties.exposureMode)
+                    IsoPickerPolicy.isAutoISOActive(cameraProperties.isoAuto)
             ) {
-                desiredControlWrites[CameraControl.EXPOSURE_MODE] =
+                desiredControlWrites[CameraControl.ISO_AUTO] =
                     CommandControlRequest(
-                        title = "MODE",
-                        control = CameraControl.EXPOSURE_MODE,
-                        currentValue = IsoPickerPolicy.AUTO_ISO_OFF_EXPOSURE_MODE,
+                        title = "ISO",
+                        control = CameraControl.ISO_AUTO,
+                        currentValue = IsoPickerPolicy.AUTO_ISO_OFF_LABEL,
                         options =
                             listOf(
-                                "Auto",
-                                "P",
-                                "A",
-                                "S",
-                                "M",
-                                "U1",
-                                "U2",
-                                "U3",
+                                IsoPickerPolicy.AUTO_ISO_ON_LABEL,
+                                IsoPickerPolicy.AUTO_ISO_OFF_LABEL,
                             ),
-                    ) to IsoPickerPolicy.AUTO_ISO_OFF_EXPOSURE_MODE
+                    ) to IsoPickerPolicy.AUTO_ISO_OFF_LABEL
             }
             desiredControlWrites[request.control] = request to label
             commandControlFeedback = null

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
@@ -743,7 +743,7 @@ internal fun MonitorScreen(
     val shutterHapticView = LocalView.current
     val shutterLongPressToggle: () -> Unit = {
         if (operatorSettings.hapticsEnabled.value) {
-            shutterHapticView.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+            shutterHapticView.performOperatorHaptic(HapticFeedbackConstants.LONG_PRESS)
         }
         toggleShutterLockOnCamera(
             captureSettings = captureSettings,
@@ -1384,15 +1384,14 @@ internal fun MonitorScreen(
             val next = !focusPointLocked
             focusPointLocked = next
             focusLockHolding = false
-            if (operatorSettings.hapticsEnabled.value) {
-                view.performHapticFeedback(
-                    if (next) {
-                        HapticFeedbackConstants.LONG_PRESS
-                    } else {
-                        HapticFeedbackConstants.KEYBOARD_TAP
-                    },
-                )
-            }
+            view.performOperatorHaptic(
+                if (next) {
+                    HapticFeedbackConstants.LONG_PRESS
+                } else {
+                    HapticFeedbackConstants.KEYBOARD_TAP
+                },
+                enabled = operatorSettings.hapticsEnabled.value,
+            )
         }
         val handleFocusFeedAction: (FocusFeedGestureAction) -> Unit = handleFocusFeedAction@{ action ->
             when (action) {
@@ -1408,7 +1407,7 @@ internal fun MonitorScreen(
                                     CameraFocusPoint(action.coordinate.x, action.coordinate.y),
                                 )
                             if (accepted && operatorSettings.hapticsEnabled.value) {
-                                view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                                view.performOperatorHaptic(HapticFeedbackConstants.KEYBOARD_TAP)
                             }
                         } catch (error: CameraFocusException) {
                             Toast.makeText(
@@ -1432,7 +1431,7 @@ internal fun MonitorScreen(
                         if (next != effectiveDisplayMode) {
                             displayMode = next
                             if (operatorSettings.hapticsEnabled.value) {
-                                view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+                                view.performOperatorHaptic(HapticFeedbackConstants.CLOCK_TICK)
                             }
                         }
                     }
@@ -1453,7 +1452,7 @@ internal fun MonitorScreen(
                 try {
                     session.resetFocusPoint()
                     if (operatorSettings.hapticsEnabled.value) {
-                        view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                        view.performOperatorHaptic(HapticFeedbackConstants.KEYBOARD_TAP)
                     }
                 } catch (error: CameraFocusException) {
                     Toast.makeText(
@@ -1711,7 +1710,7 @@ internal fun MonitorScreen(
                     onMoveCommandTile = moveCommandTileTo,
                     onReorderStarted = {
                         if (operatorSettings.hapticsEnabled.value) {
-                            view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                            view.performOperatorHaptic(HapticFeedbackConstants.LONG_PRESS)
                         }
                     },
                     onOpenAssistOptions = openAssistOptions,
@@ -1738,7 +1737,7 @@ internal fun MonitorScreen(
                         onMoveTile = moveCommandTileTo,
                         onReorderStarted = {
                             if (operatorSettings.hapticsEnabled.value) {
-                                view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                                view.performOperatorHaptic(HapticFeedbackConstants.LONG_PRESS)
                             }
                         },
                         liveFps = fpsSampler.formatted,

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/OperatorHaptics.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/OperatorHaptics.kt
@@ -1,0 +1,115 @@
+package com.opencapture.openzcine
+
+import android.os.Build
+import android.view.HapticFeedbackConstants
+import android.view.View
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalView
+
+/**
+ * Operator-facing haptics for the Android shell.
+ *
+ * iOS uses `UIImpactFeedbackGenerator` gated by `preferences.hapticsEnabled`. Android mirrors
+ * that with [View.performHapticFeedback], but system "Touch feedback" is often off — when the
+ * in-app toggle is on we ignore the global setting so the operator's preference wins.
+ * [chromeClickable] and chrome presses call [selection] automatically.
+ */
+interface OperatorHaptics {
+    fun selection()
+
+    fun tick()
+
+    fun confirm()
+
+    fun longPress()
+
+    companion object {
+        val None: OperatorHaptics =
+            object : OperatorHaptics {
+                override fun selection() = Unit
+
+                override fun tick() = Unit
+
+                override fun confirm() = Unit
+
+                override fun longPress() = Unit
+            }
+    }
+}
+
+/** Defaults to a no-op so previews and unit trees don't crash before a provider is installed. */
+val LocalOperatorHaptics = staticCompositionLocalOf { OperatorHaptics.None }
+
+private class ViewOperatorHaptics(
+    private val view: View,
+    private val enabled: () -> Boolean,
+) : OperatorHaptics {
+    override fun selection() {
+        perform(
+            preferred = HapticFeedbackConstants.CONTEXT_CLICK,
+            fallback = HapticFeedbackConstants.KEYBOARD_TAP,
+        )
+    }
+
+    override fun tick() {
+        perform(
+            preferred = HapticFeedbackConstants.CLOCK_TICK,
+            fallback = HapticFeedbackConstants.KEYBOARD_TAP,
+        )
+    }
+
+    override fun confirm() {
+        val preferred =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                HapticFeedbackConstants.CONFIRM
+            } else {
+                HapticFeedbackConstants.LONG_PRESS
+            }
+        perform(preferred = preferred, fallback = HapticFeedbackConstants.LONG_PRESS)
+    }
+
+    override fun longPress() {
+        perform(
+            preferred = HapticFeedbackConstants.LONG_PRESS,
+            fallback = HapticFeedbackConstants.KEYBOARD_TAP,
+        )
+    }
+
+    private fun perform(preferred: Int, fallback: Int) {
+        if (!enabled()) return
+        // Some surfaces clear this; keep the app toggle authoritative.
+        view.isHapticFeedbackEnabled = true
+        // App toggle is the source of truth — don't let system Sound settings silence us.
+        @Suppress("DEPRECATION")
+        val flags = HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING
+        if (!view.performHapticFeedback(preferred, flags)) {
+            view.performHapticFeedback(fallback, flags)
+        }
+    }
+}
+
+/** Builds a real haptic helper bound to the current [LocalView] and [enabled] gate. */
+@Composable
+fun rememberOperatorHaptics(enabled: () -> Boolean): OperatorHaptics {
+    val view = LocalView.current
+    val enabledState = rememberUpdatedState(enabled)
+    return remember(view) { ViewOperatorHaptics(view) { enabledState.value() } }
+}
+
+/**
+ * Fire a system haptic that respects the in-app operator toggle, not the global Sound setting.
+ * Prefer [LocalOperatorHaptics] from Compose; this is for pointer/gesture code that only has a
+ * [View].
+ */
+fun View.performOperatorHaptic(feedbackConstant: Int, enabled: Boolean = true) {
+    if (!enabled) return
+    isHapticFeedbackEnabled = true
+    @Suppress("DEPRECATION")
+    val flags = HapticFeedbackConstants.FLAG_IGNORE_GLOBAL_SETTING
+    if (!performHapticFeedback(feedbackConstant, flags)) {
+        performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP, flags)
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/ScopeView.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/ScopeView.kt
@@ -962,7 +962,7 @@ internal fun FloatingScopePanel(
                     onDragStart = {
                         isDragging = true
                         if (hapticsEnabled) {
-                            view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                            view.performOperatorHaptic(HapticFeedbackConstants.LONG_PRESS)
                         }
                     },
                     onDragEnd = {
@@ -988,7 +988,7 @@ internal fun FloatingScopePanel(
                     if (cell != hapticCell) {
                         hapticCell = cell
                         if (hapticsEnabled) {
-                            view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                            view.performOperatorHaptic(HapticFeedbackConstants.KEYBOARD_TAP)
                         }
                     }
                     frame = snapped
@@ -1023,7 +1023,7 @@ internal fun FloatingScopePanel(
                             startScale = liveScale
                             accumulated = 0f
                             if (hapticsEnabled) {
-                                view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                                view.performOperatorHaptic(HapticFeedbackConstants.LONG_PRESS)
                             }
                         },
                         onDragEnd = {

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/CameraPropertySnapshotWire.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/CameraPropertySnapshotWire.kt
@@ -72,6 +72,7 @@ internal object CameraPropertySnapshotWire {
         return CameraPropertySnapshot(
             iso = value.optionalLong("iso"),
             baseIso = value.optionalString("baseIso"),
+            isoAuto = value.optionalBoolean("isoAuto"),
             exposureMode = value.optionalString("exposureMode"),
             shutterMode = shutterMode(value.optionalString("shutterMode")),
             shutterLocked = value.optionalBoolean("shutterLocked"),

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSession.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSession.kt
@@ -245,6 +245,7 @@ private val CameraControl.nativeSelector: Int
             CameraControl.CODEC -> 18
             CameraControl.VIBRATION_REDUCTION -> 19
             CameraControl.ELECTRONIC_VR -> 20
+            CameraControl.ISO_AUTO -> 21
         }
 
 /**

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/glass/DampedDragAnimation.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/glass/DampedDragAnimation.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlin.math.abs
+// snapTo is on Animatable
 
 /**
  * Port of Kyant catalog `DampedDragAnimation` — spring-damped press/scale/value
@@ -110,6 +111,18 @@ internal class DampedDragAnimation(
             launch {
                 valueAnimation.animateTo(target, valueAnimationSpec) { updateVelocity() }
             }
+        }
+    }
+
+    /**
+     * Immediately moves the thumb to [value] (no spring). Used while the finger is down so discrete
+     * parent steps (e.g. desqueeze 0.1×) cannot yank the pill back mid-drag.
+     */
+    fun snapValue(value: Float) {
+        val target = value.coerceIn(valueRange)
+        animationScope.launch {
+            valueAnimation.snapTo(target)
+            updateVelocity()
         }
     }
 

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/glass/DragGestureInspector.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/glass/DragGestureInspector.kt
@@ -26,8 +26,11 @@ internal suspend fun PointerInputScope.inspectDragGestures(
     onDrag: (change: PointerInputChange, dragAmount: Offset) -> Unit,
 ) {
     awaitEachGesture {
-        val initialDown = awaitFirstDown(false, PointerEventPass.Initial)
-        val down = awaitFirstDown(false)
+        val initialDown = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+        val down = awaitFirstDown(requireUnconsumed = false)
+        // Claim the pointer so a parent verticalScroll cannot steal the pill drag.
+        initialDown.consume()
+        down.consume()
         val drag = initialDown
 
         onDragStart(down)
@@ -35,7 +38,11 @@ internal suspend fun PointerInputScope.inspectDragGestures(
         val upEvent =
             drag(
                 pointerId = drag.id,
-                onDrag = { onDrag(it, it.positionChange()) },
+                onDrag = { change ->
+                    val amount = change.positionChange()
+                    change.consume()
+                    onDrag(change, amount)
+                },
             )
         if (upEvent == null) {
             onDragCancel()
@@ -56,12 +63,11 @@ private suspend inline fun AwaitPointerEventScope.drag(
     var pointer = pointerId
     while (true) {
         val change = awaitDragOrUp(pointer) ?: return null
-        if (change.isConsumed) {
-            return null
-        }
         if (change.changedToUpIgnoreConsumed()) {
             return change
         }
+        // Keep dragging even if a parent briefly marked the event consumed before we claimed it;
+        // we re-consume in the onDrag callback.
         onDrag(change)
         pointer = change.id
     }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/glass/LiquidSlider.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/glass/LiquidSlider.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -71,6 +72,8 @@ internal fun LiquidSlider(
     useLiquidGlass: Boolean = true,
 ) {
     val trackBackdrop = rememberLayerBackdrop()
+    val latestValue by rememberUpdatedState(value)
+    val latestOnValueChange by rememberUpdatedState(onValueChange)
 
     BoxWithConstraints(
         modifier.fillMaxWidth(),
@@ -81,42 +84,54 @@ internal fun LiquidSlider(
         val isLtr = LocalLayoutDirection.current == LayoutDirection.Ltr
         val animationScope = rememberCoroutineScope()
         var didDrag by remember { mutableStateOf(false) }
+        // While the finger is down, ignore parent refeeds so discrete-step hosts (0…10)
+        // cannot snap the pill back to the last committed integer every frame.
+        var isDragging by remember { mutableStateOf(false) }
+        val trackWidthState = rememberUpdatedState(trackWidth)
         val dampedDragAnimation =
-            remember(animationScope) {
+            remember(animationScope, valueRange, visibilityThreshold, isLtr) {
                 DampedDragAnimation(
                     animationScope = animationScope,
-                    initialValue = value(),
+                    initialValue = latestValue(),
                     valueRange = valueRange,
                     visibilityThreshold = visibilityThreshold,
                     initialScale = 1f,
                     pressedScale = 1.5f,
-                    onDragStarted = {},
+                    onDragStarted = {
+                        isDragging = true
+                        didDrag = false
+                    },
                     onDragStopped = {
                         if (didDrag) {
-                            onValueChange(targetValue)
+                            latestOnValueChange(targetValue)
                         }
+                        isDragging = false
+                        didDrag = false
                     },
                     onDrag = { _, dragAmount ->
                         if (!didDrag) {
                             didDrag = dragAmount.x != 0f
                         }
+                        val width = trackWidthState.value.coerceAtLeast(1)
                         val delta =
                             (valueRange.endInclusive - valueRange.start) *
-                                (dragAmount.x / trackWidth.coerceAtLeast(1))
-                        onValueChange(
+                                (dragAmount.x / width)
+                        val next =
                             if (isLtr) {
                                 (targetValue + delta).coerceIn(valueRange)
                             } else {
                                 (targetValue - delta).coerceIn(valueRange)
-                            },
-                        )
+                            }
+                        // Follow the finger immediately (catalog only notifies the parent).
+                        snapValue(next)
+                        latestOnValueChange(next)
                     },
                 )
             }
-        LaunchedEffect(dampedDragAnimation) {
-            snapshotFlow { value() }
+        LaunchedEffect(dampedDragAnimation, isDragging) {
+            snapshotFlow { latestValue() }
                 .collectLatest { next ->
-                    if (dampedDragAnimation.targetValue != next) {
+                    if (!isDragging && dampedDragAnimation.targetValue != next) {
                         dampedDragAnimation.updateValue(next)
                     }
                 }
@@ -127,7 +142,7 @@ internal fun LiquidSlider(
                 Modifier
                     .clip(Capsule())
                     .background(trackColor)
-                    .pointerInput(animationScope) {
+                    .pointerInput(animationScope, valueRange, isLtr, trackWidth) {
                         detectTapGestures { position ->
                             val delta =
                                 (valueRange.endInclusive - valueRange.start) *
@@ -141,7 +156,7 @@ internal fun LiquidSlider(
                                     }
                                 ).coerceIn(valueRange)
                             dampedDragAnimation.animateToValue(targetValue)
-                            onValueChange(targetValue)
+                            latestOnValueChange(targetValue)
                         }
                     }
                     .height(6.dp)

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaBrowseScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaBrowseScreen.kt
@@ -1,5 +1,7 @@
 package com.opencapture.openzcine.media
 
+import com.opencapture.openzcine.performOperatorHaptic
+
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -2696,12 +2698,12 @@ private fun Modifier.mediaSelectionGestures(
                                 paintSelect = paintSelect,
                             ),
                         )
-                        view.performHapticFeedback(HapticFeedbackConstants.CLOCK_TICK)
+                        view.performOperatorHaptic(HapticFeedbackConstants.CLOCK_TICK)
                     }
                     fun paintAt(local: Offset) {
                         indexAt(local)?.let(::paintTo)
                     }
-                    view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                    view.performOperatorHaptic(HapticFeedbackConstants.LONG_PRESS)
                     paintTo(startIndex)
 
                     val height = size.height.toFloat()

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
@@ -1004,10 +1004,11 @@ private fun ProgressivePlayer(
     }
 
     val cacheFailed = entry.state == MediaCacheState.FAILED
+    // Apply de-squeeze whenever DESQ is on — do not require other framing tools.
     val horizontalPresentationScale =
-        if (framingAssistsVisible) playbackFramingConfiguration.horizontalPresentationScale else 1f
+        playbackFramingConfiguration.horizontalPresentationScale
     val verticalPresentationScale =
-        if (framingAssistsVisible) playbackFramingConfiguration.verticalPresentationScale else 1f
+        playbackFramingConfiguration.verticalPresentationScale
     val density = LocalDensity.current.density
     val viewportWidthDp = viewport.width / density
     val viewportHeightDp = viewport.height / density

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
@@ -1,6 +1,7 @@
 @file:androidx.media3.common.util.UnstableApi
 
 package com.opencapture.openzcine.media
+import com.opencapture.openzcine.performOperatorHaptic
 
 import android.net.Uri
 import android.os.Build
@@ -1122,7 +1123,7 @@ private fun ProgressivePlayer(
                                     PlaybackTimeline.clampPosition(player.currentPosition, duration)
                                 frameScrubHorizontal = 0f
                                 scrubPosition = frameScrubOrigin.toFloat()
-                                hapticView.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                                hapticView.performOperatorHaptic(HapticFeedbackConstants.LONG_PRESS)
                             },
                             onDragEnd = ::finishFrameScrub,
                             onDragCancel = ::finishFrameScrub,

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackAssistOptions.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackAssistOptions.kt
@@ -1255,8 +1255,26 @@ private fun DesqueezeOptions(actions: AssistOptionsActions, settings: OperatorSe
     SegmentedChoice(
         LocalDesqueezeRatio.entries.toList(),
         LocalDesqueezeRatio::label,
-        selected = { settings.desqueezeRatio == it },
+        selected = {
+            LocalDesqueezeRatio.matching(settings.desqueezeFactor) == it
+        },
     ) { settings.desqueezeRatio = it }
+    // Custom 1.0…2.0 factor (0.1 steps) — same range as iOS playback/live desqueeze.
+    AssistInlineRow(title = "Custom") {
+        GlassPillSlider(
+            value = ((settings.desqueezeFactor - 1f) * 10f).toInt().coerceIn(0, 10),
+            range = 0..10,
+            onChange = { step -> settings.desqueezeFactor = 1f + (step / 10f) },
+            modifier = Modifier.width(150.dp),
+        )
+        Text(
+            String.format("%.1f×", settings.desqueezeFactor),
+            style = chromeStyle(11.5f, FontWeight.Medium, mono = true),
+            color = LiveDesign.text,
+            modifier = Modifier.widthIn(min = 40.dp),
+            textAlign = androidx.compose.ui.text.style.TextAlign.End,
+        )
+    }
     SegmentedChoice(
         LocalDesqueezeOrientation.entries.toList(),
         LocalDesqueezeOrientation::label,

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackAssistOptions.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackAssistOptions.kt
@@ -394,7 +394,7 @@ private fun PlaybackAssistOptionsContent(
         AssistTool.CROSS ->
             OptionCopy("Tap the toolbar button to show or hide the centre crosshair.")
         AssistTool.LEVEL -> LevelOptions(actions, settings)
-        AssistTool.DESQ -> DesqueezeOptions(actions, settings)
+        AssistTool.DESQ -> DesqueezeOptions(settings)
         AssistTool.AUDIO ->
             OptionCopy("Meters the playing clip's audio. Available during media playback.")
     }
@@ -1246,12 +1246,8 @@ private fun LevelOptions(actions: AssistOptionsActions, settings: OperatorSettin
 }
 
 @Composable
-private fun DesqueezeOptions(actions: AssistOptionsActions, settings: OperatorSettings) {
-    CircleToggleRow(
-        "Enable",
-        actions.isOn(AssistTool.DESQ),
-        divider = false,
-    ) { actions.setVisible(AssistTool.DESQ, !actions.isOn(AssistTool.DESQ)) }
+private fun DesqueezeOptions(settings: OperatorSettings) {
+    // On/off is the assist-bar DESQ chip; this panel only configures factor/axis.
     SegmentedChoice(
         LocalDesqueezeRatio.entries.toList(),
         LocalDesqueezeRatio::label,

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackAssistOptions.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackAssistOptions.kt
@@ -1255,7 +1255,7 @@ private fun DesqueezeOptions(settings: OperatorSettings) {
             LocalDesqueezeRatio.matching(settings.desqueezeFactor) == it
         },
     ) { settings.desqueezeRatio = it }
-    // Custom 1.0…2.0 factor (0.1 steps) — same range as iOS playback/live desqueeze.
+    // Custom 1.0…2.0 factor (0.01 steps) — same range as iOS playback/live desqueeze.
     // Full-width row (like brightness) so the pill has enough track to drag.
     AssistRowDivider()
     Row(
@@ -1265,16 +1265,21 @@ private fun DesqueezeOptions(settings: OperatorSettings) {
     ) {
         OptionLabel("Custom")
         GlassPillSlider(
-            value = ((settings.desqueezeFactor - 1f) * 10f).toInt().coerceIn(0, 10),
-            range = 0..10,
-            onChange = { step -> settings.desqueezeFactor = 1f + (step / 10f) },
+            value =
+                ((settings.desqueezeFactor - 1f) / LocalDesqueezeRatio.FACTOR_STEP)
+                    .toInt()
+                    .coerceIn(0, 100),
+            range = 0..100,
+            onChange = { step ->
+                settings.desqueezeFactor = 1f + (step * LocalDesqueezeRatio.FACTOR_STEP)
+            },
             modifier = Modifier.weight(1f),
         )
         Text(
-            String.format("%.1f×", settings.desqueezeFactor),
+            String.format("%.2f×", settings.desqueezeFactor),
             style = chromeStyle(11.5f, FontWeight.Medium, mono = true),
             color = LiveDesign.text,
-            modifier = Modifier.widthIn(min = 40.dp),
+            modifier = Modifier.widthIn(min = 48.dp),
             textAlign = androidx.compose.ui.text.style.TextAlign.End,
         )
     }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackAssistOptions.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackAssistOptions.kt
@@ -1256,12 +1256,19 @@ private fun DesqueezeOptions(settings: OperatorSettings) {
         },
     ) { settings.desqueezeRatio = it }
     // Custom 1.0…2.0 factor (0.1 steps) — same range as iOS playback/live desqueeze.
-    AssistInlineRow(title = "Custom") {
+    // Full-width row (like brightness) so the pill has enough track to drag.
+    AssistRowDivider()
+    Row(
+        Modifier.fillMaxWidth().heightIn(min = 40.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        OptionLabel("Custom")
         GlassPillSlider(
             value = ((settings.desqueezeFactor - 1f) * 10f).toInt().coerceIn(0, 10),
             range = 0..10,
             onChange = { step -> settings.desqueezeFactor = 1f + (step / 10f) },
-            modifier = Modifier.width(150.dp),
+            modifier = Modifier.weight(1f),
         )
         Text(
             String.format("%.1f×", settings.desqueezeFactor),

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/OperatorSettings.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/OperatorSettings.kt
@@ -13,6 +13,7 @@ import com.opencapture.openzcine.FeedPeakingSensitivity
 import com.opencapture.openzcine.FeedZebraStripeColor
 import com.opencapture.openzcine.FeedZebraUnit
 import com.opencapture.openzcine.R
+import kotlin.math.roundToInt
 
 /**
  * Top-level monitor layout selected by the operator's DISP button.
@@ -184,6 +185,8 @@ public enum class LocalDesqueezeRatio(
     X133("1.33x", 1.33f),
     /** 1.5× anamorphic factor. */
     X150("1.5x", 1.5f),
+    /** 1.6× anamorphic factor. */
+    X160("1.6x", 1.6f),
     /** 1.65× anamorphic factor. */
     X165("1.65x", 1.65f),
     /** 1.8× anamorphic factor. */
@@ -195,6 +198,14 @@ public enum class LocalDesqueezeRatio(
     internal companion object {
         fun fromStoredName(value: String?): LocalDesqueezeRatio? =
             entries.firstOrNull { it.name == value }
+
+        fun matching(factor: Float): LocalDesqueezeRatio? =
+            entries.firstOrNull { kotlin.math.abs(it.factor - factor) < 0.001f }
+
+        fun snap(raw: Float): Float {
+            val clamped = raw.coerceIn(1f, 2f)
+            return ((clamped / 0.1f).roundToInt() * 0.1f).coerceIn(1f, 2f)
+        }
     }
 }
 
@@ -403,8 +414,10 @@ public data class LocalFramingAssistConfiguration(
     public val levelStyle: LocalLevelStyle = LocalLevelStyle.HORIZON,
     /** Whether the local de-squeeze presentation is applied. */
     public val desqueezeEnabled: Boolean,
-    /** The local anamorphic factor. */
+    /** Named chip when the factor matches a preset (UI highlight). */
     public val desqueezeRatio: LocalDesqueezeRatio,
+    /** Applied squeeze factor in 1.0…2.0 (source of truth for rendering). */
+    public val desqueezeFactor: Float = desqueezeRatio.factor,
     /** The source axis compressed by the anamorphic capture. */
     public val desqueezeOrientation: LocalDesqueezeOrientation,
 ) {
@@ -420,7 +433,7 @@ public data class LocalFramingAssistConfiguration(
     public val horizontalPresentationScale: Float
         get() =
             if (desqueezeEnabled && desqueezeOrientation == LocalDesqueezeOrientation.HORIZONTAL) {
-                1f / desqueezeRatio.factor
+                1f / desqueezeFactor.coerceAtLeast(1f)
             } else {
                 1f
             }
@@ -429,7 +442,7 @@ public data class LocalFramingAssistConfiguration(
     public val verticalPresentationScale: Float
         get() =
             if (desqueezeEnabled && desqueezeOrientation == LocalDesqueezeOrientation.VERTICAL) {
-                1f / desqueezeRatio.factor
+                1f / desqueezeFactor.coerceAtLeast(1f)
             } else {
                 1f
             }
@@ -522,6 +535,7 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
     private val guideFamilyState = mutableStateOf(loadGuideFamily())
     private val selectedGuideRatiosState = mutableStateOf(loadSelectedGuideRatios())
     private val desqueezeRatioState = mutableStateOf(loadDesqueezeRatio())
+    private val desqueezeFactorState = mutableStateOf(loadDesqueezeFactor())
     private val desqueezeOrientationState = mutableStateOf(loadDesqueezeOrientation())
     private val levelStyleState = mutableStateOf(loadLevelStyle())
     private val scopeCrushClipCompensationState = mutableStateOf(loadScopeCrushClipCompensation())
@@ -666,12 +680,31 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
         return selectedGuideRatiosState.value
     }
 
-    /** The selected local anamorphic factor; it applies only when [desqueezeEnabled] is on. */
+    /** Named de-squeeze chip; selecting a chip also snaps [desqueezeFactor]. */
     public var desqueezeRatio: LocalDesqueezeRatio
         get() = desqueezeRatioState.value
         set(new) {
             desqueezeRatioState.value = new
-            preferences.edit().putString(DESQUEEZE_RATIO_KEY, new.name).apply()
+            desqueezeFactorState.value = new.factor
+            preferences
+                .edit()
+                .putString(DESQUEEZE_RATIO_KEY, new.name)
+                .putFloat(DESQUEEZE_FACTOR_KEY, new.factor)
+                .apply()
+        }
+
+    /** Applied de-squeeze factor (1.0…2.0, 0.1 steps); source of truth for presentation scale. */
+    public var desqueezeFactor: Float
+        get() = desqueezeFactorState.value
+        set(new) {
+            val snapped = LocalDesqueezeRatio.snap(new)
+            desqueezeFactorState.value = snapped
+            LocalDesqueezeRatio.matching(snapped)?.let { desqueezeRatioState.value = it }
+            preferences
+                .edit()
+                .putFloat(DESQUEEZE_FACTOR_KEY, snapped)
+                .putString(DESQUEEZE_RATIO_KEY, desqueezeRatioState.value.name)
+                .apply()
         }
 
     /** Selected camera-level presentation; persisted immediately on change. */
@@ -877,6 +910,7 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
                 levelStyle = levelStyle,
                 desqueezeEnabled = desqueezeEnabled.value,
                 desqueezeRatio = desqueezeRatio,
+                desqueezeFactor = desqueezeFactor,
                 desqueezeOrientation = desqueezeOrientation,
             )
 
@@ -1120,10 +1154,18 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
         LocalDesqueezeRatio.fromStoredName(preferences.getString(DESQUEEZE_RATIO_KEY, null))
             ?: legacyDesqueezeRatio()
 
+    private fun loadDesqueezeFactor(): Float {
+        if (preferences.contains(DESQUEEZE_FACTOR_KEY)) {
+            return LocalDesqueezeRatio.snap(preferences.getFloat(DESQUEEZE_FACTOR_KEY, 1f))
+        }
+        return loadDesqueezeRatio().factor
+    }
+
     private fun legacyDesqueezeRatio(): LocalDesqueezeRatio =
         when (preferences.getString(LEGACY_DESQUEEZE_PRESENTATION_KEY, null)) {
             "X133" -> LocalDesqueezeRatio.X133
             "X150" -> LocalDesqueezeRatio.X150
+            "X160" -> LocalDesqueezeRatio.X160
             "X165" -> LocalDesqueezeRatio.X165
             "X180" -> LocalDesqueezeRatio.X180
             "X200" -> LocalDesqueezeRatio.X200
@@ -1335,6 +1377,7 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
         const val RULE_OF_THIRDS_KEY = "assist.local.ruleOfThirds"
         const val DESQUEEZE_ENABLED_KEY = "assist.local.desqueeze.enabled.v2"
         const val DESQUEEZE_RATIO_KEY = "assist.local.desqueeze.ratio.v2"
+        const val DESQUEEZE_FACTOR_KEY = "assist.local.desqueeze.factor.v1"
         const val DESQUEEZE_ORIENTATION_KEY = "assist.local.desqueeze.orientation.v2"
         const val LEGACY_FRAMING_GUIDE_KEY = "assist.local.framingGuide.v1"
         const val LEGACY_DESQUEEZE_PRESENTATION_KEY = "assist.local.desqueezePresentation.v1"

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/OperatorSettings.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/OperatorSettings.kt
@@ -200,11 +200,14 @@ public enum class LocalDesqueezeRatio(
             entries.firstOrNull { it.name == value }
 
         fun matching(factor: Float): LocalDesqueezeRatio? =
-            entries.firstOrNull { kotlin.math.abs(it.factor - factor) < 0.001f }
+            entries.firstOrNull { kotlin.math.abs(it.factor - factor) < 0.005f }
+
+        /** Custom slider step (1.00…2.00 in 0.01 increments). */
+        const val FACTOR_STEP: Float = 0.01f
 
         fun snap(raw: Float): Float {
             val clamped = raw.coerceIn(1f, 2f)
-            return ((clamped / 0.1f).roundToInt() * 0.1f).coerceIn(1f, 2f)
+            return ((clamped / FACTOR_STEP).roundToInt() * FACTOR_STEP).coerceIn(1f, 2f)
         }
     }
 }
@@ -693,7 +696,7 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
                 .apply()
         }
 
-    /** Applied de-squeeze factor (1.0…2.0, 0.1 steps); source of truth for presentation scale. */
+    /** Applied de-squeeze factor (1.0…2.0, 0.01 steps); source of truth for presentation scale. */
     public var desqueezeFactor: Float
         get() = desqueezeFactorState.value
         set(new) {

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/OperatorSettingsScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/OperatorSettingsScreen.kt
@@ -1026,6 +1026,7 @@ private fun desqueezeRatioLabel(value: LocalDesqueezeRatio): String =
             LocalDesqueezeRatio.X100 -> R.string.desqueeze_1
             LocalDesqueezeRatio.X133 -> R.string.desqueeze_133
             LocalDesqueezeRatio.X150 -> R.string.desqueeze_15
+            LocalDesqueezeRatio.X160 -> R.string.desqueeze_16
             LocalDesqueezeRatio.X165 -> R.string.desqueeze_165
             LocalDesqueezeRatio.X180 -> R.string.desqueeze_18
             LocalDesqueezeRatio.X200 -> R.string.desqueeze_2

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/OperatorSettingsScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/OperatorSettingsScreen.kt
@@ -1,5 +1,7 @@
 package com.opencapture.openzcine.settings
 
+import com.opencapture.openzcine.performOperatorHaptic
+
 import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
@@ -222,7 +224,7 @@ internal fun OperatorSettingsScreen(
         val hapticsWereEnabled = settings.hapticsEnabled.value
         toggle.toggle()
         if (hapticsWereEnabled) {
-            feedbackView.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+            feedbackView.performOperatorHaptic(HapticFeedbackConstants.KEYBOARD_TAP)
         }
     }
     val toggleAssist: (AssistTool) -> Unit = { tool ->
@@ -236,12 +238,12 @@ internal fun OperatorSettingsScreen(
                 Toast.LENGTH_SHORT,
             ).show()
         } else if (hapticsEnabled) {
-            feedbackView.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+            feedbackView.performOperatorHaptic(HapticFeedbackConstants.KEYBOARD_TAP)
         }
     }
     val emitHaptic: () -> Unit = {
         if (settings.hapticsEnabled.value) {
-            feedbackView.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+            feedbackView.performOperatorHaptic(HapticFeedbackConstants.KEYBOARD_TAP)
         }
     }
     var selectedTab by rememberSaveable(initialTab) { mutableStateOf(initialTab) }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/SettingsComponents.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/SettingsComponents.kt
@@ -26,7 +26,9 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -598,7 +600,18 @@ public fun GlassPillSlider(
     val localBackdrop = rememberLayerBackdrop()
     val sceneBackdrop = monitorGlass?.layerBackdrop
     val latestOnChange by rememberUpdatedState(onChange)
+    val latestValue by rememberUpdatedState(value)
     val floatRange = range.first.toFloat()..range.last.toFloat()
+    // Continuous thumb position while dragging. Discrete onChange (Int steps) alone cannot
+    // drive a smooth pill drag — intermediate floats would be rounded away and the thumb
+    // would stick (especially on short ranges like desqueeze 0…10).
+    var displayValue by remember { mutableFloatStateOf(value.toFloat()) }
+    // Accept external commits without yanking the pill back to the last Int mid-drag.
+    SideEffect {
+        if (displayValue.roundToInt().coerceIn(range) != value) {
+            displayValue = value.toFloat()
+        }
+    }
 
     Box(
         modifier
@@ -617,6 +630,7 @@ public fun GlassPillSlider(
                         (range.first + target * (range.last - range.first))
                             .roundToInt()
                             .coerceIn(range)
+                    displayValue = next.toFloat()
                     latestOnChange(next)
                     true
                 }
@@ -641,10 +655,11 @@ public fun GlassPillSlider(
             )
         }
         LiquidSlider(
-            value = { value.toFloat() },
+            value = { displayValue },
             onValueChange = { next ->
+                displayValue = next
                 val rounded = next.roundToInt().coerceIn(range)
-                if (rounded != value) latestOnChange(rounded)
+                if (rounded != latestValue) latestOnChange(rounded)
             },
             valueRange = floatRange,
             visibilityThreshold = 0.5f,

--- a/Apps/Android/app/src/main/res/values/strings.xml
+++ b/Apps/Android/app/src/main/res/values/strings.xml
@@ -337,6 +337,7 @@
     <string name="command_iso_recording_wait">ISO is unavailable during recording until codec readback completes.</string>
     <string name="command_iso_recording_locked">ISO is locked while recording in R3D NE.</string>
     <string name="iso_auto_drum_locked">Auto ISO is on — the camera sets sensitivity. Switch to Auto Off to choose a value.</string>
+    <string name="iso_manual_requires_m_mode">Manual ISO needs exposure mode M. The camera is setting sensitivity.</string>
     <string name="command_iso_wait_codec">Waiting for the camera codec before offering ISO values.</string>
     <string name="command_iso_wait_base">Waiting for the active base-ISO circuit.</string>
     <string name="command_iso_no_values">This camera did not provide ISO values for the active circuit.</string>
@@ -476,7 +477,6 @@
     <string name="camera_hop_failed_title">Couldn\'t rejoin camera</string>
     <string name="camera_hop_failed_fallback">Open the camera\'s network screen and reconnect from My cameras.</string>
     <string name="control_set_success">%1$s set to %2$s.</string>
-    <string name="control_confirmation_failed">%1$s did not confirm %2$s. Check the active camera mode and try again.</string>
     <string name="control_change_rejected">The camera rejected the control change.</string>
     <string name="control_error">%1$s: %2$s</string>
     <string name="focus_change_rejected">The camera rejected the focus-point change.</string>

--- a/Apps/Android/app/src/main/res/values/strings.xml
+++ b/Apps/Android/app/src/main/res/values/strings.xml
@@ -749,9 +749,11 @@
     <string name="desqueeze_1">1x</string>
     <string name="desqueeze_133">1.33x</string>
     <string name="desqueeze_15">1.5x</string>
+    <string name="desqueeze_16">1.6x</string>
     <string name="desqueeze_165">1.65x</string>
     <string name="desqueeze_18">1.8x</string>
     <string name="desqueeze_2">2x</string>
+    <string name="desqueeze_custom">Custom %1$.1f×</string>
     <string name="orientation_horizontal">Horizontal</string>
     <string name="orientation_vertical">Vertical</string>
     <string name="level_horizon">Horizon</string>

--- a/Apps/Android/app/src/main/res/values/strings.xml
+++ b/Apps/Android/app/src/main/res/values/strings.xml
@@ -336,6 +336,7 @@
     <!-- DISP command dashboard. -->
     <string name="command_iso_recording_wait">ISO is unavailable during recording until codec readback completes.</string>
     <string name="command_iso_recording_locked">ISO is locked while recording in R3D NE.</string>
+    <string name="iso_auto_drum_locked">Auto ISO is on — the camera sets sensitivity. Switch to Auto Off to choose a value.</string>
     <string name="command_iso_wait_codec">Waiting for the camera codec before offering ISO values.</string>
     <string name="command_iso_wait_base">Waiting for the active base-ISO circuit.</string>
     <string name="command_iso_no_values">This camera did not provide ISO values for the active circuit.</string>

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/FramingAssistsTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/FramingAssistsTest.kt
@@ -20,14 +20,14 @@ class FramingAssistsTest {
             localDesqueezePresentationRect(
                 feed = feed,
                 enabled = true,
-                ratio = LocalDesqueezeRatio.X200,
+                factor = LocalDesqueezeRatio.X200.factor,
                 orientation = LocalDesqueezeOrientation.HORIZONTAL,
             )
         val vertical =
             localDesqueezePresentationRect(
                 feed = feed,
                 enabled = true,
-                ratio = LocalDesqueezeRatio.X200,
+                factor = LocalDesqueezeRatio.X200.factor,
                 orientation = LocalDesqueezeOrientation.VERTICAL,
             )
 

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/MonitorCameraControlsTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/MonitorCameraControlsTest.kt
@@ -509,10 +509,73 @@ class MonitorCameraControlsTest {
                     codecSelection = "N-RAW",
                 ),
             )
+        // Without exposure mode M, only Auto On is offered (manual needs M).
         val iso = monitorCaptureSettings(dashboard, strings).first { it.kind == MonitorPickerKind.ISO }
-        assertEquals("Sensitivity", iso.picker?.subtitle)
+        assertEquals("Sensitivity · auto (M mode for manual)", iso.picker?.subtitle)
         assertEquals(1, iso.picker?.modes?.size)
+        assertEquals("Auto On", iso.picker?.modes?.single()?.label)
         assertEquals(IsoPickerPolicy.unifiedOptions, iso.picker?.modes?.single()?.request?.options)
+    }
+
+    @Test
+    fun `ISO Auto Off is available only in exposure mode M for non R3D`() {
+        val dashboard =
+            dashboard(
+                cameraSnapshot().copy(
+                    codec = "N-RAW",
+                    codecSelection = "N-RAW",
+                    exposureMode = "M",
+                    isoAuto = false,
+                ),
+            )
+        val iso =
+            monitorCaptureSettings(
+                    dashboard,
+                    strings,
+                    isoAuto = false,
+                    exposureMode = "M",
+                )
+                .first { it.kind == MonitorPickerKind.ISO }
+        assertEquals(2, iso.picker?.modes?.size)
+        assertEquals(listOf("Auto On", "Auto Off"), iso.picker?.modes?.map { it.label })
+        assertEquals(false, iso.picker?.drumInteractionLocked)
+
+        val aperture =
+            monitorCaptureSettings(
+                    dashboard,
+                    strings,
+                    isoAuto = true,
+                    exposureMode = "A",
+                )
+                .first { it.kind == MonitorPickerKind.ISO }
+        assertEquals(1, aperture.picker?.modes?.size)
+        assertEquals("Auto On", aperture.picker?.modes?.single()?.label)
+        assertEquals(true, aperture.picker?.drumInteractionLocked)
+    }
+
+    @Test
+    fun `R3D NE dual base ISO stays manual in aperture priority`() {
+        val dashboard =
+            dashboard(
+                cameraSnapshot().copy(
+                    codec = "R3D NE",
+                    codecSelection = "R3D NE",
+                    exposureMode = "A",
+                    iso = 800,
+                ),
+            )
+        val iso =
+            monitorCaptureSettings(
+                    dashboard,
+                    strings,
+                    exposureMode = "A",
+                )
+                .first { it.kind == MonitorPickerKind.ISO }
+        assertEquals("Sensitivity · dual base", iso.picker?.subtitle)
+        assertEquals(2, iso.picker?.modes?.size)
+        assertEquals(listOf("Low Base", "High Base"), iso.picker?.modes?.map { it.label })
+        assertEquals(false, iso.picker?.drumInteractionLocked)
+        assertEquals(null, iso.picker?.drumLockBanner)
     }
 
     @Test

--- a/Apps/Android/core-api/src/main/kotlin/com/opencapture/openzcine/core/CameraSession.kt
+++ b/Apps/Android/core-api/src/main/kotlin/com/opencapture/openzcine/core/CameraSession.kt
@@ -123,6 +123,12 @@ public enum class CameraControl {
     /** Movie ISO sensitivity, such as `"800"`. */
     ISO,
 
+    /**
+     * Movie ISO auto/manual (`MovISOAutoControl`), `"ON"` or `"OFF"`.
+     * Independent of [EXPOSURE_MODE] Auto.
+     */
+    ISO_AUTO,
+
     /** Movie shutter speed or angle, such as `"1/50"` or `"180.0°"`. */
     SHUTTER,
 
@@ -279,6 +285,7 @@ public data class CameraControlCapabilities(
     public fun options(control: CameraControl): List<String> =
         when (control) {
             CameraControl.ISO -> isoValues
+            CameraControl.ISO_AUTO -> listOf("ON", "OFF")
             CameraControl.SHUTTER -> shutterValues
             CameraControl.IRIS -> irisValues
             CameraControl.WHITE_BALANCE -> whiteBalanceValues
@@ -314,6 +321,11 @@ public data class CameraPropertySnapshot(
     val iso: Long? = null,
     /** Dual-base ISO circuit label when the camera exposes one. */
     val baseIso: String? = null,
+    /**
+     * Movie ISO auto (`MovISOAutoControl` 0xD0AD). `true` = camera owns ISO.
+     * Independent of [exposureMode] Auto.
+     */
+    val isoAuto: Boolean? = null,
     /** Exposure-program label, such as `M`. */
     val exposureMode: String? = null,
     /** The camera's active shutter display convention. */

--- a/Apps/Android/core-api/src/main/kotlin/com/opencapture/openzcine/core/FakeCameraSession.kt
+++ b/Apps/Android/core-api/src/main/kotlin/com/opencapture/openzcine/core/FakeCameraSession.kt
@@ -74,6 +74,10 @@ public class FakeCameraSession(
                 mutableProperties.update {
                     it.copy(iso = label.toLongOrNull() ?: it.iso)
                 }
+            CameraControl.ISO_AUTO ->
+                mutableProperties.update {
+                    it.copy(isoAuto = label.equals("ON", ignoreCase = true))
+                }
             CameraControl.BASE_ISO ->
                 mutableProperties.update { it.copy(baseIso = label) }
             CameraControl.SHUTTER ->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- Playback and live **desqueeze**: scales the picture (not only guides), with 1.6× and custom
+  1.00–2.00× (0.01 steps) on iOS and Android.
+- **Auto ISO** for non-R3D movie codecs (N-RAW / ProRes / H.26x): Auto On/Off controls movie ISO
+  auto (not P/A/S/M). Live working ISO while Auto is on (e.g. A51200); manual / Auto Off only in
+  exposure mode **M**. R3D NE keeps Low/High dual-base and stays manual in every exposure mode.
 - USB-C tethered transport (iOS, via ImageCaptureCore): USB camera discovery, connection,
   auto-reconnect on plug-in, and a transport-aware first-pair wizard with real USB-C setup steps.
   Wi-Fi (PTP-IP) and USB-C now share one session layer behind a transaction-level
@@ -22,6 +27,8 @@ All notable changes to this project are documented here. The format is based on
 
 ### Changed
 
+- Android control writes: facade owns encode + native confirm; shell no longer soft-fails after a
+  successful apply (see `docs/android-control-writes.md`).
 - TestFlight notes are now reviewed, tester-written copy with concrete test steps. CI rejects stale
   notes, commit titles, and common implementation jargon before an iOS build can ship.
 

--- a/Sources/OpenZCineAndroidFacade/AndroidCameraControlWire.swift
+++ b/Sources/OpenZCineAndroidFacade/AndroidCameraControlWire.swift
@@ -7,6 +7,7 @@ import OpenZCineCore
 /// corresponding `PTPCameraPropertyWrite`; no Nikon value crosses JNI.
 enum AndroidCameraControl: Hashable, Sendable {
     case iso
+    case isoAuto
     case shutter
     case iris
     case whiteBalance
@@ -32,7 +33,7 @@ enum AndroidCameraControl: Hashable, Sendable {
     /// Exposure mode remains the one iOS-parity control whose fixed program labels are owned by
     /// the shared decoder rather than a body descriptor.
     var requiresCapabilityValidation: Bool {
-        self != .exposureMode
+        self != .exposureMode && self != .isoAuto
     }
 
     /// When the capability domain is still empty (descriptor bootstrap pending, or
@@ -42,7 +43,7 @@ enum AndroidCameraControl: Hashable, Sendable {
     /// matching iOS, which never invents packed MovScreenSize / MovFileType values.
     var allowsEncodeWithoutCapabilityDomain: Bool {
         switch self {
-        case .iso, .shutter, .iris, .whiteBalance, .focusMode, .focusArea, .focusSubject,
+        case .iso, .isoAuto, .shutter, .iris, .whiteBalance, .focusMode, .focusArea, .focusSubject,
             .exposureMode, .audioSensitivity, .audioInput, .windFilter, .attenuator,
             .audio32BitFloat, .shutterMode, .shutterLock, .vibrationReduction, .baseISO:
             // baseISO: the capture-bar dual-base tabs always send Low/High; encode when the
@@ -58,6 +59,7 @@ enum AndroidCameraControl: Hashable, Sendable {
     var sharedControl: PTPCameraControl? {
         switch self {
         case .iso: .iso
+        case .isoAuto: .isoAuto
         case .shutter: .shutter
         case .iris: .iris
         case .whiteBalance: .whiteBalanceKelvin
@@ -83,6 +85,7 @@ enum AndroidCameraControl: Hashable, Sendable {
     init(_ control: PTPCameraControl) {
         switch control {
         case .iso: self = .iso
+        case .isoAuto: self = .isoAuto
         case .shutter: self = .shutter
         case .iris: self = .iris
         case .whiteBalanceKelvin: self = .whiteBalance
@@ -131,6 +134,7 @@ enum AndroidCameraControlWire {
         case 18: return .codec
         case 19: return .vibrationReduction
         case 20: return .electronicVR
+        case 21: return .isoAuto
         default: return nil
         }
     }

--- a/Sources/OpenZCineAndroidFacade/AndroidCameraPropertyReadbackWire.swift
+++ b/Sources/OpenZCineAndroidFacade/AndroidCameraPropertyReadbackWire.swift
@@ -200,6 +200,7 @@ public enum AndroidCameraPropertyReadbackWire {
         var fields = [(key: "result", value: readback.result.rawValue)]
         append("iso", value: properties.iso.map { String($0) }, to: &fields)
         append("baseIso", value: properties.baseISO, to: &fields)
+        append("isoAuto", value: properties.isoAuto.map { String($0) }, to: &fields)
         append("exposureMode", value: properties.exposureMode, to: &fields)
         append("shutterMode", value: properties.shutterMode?.rawValue, to: &fields)
         append("shutterLocked", value: properties.shutterLocked.map { String($0) }, to: &fields)

--- a/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
+++ b/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
@@ -2077,7 +2077,16 @@ public final class PTPIPClientSession: @unchecked Sendable {
                 // values in the live enum (the body often only advertises the active state).
                 let isShutterLockToggle =
                     control == .shutterLock && (label == "Locked" || label == "Unlocked")
-                if !isFineKelvin, !isShutterLockToggle {
+                // Movie ISO: the capability list is a UI ladder (dual-base circuit / unified
+                // steps). Auto can park outside it (e.g. 51200) and the body still accepts
+                // MovieExposureIndex / MovieISOSensitivity. Rejecting here flashes a false
+                // "not supported" after Auto Off (or a dual-write) already moved the body.
+                // Any numeric label the shared core can encode is allowed; the body remains
+                // the authority if a value is truly out of range.
+                let isEncodableISO =
+                    control == .iso
+                    && PTPCameraPropertyWrite.isoWrite(label: label, dualBase: false) != nil
+                if !isFineKelvin, !isShutterLockToggle, !isEncodableISO {
                     return []
                 }
             }
@@ -2402,6 +2411,7 @@ public final class PTPIPClientSession: @unchecked Sendable {
     /// True when a property write is confirmed by readback.
     /// - `MovScreenSize`: decoded width/height/fps (camera may rewrite low packing bits).
     /// - `MovieFocusMode`: decoded label (MF raw 3 lens-ring and 4 menu are equivalent).
+    /// - Movie ISO family: UINT32 value (payload may be padded beyond 4 bytes).
     /// - Other properties: byte-exact.
     static func propertyWriteMatchesReadback(
         write: PTPCameraPropertyWrite,
@@ -2424,6 +2434,17 @@ public final class PTPIPClientSession: @unchecked Sendable {
             // Label match: MF (3/4) and AF labels compare as decoded strings.
             return PTPCameraPropertyDecoders.movieFocusMode(written)
                 == PTPCameraPropertyDecoders.movieFocusMode(live)
+        }
+        // Effective / dual-base / exposure-index ISO — compare the UINT32, not raw length.
+        if write.property == .movieExposureIndex
+            || write.property == .movieISOSensitivity
+            || write.property == .isoControlSensitivity,
+            write.data.count >= 4,
+            readback.count >= 4
+        {
+            let written = ByteCoding.readUInt32LE([UInt8](write.data), at: 0)
+            let live = ByteCoding.readUInt32LE([UInt8](readback), at: 0)
+            return written == live
         }
         return readback == write.data
     }

--- a/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
+++ b/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
@@ -2083,7 +2083,7 @@ public final class PTPIPClientSession: @unchecked Sendable {
             }
         }
         switch control {
-        case .iso, .focusMode:
+        case .iso, .isoAuto, .focusMode:
             return sharedControlWrites(control, label: label)
         case .shutter:
             if let write = shutterDescriptorWrite(label: label) {
@@ -2273,6 +2273,7 @@ public final class PTPIPClientSession: @unchecked Sendable {
             usesNikonZRFallbacks: usesNikonZRFallbacks)
         return switch control {
         case .iso: capabilities.isoValues
+        case .isoAuto: ["ON", "OFF"]
         case .shutter: capabilities.shutterValues
         case .iris: capabilities.irisValues
         case .whiteBalance: capabilities.whiteBalanceValues

--- a/Sources/OpenZCineCore/ISOPickerPolicy.swift
+++ b/Sources/OpenZCineCore/ISOPickerPolicy.swift
@@ -41,13 +41,37 @@ public enum ISOPickerPolicy: Sendable {
         isR3DNECodec(codec)
     }
 
+    /// Non-R3D NE codecs use Auto On/Off tabs instead of dual-base circuits.
+    public static func showsAutoISOControl(codec: String) -> Bool {
+        !showsDualBaseCircuits(codec: codec)
+    }
+
+    /// Exposure modes where the body typically owns ISO (auto ISO). Manual ISO is free in `M`.
+    public static func isAutoISOActive(exposureMode: String?) -> Bool {
+        guard let mode = exposureMode?.trimmingCharacters(in: .whitespacesAndNewlines), !mode.isEmpty
+        else { return false }
+        switch mode {
+        case "Auto", "P", "A", "S":
+            return true
+        default:
+            // U1–U3 and M are treated as operator-controlled ISO unless the body reports Auto.
+            return mode.localizedCaseInsensitiveContains("auto")
+        }
+    }
+
+    /// Exposure-mode label that enables auto ISO (full Auto program).
+    public static let autoISOOnExposureMode = "Auto"
+
+    /// Exposure-mode label that releases ISO for the drum (manual movie exposure).
+    public static let autoISOOffExposureMode = "M"
+
     /// ISO cannot be changed while recording in R3D NE; other codecs allow mid-roll ISO changes.
     public static func blocksISOChangeWhileRecording(codec: String, isRecording: Bool) -> Bool {
         isR3DNECodec(codec) && isRecording
     }
 
     /// Star markers for the active layout. Dual-base marks one native base per circuit tab;
-    /// unified marks both native bases on the single drum.
+    /// unified / Auto ISO marks both native bases on the single drum.
     public static func markedValues(codec: String, modeIndex: Int) -> Set<String> {
         if showsDualBaseCircuits(codec: codec) {
             guard modeIndex == 0 || modeIndex == 1 else { return [] }
@@ -58,26 +82,49 @@ public enum ISOPickerPolicy: Sendable {
 
     /// Subtitle shown under the ISO picker header.
     public static func pickerSubtitle(codec: String) -> String {
-        showsDualBaseCircuits(codec: codec) ? "Sensitivity · dual base" : "Sensitivity"
+        if showsDualBaseCircuits(codec: codec) { return "Sensitivity · dual base" }
+        if showsAutoISOControl(codec: codec) { return "Sensitivity · auto / manual" }
+        return "Sensitivity"
     }
 
-    /// Mode tabs for the ISO picker. Empty when the unified drum is shown.
+    /// Mode tabs for the ISO picker.
+    /// R3D NE → Low/High base; other codecs → Auto On / Auto Off; never empty for ZR movie codecs.
     public static func pickerModes(codec: String) -> [ISOPickerMode] {
-        guard showsDualBaseCircuits(codec: codec) else { return [] }
-        return [
-            ISOPickerMode(
-                title: "Low Base",
-                detail: "\(lowBaseMarker) · 200-3200",
-                options: lowBaseOptions,
-                base: lowBaseMarker
-            ),
-            ISOPickerMode(
-                title: "High Base",
-                detail: "\(highBaseMarker) · 1600-25600",
-                options: highBaseOptions,
-                base: highBaseMarker
-            ),
-        ]
+        if showsDualBaseCircuits(codec: codec) {
+            return [
+                ISOPickerMode(
+                    title: "Low Base",
+                    detail: "\(lowBaseMarker) · 200-3200",
+                    options: lowBaseOptions,
+                    base: lowBaseMarker
+                ),
+                ISOPickerMode(
+                    title: "High Base",
+                    detail: "\(highBaseMarker) · 1600-25600",
+                    options: highBaseOptions,
+                    base: highBaseMarker
+                ),
+            ]
+        }
+        if showsAutoISOControl(codec: codec) {
+            return [
+                ISOPickerMode(
+                    title: "Auto On",
+                    detail: "Camera controls ISO",
+                    options: unifiedOptions,
+                    base: lowBaseMarker,
+                    activatesAutoISO: true
+                ),
+                ISOPickerMode(
+                    title: "Auto Off",
+                    detail: "Manual ISO",
+                    options: unifiedOptions,
+                    base: lowBaseMarker,
+                    activatesAutoISO: false
+                ),
+            ]
+        }
+        return []
     }
 
     /// Options for the active ISO layout and mode tab.
@@ -86,19 +133,33 @@ public enum ISOPickerPolicy: Sendable {
         guard !modes.isEmpty, modes.indices.contains(modeIndex) else { return unifiedOptions }
         return modes[modeIndex].options
     }
+
+    /// Active mode tab for Auto ISO codecs: 0 = Auto On, 1 = Auto Off.
+    public static func autoISOModeIndex(exposureMode: String?) -> Int {
+        isAutoISOActive(exposureMode: exposureMode) ? 0 : 1
+    }
 }
 
-/// One segmented mode under the ISO picker (LOW/HIGH base circuits for R3D NE).
+/// One segmented mode under the ISO picker (LOW/HIGH base or Auto On/Off).
 public struct ISOPickerMode: Equatable, Sendable {
     public let title: String
     public let detail: String?
     public let options: [String]
     public let base: String
+    /// When non-nil, selecting this tab should switch camera auto-ISO on (`true`) or off (`false`).
+    public let activatesAutoISO: Bool?
 
-    public init(title: String, detail: String? = nil, options: [String], base: String) {
+    public init(
+        title: String,
+        detail: String? = nil,
+        options: [String],
+        base: String,
+        activatesAutoISO: Bool? = nil
+    ) {
         self.title = title
         self.detail = detail
         self.options = options
         self.base = base
+        self.activatesAutoISO = activatesAutoISO
     }
 }

--- a/Sources/OpenZCineCore/ISOPickerPolicy.swift
+++ b/Sources/OpenZCineCore/ISOPickerPolicy.swift
@@ -54,6 +54,30 @@ public enum ISOPickerPolicy: Sendable {
         isoAuto == true
     }
 
+    /// Whether the operator may write a manual movie ISO value for this codec / mode.
+    ///
+    /// - **R3D NE** (dual-base): always manual ISO — the body forces dual-base circuits even in
+    ///   A/S/P; exposure program does not own sensitivity.
+    /// - **Other codecs**: only **M** accepts Auto Off + ISO drum writes; P/A/S/Auto keep
+    ///   sensitivity camera-owned. Fail closed when the mode is unknown.
+    public static func allowsManualISO(codec: String, exposureMode: String?) -> Bool {
+        if showsDualBaseCircuits(codec: codec) { return true }
+        return exposureMode == "M"
+    }
+
+    /// True when the ISO value drum is camera-owned (Auto On, or non-R3D mode is not M).
+    ///
+    /// Always `false` for R3D NE dual-base (manual circuits); recording lock is separate.
+    public static func isISOValueCameraOwned(
+        codec: String,
+        isoAuto: Bool?,
+        exposureMode: String?
+    ) -> Bool {
+        if showsDualBaseCircuits(codec: codec) { return false }
+        return isAutoISOActive(isoAuto: isoAuto)
+            || !allowsManualISO(codec: codec, exposureMode: exposureMode)
+    }
+
     /// Label written for Auto On (`MovISOAutoControl` UINT8 = 1).
     public static let autoISOOnLabel = "ON"
 
@@ -76,15 +100,20 @@ public enum ISOPickerPolicy: Sendable {
     }
 
     /// Subtitle shown under the ISO picker header.
-    public static func pickerSubtitle(codec: String) -> String {
+    public static func pickerSubtitle(codec: String, exposureMode: String? = nil) -> String {
         if showsDualBaseCircuits(codec: codec) { return "Sensitivity · dual base" }
-        if showsAutoISOControl(codec: codec) { return "Sensitivity · auto / manual" }
+        if showsAutoISOControl(codec: codec) {
+            if allowsManualISO(codec: codec, exposureMode: exposureMode) {
+                return "Sensitivity · auto / manual"
+            }
+            return "Sensitivity · auto (M mode for manual)"
+        }
         return "Sensitivity"
     }
 
     /// Mode tabs for the ISO picker.
-    /// R3D NE → Low/High base; other codecs → Auto On / Auto Off; never empty for ZR movie codecs.
-    public static func pickerModes(codec: String) -> [ISOPickerMode] {
+    /// R3D NE → Low/High base; other codecs → Auto On / Auto Off (Auto Off only in M mode).
+    public static func pickerModes(codec: String, exposureMode: String? = nil) -> [ISOPickerMode] {
         if showsDualBaseCircuits(codec: codec) {
             return [
                 ISOPickerMode(
@@ -102,36 +131,69 @@ public enum ISOPickerPolicy: Sendable {
             ]
         }
         if showsAutoISOControl(codec: codec) {
-            return [
+            var modes = [
                 ISOPickerMode(
                     title: "Auto On",
                     detail: "Camera controls ISO",
                     options: unifiedOptions,
                     base: lowBaseMarker,
                     activatesAutoISO: true
-                ),
-                ISOPickerMode(
-                    title: "Auto Off",
-                    detail: "Manual ISO",
-                    options: unifiedOptions,
-                    base: lowBaseMarker,
-                    activatesAutoISO: false
-                ),
+                )
             ]
+            // Manual ISO / Auto Off only when the exposure dial is M (non-R3D).
+            if allowsManualISO(codec: codec, exposureMode: exposureMode) {
+                modes.append(
+                    ISOPickerMode(
+                        title: "Auto Off",
+                        detail: "Manual ISO",
+                        options: unifiedOptions,
+                        base: lowBaseMarker,
+                        activatesAutoISO: false
+                    )
+                )
+            }
+            return modes
         }
         return []
     }
 
     /// Options for the active ISO layout and mode tab.
-    public static func options(codec: String, modeIndex: Int) -> [String] {
+    ///
+    /// When Auto is driving a value outside the fixed ladder (e.g. 51200), `includingLiveISO`
+    /// injects it so the locked drum can centre on the body's working sensitivity.
+    public static func options(
+        codec: String,
+        modeIndex: Int,
+        includingLiveISO: String? = nil
+    ) -> [String] {
         let modes = pickerModes(codec: codec)
-        guard !modes.isEmpty, modes.indices.contains(modeIndex) else { return unifiedOptions }
-        return modes[modeIndex].options
+        var base =
+            (!modes.isEmpty && modes.indices.contains(modeIndex))
+            ? modes[modeIndex].options : unifiedOptions
+        if let live = includingLiveISO?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !live.isEmpty,
+            live.allSatisfy(\.isNumber),
+            !base.contains(live)
+        {
+            let liveValue = UInt32(live) ?? 0
+            if let insertAt = base.firstIndex(where: { (UInt32($0) ?? 0) > liveValue }) {
+                base.insert(live, at: insertAt)
+            } else {
+                base.append(live)
+            }
+        }
+        return base
     }
 
-    /// Active mode tab for Auto ISO codecs: 0 = Auto On, 1 = Auto Off.
-    public static func autoISOModeIndex(isoAuto: Bool?) -> Int {
-        isAutoISOActive(isoAuto: isoAuto) ? 0 : 1
+    /// Active mode tab for Auto ISO codecs: 0 = Auto On, 1 = Auto Off (when available).
+    public static func autoISOModeIndex(
+        codec: String,
+        isoAuto: Bool?,
+        exposureMode: String? = nil
+    ) -> Int {
+        // Without Auto Off (non-M on non-R3D), stay on the only tab.
+        guard allowsManualISO(codec: codec, exposureMode: exposureMode) else { return 0 }
+        return isAutoISOActive(isoAuto: isoAuto) ? 0 : 1
     }
 }
 

--- a/Sources/OpenZCineCore/ISOPickerPolicy.swift
+++ b/Sources/OpenZCineCore/ISOPickerPolicy.swift
@@ -42,8 +42,11 @@ public enum ISOPickerPolicy: Sendable {
     }
 
     /// Non-R3D NE codecs use Auto On/Off tabs instead of dual-base circuits.
+    /// Empty/unknown codec stays closed until the body reports a real file type.
     public static func showsAutoISOControl(codec: String) -> Bool {
-        !showsDualBaseCircuits(codec: codec)
+        let trimmed = codec.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        return !showsDualBaseCircuits(codec: trimmed)
     }
 
     /// Whether movie ISO auto is active (`MovieISOAutoControl` / `MovISOAutoControl` 0xD0AD).

--- a/Sources/OpenZCineCore/ISOPickerPolicy.swift
+++ b/Sources/OpenZCineCore/ISOPickerPolicy.swift
@@ -46,24 +46,19 @@ public enum ISOPickerPolicy: Sendable {
         !showsDualBaseCircuits(codec: codec)
     }
 
-    /// Exposure modes where the body typically owns ISO (auto ISO). Manual ISO is free in `M`.
-    public static func isAutoISOActive(exposureMode: String?) -> Bool {
-        guard let mode = exposureMode?.trimmingCharacters(in: .whitespacesAndNewlines), !mode.isEmpty
-        else { return false }
-        switch mode {
-        case "Auto", "P", "A", "S":
-            return true
-        default:
-            // U1–U3 and M are treated as operator-controlled ISO unless the body reports Auto.
-            return mode.localizedCaseInsensitiveContains("auto")
-        }
+    /// Whether movie ISO auto is active (`MovieISOAutoControl` / `MovISOAutoControl` 0xD0AD).
+    ///
+    /// This is independent of exposure-program Auto (P/A/S/M). Unpolled (`nil`) means manual until
+    /// the body reports otherwise so the drum is not falsely locked.
+    public static func isAutoISOActive(isoAuto: Bool?) -> Bool {
+        isoAuto == true
     }
 
-    /// Exposure-mode label that enables auto ISO (full Auto program).
-    public static let autoISOOnExposureMode = "Auto"
+    /// Label written for Auto On (`MovISOAutoControl` UINT8 = 1).
+    public static let autoISOOnLabel = "ON"
 
-    /// Exposure-mode label that releases ISO for the drum (manual movie exposure).
-    public static let autoISOOffExposureMode = "M"
+    /// Label written for Auto Off (`MovISOAutoControl` UINT8 = 0).
+    public static let autoISOOffLabel = "OFF"
 
     /// ISO cannot be changed while recording in R3D NE; other codecs allow mid-roll ISO changes.
     public static func blocksISOChangeWhileRecording(codec: String, isRecording: Bool) -> Bool {
@@ -135,8 +130,8 @@ public enum ISOPickerPolicy: Sendable {
     }
 
     /// Active mode tab for Auto ISO codecs: 0 = Auto On, 1 = Auto Off.
-    public static func autoISOModeIndex(exposureMode: String?) -> Int {
-        isAutoISOActive(exposureMode: exposureMode) ? 0 : 1
+    public static func autoISOModeIndex(isoAuto: Bool?) -> Int {
+        isAutoISOActive(isoAuto: isoAuto) ? 0 : 1
     }
 }
 

--- a/Sources/OpenZCineCore/OperatorPreferences.swift
+++ b/Sources/OpenZCineCore/OperatorPreferences.swift
@@ -770,7 +770,8 @@ public struct AssistConfiguration: Codable, Equatable, Sendable {
         public init(from decoder: Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
-            orientation = try c.decodeIfPresent(Orientation.self, forKey: .orientation) ?? .horizontal
+            orientation =
+                try c.decodeIfPresent(Orientation.self, forKey: .orientation) ?? .horizontal
             if let storedFactor = try c.decodeIfPresent(Double.self, forKey: .factor) {
                 factor = Self.snap(storedFactor)
                 ratio =

--- a/Sources/OpenZCineCore/OperatorPreferences.swift
+++ b/Sources/OpenZCineCore/OperatorPreferences.swift
@@ -702,10 +702,10 @@ public struct AssistConfiguration: Codable, Equatable, Sendable {
                 }
             }
 
-            /// Nearest named chip for a snapped factor, if any chip matches within 0.001.
+            /// Nearest named chip for a snapped factor, if any chip matches within half a step.
             public static func matching(factor: Double) -> Ratio? {
                 let snapped = Desqueeze.snap(factor)
-                return allCases.first { abs($0.factor - snapped) < 0.001 }
+                return allCases.first { abs($0.factor - snapped) < 0.005 }
             }
         }
 
@@ -716,8 +716,8 @@ public struct AssistConfiguration: Codable, Equatable, Sendable {
 
         /// Inclusive operator range for custom de-squeeze.
         public static let factorRange: ClosedRange<Double> = 1.0...2.0
-        /// Slider / step size for custom factor (0.1×).
-        public static let factorStep: Double = 0.1
+        /// Slider / step size for custom factor (0.01×).
+        public static let factorStep: Double = 0.01
 
         public init(
             enabled: Bool = false,

--- a/Sources/OpenZCineCore/OperatorPreferences.swift
+++ b/Sources/OpenZCineCore/OperatorPreferences.swift
@@ -679,10 +679,12 @@ public struct AssistConfiguration: Codable, Equatable, Sendable {
     }
 
     public struct Desqueeze: Codable, Equatable, Sendable {
+        /// Common anamorphic squeeze chips (including 1.6×). Custom values use [factor].
         public enum Ratio: String, CaseIterable, Codable, Equatable, Sendable {
             case x1 = "1x"
             case x133 = "1.33x"
             case x15 = "1.5x"
+            case x16 = "1.6x"
             case x165 = "1.65x"
             case x18 = "1.8x"
             case x2 = "2x"
@@ -693,10 +695,17 @@ public struct AssistConfiguration: Codable, Equatable, Sendable {
                 case .x1: 1.0
                 case .x133: 1.33
                 case .x15: 1.5
+                case .x16: 1.6
                 case .x165: 1.65
                 case .x18: 1.8
                 case .x2: 2.0
                 }
+            }
+
+            /// Nearest named chip for a snapped factor, if any chip matches within 0.001.
+            public static func matching(factor: Double) -> Ratio? {
+                let snapped = Desqueeze.snap(factor)
+                return allCases.first { abs($0.factor - snapped) < 0.001 }
             }
         }
 
@@ -705,17 +714,84 @@ public struct AssistConfiguration: Codable, Equatable, Sendable {
             case vertical = "Vertical"
         }
 
+        /// Inclusive operator range for custom de-squeeze.
+        public static let factorRange: ClosedRange<Double> = 1.0...2.0
+        /// Slider / step size for custom factor (0.1×).
+        public static let factorStep: Double = 0.1
+
         public init(
-            enabled: Bool = false, ratio: Ratio = .x1, orientation: Orientation = .horizontal
+            enabled: Bool = false,
+            ratio: Ratio = .x1,
+            factor: Double? = nil,
+            orientation: Orientation = .horizontal
         ) {
             self.enabled = enabled
-            self.ratio = ratio
             self.orientation = orientation
+            let resolved = Self.snap(factor ?? ratio.factor)
+            self.factor = resolved
+            self.ratio = Ratio.matching(factor: resolved) ?? ratio
         }
 
         public var enabled: Bool
+        /// Named chip when the factor matches a preset; otherwise the last selected chip (UI only).
         public var ratio: Ratio
+        /// Applied squeeze factor in [factorRange], always the source of truth for rendering.
+        public var factor: Double
         public var orientation: Orientation
+
+        /// True when [factor] is not one of the named chips (custom slider value).
+        public var isCustomFactor: Bool { Ratio.matching(factor: factor) == nil }
+
+        /// Sets the applied factor from a named chip.
+        public mutating func select(ratio: Ratio) {
+            self.ratio = ratio
+            self.factor = ratio.factor
+        }
+
+        /// Sets a custom (or snapped) factor from the 1.0…2.0 slider.
+        public mutating func select(factor raw: Double) {
+            let snapped = Self.snap(raw)
+            self.factor = snapped
+            if let match = Ratio.matching(factor: snapped) {
+                self.ratio = match
+            }
+        }
+
+        public static func snap(_ raw: Double) -> Double {
+            let clamped = min(max(raw, factorRange.lowerBound), factorRange.upperBound)
+            let steps = (clamped / factorStep).rounded()
+            return min(max(steps * factorStep, factorRange.lowerBound), factorRange.upperBound)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case enabled, ratio, factor, orientation
+        }
+
+        public init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? false
+            orientation = try c.decodeIfPresent(Orientation.self, forKey: .orientation) ?? .horizontal
+            if let storedFactor = try c.decodeIfPresent(Double.self, forKey: .factor) {
+                factor = Self.snap(storedFactor)
+                ratio =
+                    try c.decodeIfPresent(Ratio.self, forKey: .ratio)
+                    ?? Ratio.matching(factor: factor) ?? .x1
+            } else if let storedRatio = try c.decodeIfPresent(Ratio.self, forKey: .ratio) {
+                ratio = storedRatio
+                factor = storedRatio.factor
+            } else {
+                ratio = .x1
+                factor = 1.0
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var c = encoder.container(keyedBy: CodingKeys.self)
+            try c.encode(enabled, forKey: .enabled)
+            try c.encode(ratio, forKey: .ratio)
+            try c.encode(factor, forKey: .factor)
+            try c.encode(orientation, forKey: .orientation)
+        }
     }
 
     /// How much crush/clip pile-up to tolerate at scope edges before traffic lights glow,

--- a/Sources/OpenZCineCore/PTPCameraProperties.swift
+++ b/Sources/OpenZCineCore/PTPCameraProperties.swift
@@ -29,6 +29,8 @@ public enum PTPCameraControl: Equatable, Sendable {
 extension PTPPropertyCode {
     /// One-at-a-time property polling order used between live-view frame requests.
     public static let liveMonitorPollOrder: [PTPPropertyCode] = [
+        // Effective/working ISO (incl. Auto ISO). Prefer over dual-base D09E for display.
+        .isoControlSensitivity,
         .movieISOSensitivity,
         .movieISOAutoControl,
         .movieBaseISO,
@@ -1147,9 +1149,22 @@ public struct PTPCameraPropertySnapshot: Equatable, Sendable {
     public func applying(property: PTPPropertyCode, data: Data) -> PTPCameraPropertySnapshot {
         let bytes = Array(data)
         switch property {
-        case .movieISOSensitivity where bytes.count >= 4,
-            .movieExposureIndex where bytes.count >= 4:
-            // Both carry UINT32 working ISO; dual-base uses D09E, other codecs write D1AA.
+        case .isoControlSensitivity where bytes.count >= 4:
+            // `ISOControlSensitivity` 0xD0B5 — effective/working ISO the body is applying
+            // (manual or Auto). Authoritative readout for the ISO tile and Auto On display.
+            return replacing(iso: ByteCoding.readUInt32LE(bytes, at: 0))
+        case .movieISOSensitivity where bytes.count >= 4:
+            // Dual-base R3D circuit ISO (0x0001_D09E). On non-R3D codecs this often sticks
+            // at the native base (e.g. 800) and must not overwrite effective ISO from D0B5.
+            let value = ByteCoding.readUInt32LE(bytes, at: 0)
+            if ISOPickerPolicy.showsDualBaseCircuits(codec: fileType ?? "") {
+                return replacing(iso: value)
+            }
+            // Seed only until the effective property has been polled.
+            if iso == nil { return replacing(iso: value) }
+            return self
+        case .movieExposureIndex where bytes.count >= 4:
+            // Manual movie ISO write path (0xD1AA) — UINT32. Used for write confirmation.
             return replacing(iso: ByteCoding.readUInt32LE(bytes, at: 0))
         case .movieISOAutoControl where bytes.count >= 1:
             // UINT8 On/Off — 1 = auto ISO, 0 = manual (libgphoto2 Nikon OnOff convention).
@@ -1375,8 +1390,8 @@ extension CameraDisplayState {
         switch label {
         case "ISO":
             // Movie ISO auto (`MovISOAutoControl`) — not exposure-program Auto.
-            // When auto is on, still surface the body's working ISO so the drum/tile can
-            // show the live value while interaction is locked.
+            // When auto is on, surface the body's effective ISO (ISOControlSensitivity)
+            // so the drum/tile tracks Auto changes (e.g. A51200, not a stale dual-base base).
             if properties.isoAuto == true {
                 properties.iso.map { "A\($0)" } ?? "Auto"
             } else {

--- a/Sources/OpenZCineCore/PTPCameraProperties.swift
+++ b/Sources/OpenZCineCore/PTPCameraProperties.swift
@@ -120,13 +120,9 @@ public struct PTPCameraPropertyWrite: Equatable, Sendable {
     {
         switch control {
         case .iso:
-            guard let iso = UInt32(label.trimmingCharacters(in: .whitespacesAndNewlines)) else {
-                return nil
-            }
-            return PTPCameraPropertyWrite(
-                property: .movieISOSensitivity,
-                data: Data(ByteCoding.uint32LE(iso))
-            )
+            // Without codec context, prefer `MovieExposureIndex` (0xD1AA) — the documented movie
+            // ISO write. Dual-base R3D NE uses `MovieISOSensitivity` via the snapshot overload.
+            return isoWrite(label: label, dualBase: false)
         case .isoAuto:
             // `MovISOAutoControl` 0xD0AD — UINT8 On/Off (1 = auto ISO, 0 = manual).
             guard let code = PTPCameraPropertyDecoders.onOffCode(for: label) else { return nil }
@@ -217,13 +213,21 @@ public struct PTPCameraPropertyWrite: Equatable, Sendable {
         label: String,
         snapshot: PTPCameraPropertySnapshot
     ) -> PTPCameraPropertyWrite? {
-        request(control: control, label: label)
+        if control == .iso {
+            let dualBase = ISOPickerPolicy.showsDualBaseCircuits(
+                codec: snapshot.fileType ?? "")
+            return isoWrite(label: label, dualBase: dualBase)
+        }
+        return request(control: control, label: label)
     }
 
     /// All property writes a picker selection should send — usually one, but a **Kelvin** white
     /// balance needs **two**: switch into colour-temperature mode (`MovieWhiteBalance` = "Color
     /// temp") *then* set `MovieWBColorTemp`. Writing only the temperature leaves the body in its
     /// current preset mode and the Kelvin never takes effect.
+    ///
+    /// Movie ISO also expands: when ISO auto is active, turn it off first so the body accepts the
+    /// manual sensitivity write.
     public static func requests(
         control: PTPCameraControl,
         label: String,
@@ -243,7 +247,34 @@ public struct PTPCameraPropertyWrite: Equatable, Sendable {
                 ]
             }
         }
+        if control == .iso {
+            var writes: [PTPCameraPropertyWrite] = []
+            if snapshot.isoAuto == true {
+                writes.append(movieISOAuto(enabled: false))
+            }
+            if let iso = isoWrite(
+                label: label,
+                dualBase: ISOPickerPolicy.showsDualBaseCircuits(codec: snapshot.fileType ?? ""))
+            {
+                writes.append(iso)
+            }
+            return writes
+        }
         return request(control: control, label: label, snapshot: snapshot).map { [$0] } ?? []
+    }
+
+    /// Encodes a movie ISO sensitivity write.
+    ///
+    /// - Dual-base R3D NE: `MovieISOSensitivity` (0x0001_D09E) — range follows the base circuit.
+    /// - Other codecs: `MovieExposureIndex` (0xD1AA) — documented video ISO write; R3D rejects it.
+    public static func isoWrite(label: String, dualBase: Bool) -> PTPCameraPropertyWrite? {
+        guard let iso = UInt32(label.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            return nil
+        }
+        return PTPCameraPropertyWrite(
+            property: dualBase ? .movieISOSensitivity : .movieExposureIndex,
+            data: Data(ByteCoding.uint32LE(iso))
+        )
     }
 
     /// A `MovScreenSize` write for an exact camera-advertised mode value (from the descriptor enum).
@@ -1116,7 +1147,9 @@ public struct PTPCameraPropertySnapshot: Equatable, Sendable {
     public func applying(property: PTPPropertyCode, data: Data) -> PTPCameraPropertySnapshot {
         let bytes = Array(data)
         switch property {
-        case .movieISOSensitivity where bytes.count >= 4:
+        case .movieISOSensitivity where bytes.count >= 4,
+            .movieExposureIndex where bytes.count >= 4:
+            // Both carry UINT32 working ISO; dual-base uses D09E, other codecs write D1AA.
             return replacing(iso: ByteCoding.readUInt32LE(bytes, at: 0))
         case .movieISOAutoControl where bytes.count >= 1:
             // UINT8 On/Off — 1 = auto ISO, 0 = manual (libgphoto2 Nikon OnOff convention).

--- a/Sources/OpenZCineCore/PTPCameraProperties.swift
+++ b/Sources/OpenZCineCore/PTPCameraProperties.swift
@@ -8,6 +8,8 @@ import Foundation
 /// safe-point write queue, surfacing a clear message on rejection. [verify-on-HW]
 public enum PTPCameraControl: Equatable, Sendable {
     case iso
+    /// Movie ISO auto/manual (`MovISOAutoControl` 0xD0AD) — not exposure program.
+    case isoAuto
     case shutter
     case iris
     case whiteBalanceKelvin
@@ -28,6 +30,7 @@ extension PTPPropertyCode {
     /// One-at-a-time property polling order used between live-view frame requests.
     public static let liveMonitorPollOrder: [PTPPropertyCode] = [
         .movieISOSensitivity,
+        .movieISOAutoControl,
         .movieBaseISO,
         .movieShutterMode,
         .movieTVLockSetting,
@@ -124,6 +127,10 @@ public struct PTPCameraPropertyWrite: Equatable, Sendable {
                 property: .movieISOSensitivity,
                 data: Data(ByteCoding.uint32LE(iso))
             )
+        case .isoAuto:
+            // `MovISOAutoControl` 0xD0AD — UINT8 On/Off (1 = auto ISO, 0 = manual).
+            guard let code = PTPCameraPropertyDecoders.onOffCode(for: label) else { return nil }
+            return PTPCameraPropertyWrite(property: .movieISOAutoControl, data: Data([code]))
         case .shutter:
             return shutterWrite(label: label)
         case .iris:
@@ -277,6 +284,14 @@ public struct PTPCameraPropertyWrite: Equatable, Sendable {
     /// Electronic VR toggle (`ElectronicVR` 0xD314, UINT8 on/off). [verify-on-HW]
     public static func electronicVR(on: Bool) -> PTPCameraPropertyWrite {
         PTPCameraPropertyWrite(property: .electronicVR, data: Data([on ? 1 : 0]))
+    }
+
+    /// Movie ISO auto/manual (`MovISOAutoControl` 0xD0AD, UINT8 on/off).
+    ///
+    /// Independent of exposure-program Auto. libgphoto2 `PTP_DPC_NIKON_MovISOAutoControl`;
+    /// MAID `MovieISOControl` bool. [verify-on-HW]
+    public static func movieISOAuto(enabled: Bool) -> PTPCameraPropertyWrite {
+        PTPCameraPropertyWrite(property: .movieISOAutoControl, data: Data([enabled ? 1 : 0]))
     }
 
     /// Encodes a shutter label to a write: a `"N°"` angle to `movieShutterAngle`, or an `"N/D"`
@@ -949,6 +964,7 @@ public struct PTPCameraPropertySnapshot: Equatable, Sendable {
     public init(
         iso: UInt32? = nil,
         baseISO: String? = nil,
+        isoAuto: Bool? = nil,
         exposureMode: String? = nil,
         shutterMode: ShutterDisplayMode? = nil,
         shutterLocked: Bool? = nil,
@@ -984,6 +1000,7 @@ public struct PTPCameraPropertySnapshot: Equatable, Sendable {
     ) {
         self.iso = iso
         self.baseISO = baseISO
+        self.isoAuto = isoAuto
         self.exposureMode = exposureMode
         self.shutterMode = shutterMode
         self.shutterLocked = shutterLocked
@@ -1021,6 +1038,8 @@ public struct PTPCameraPropertySnapshot: Equatable, Sendable {
     // Exposure.
     public let iso: UInt32?
     public let baseISO: String?
+    /// Movie ISO auto (`MovISOAutoControl` 0xD0AD). `true` = camera owns ISO; independent of P/A/S/M.
+    public let isoAuto: Bool?
     public let exposureMode: String?  // Auto/P/S/A/M/U1–U3, decoded from 0x500E
     public let shutterMode: ShutterDisplayMode?
     public let shutterLocked: Bool?  // movie shutter speed/angle lock (MovieTVLockSetting)
@@ -1099,6 +1118,9 @@ public struct PTPCameraPropertySnapshot: Equatable, Sendable {
         switch property {
         case .movieISOSensitivity where bytes.count >= 4:
             return replacing(iso: ByteCoding.readUInt32LE(bytes, at: 0))
+        case .movieISOAutoControl where bytes.count >= 1:
+            // UINT8 On/Off — 1 = auto ISO, 0 = manual (libgphoto2 Nikon OnOff convention).
+            return replacing(isoAuto: bytes[0] != 0)
         case .movieBaseISO where bytes.count >= 1:
             return replacing(baseISO: PTPCameraPropertyDecoders.baseISO(bytes[0]))
         case .exposureProgramMode where bytes.count >= 2:
@@ -1197,6 +1219,7 @@ public struct PTPCameraPropertySnapshot: Equatable, Sendable {
     private func replacing(
         iso: UInt32? = nil,
         baseISO: String? = nil,
+        isoAuto: Bool? = nil,
         exposureMode: String? = nil,
         shutterMode: ShutterDisplayMode? = nil,
         shutterLocked: Bool? = nil,
@@ -1233,6 +1256,7 @@ public struct PTPCameraPropertySnapshot: Equatable, Sendable {
         PTPCameraPropertySnapshot(
             iso: iso ?? self.iso,
             baseISO: baseISO ?? self.baseISO,
+            isoAuto: isoAuto ?? self.isoAuto,
             exposureMode: exposureMode ?? self.exposureMode,
             shutterMode: shutterMode ?? self.shutterMode,
             shutterLocked: shutterLocked ?? self.shutterLocked,
@@ -1317,7 +1341,12 @@ extension CameraDisplayState {
     ) -> String {
         switch label {
         case "ISO":
-            properties.iso.map(String.init) ?? existing
+            // Movie ISO auto (`MovISOAutoControl`) — not exposure-program Auto.
+            if properties.isoAuto == true {
+                "Auto"
+            } else {
+                properties.iso.map(String.init) ?? existing
+            }
         case "SHUTTER":
             switch properties.shutterMode {
             case .speed: properties.shutterSpeed ?? properties.shutterAngle ?? existing

--- a/Sources/OpenZCineCore/PTPCameraProperties.swift
+++ b/Sources/OpenZCineCore/PTPCameraProperties.swift
@@ -1375,8 +1375,10 @@ extension CameraDisplayState {
         switch label {
         case "ISO":
             // Movie ISO auto (`MovISOAutoControl`) — not exposure-program Auto.
+            // When auto is on, still surface the body's working ISO so the drum/tile can
+            // show the live value while interaction is locked.
             if properties.isoAuto == true {
-                "Auto"
+                properties.iso.map { "A\($0)" } ?? "Auto"
             } else {
                 properties.iso.map(String.init) ?? existing
             }

--- a/Sources/OpenZCineCore/PTPOperation.swift
+++ b/Sources/OpenZCineCore/PTPOperation.swift
@@ -88,6 +88,9 @@ public enum PTPPropertyCode: UInt32, Sendable {
 
     // Exposure.
     case isoControlSensitivity = 0xD0B5
+    /// Movie ISO auto/manual control (libgphoto2 `PTP_DPC_NIKON_MovISOAutoControl`).
+    /// UINT8 On/Off — independent of exposure-program Auto (0x500E). MAID: MovieISOControl bool.
+    case movieISOAutoControl = 0xD0AD
     case movieExposureIndex = 0xD1AA
     case movieBaseISO = 0x0001_D09D  // [ZR-only · verify-on-HW]
     case movieISOSensitivity = 0x0001_D09E  // [ZR-only · verify-on-HW]

--- a/Sources/OpenZCineCore/PTPOperation.swift
+++ b/Sources/OpenZCineCore/PTPOperation.swift
@@ -91,8 +91,11 @@ public enum PTPPropertyCode: UInt32, Sendable {
     /// Movie ISO auto/manual control (libgphoto2 `PTP_DPC_NIKON_MovISOAutoControl`).
     /// UINT8 On/Off — independent of exposure-program Auto (0x500E). MAID: MovieISOControl bool.
     case movieISOAutoControl = 0xD0AD
+    /// Movie exposure index / video ISO write (libgphoto2 `PTP_DPC_NIKON_MovieISO` / design docs).
+    /// UINT32. Rejected on R3D NE — dual-base uses `movieISOSensitivity` instead.
     case movieExposureIndex = 0xD1AA
     case movieBaseISO = 0x0001_D09D  // [ZR-only · verify-on-HW]
+    /// Dual-base working video ISO (ZR). Range follows Low/High base circuit.
     case movieISOSensitivity = 0x0001_D09E  // [ZR-only · verify-on-HW]
     case movieShutterMode = 0x0001_D074  // UINT8: 1 speed, 2 angle [ZR-only · verify-on-HW]
     case movieTVLockSetting = 0x0001_D00F  // movie shutter speed/angle lock

--- a/Tests/OpenZCineAndroidFacadeTests/AndroidCameraControlWireTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/AndroidCameraControlWireTests.swift
@@ -26,7 +26,8 @@ struct AndroidCameraControlWireTests {
         #expect(AndroidCameraControlWire.control(selector: 18) == .codec)
         #expect(AndroidCameraControlWire.control(selector: 19) == .vibrationReduction)
         #expect(AndroidCameraControlWire.control(selector: 20) == .electronicVR)
+        #expect(AndroidCameraControlWire.control(selector: 21) == .isoAuto)
         #expect(AndroidCameraControlWire.control(selector: -1) == nil)
-        #expect(AndroidCameraControlWire.control(selector: 21) == nil)
+        #expect(AndroidCameraControlWire.control(selector: 22) == nil)
     }
 }

--- a/Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift
@@ -838,6 +838,9 @@ final class FakeZRServer: @unchecked Sendable {
             return Data(ByteCoding.uint32LE(0))
         case .movieISOSensitivity, .movieExposureIndex:
             return Data(ByteCoding.uint32LE(800))
+        case .isoControlSensitivity:
+            // Effective/working ISO (0xD0B5) — may differ from dual-base D09E under Auto.
+            return Data(ByteCoding.uint32LE(800))
         case .movieISOAutoControl:
             return Data([0])  // manual ISO by default
         case .movieBaseISO:

--- a/Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift
@@ -838,6 +838,8 @@ final class FakeZRServer: @unchecked Sendable {
             return Data(ByteCoding.uint32LE(0))
         case .movieISOSensitivity:
             return Data(ByteCoding.uint32LE(800))
+        case .movieISOAutoControl:
+            return Data([0])  // manual ISO by default
         case .movieBaseISO:
             return Data([2])  // High
         case .exposureProgramMode:
@@ -1009,6 +1011,8 @@ final class FakeZRServer: @unchecked Sendable {
                 values: [25, 50, 100].map { ByteCoding.uint32LE(0x0001_0000 | UInt32($0)) })
         case .movieBaseISO:
             return enumDescriptor(property: property, valueByteCount: 1, values: [[1], [2]])
+        case .movieISOAutoControl:
+            return enumDescriptor(property: property, valueByteCount: 1, values: [[0], [1]])
         case .movieShutterMode:
             return enumDescriptor(property: property, valueByteCount: 1, values: [[1], [2]])
         case .movieTVLockSetting:

--- a/Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift
@@ -836,7 +836,7 @@ final class FakeZRServer: @unchecked Sendable {
         case .movieRecProhibitionCondition:
             // 0 = nothing prohibits recording.
             return Data(ByteCoding.uint32LE(0))
-        case .movieISOSensitivity:
+        case .movieISOSensitivity, .movieExposureIndex:
             return Data(ByteCoding.uint32LE(800))
         case .movieISOAutoControl:
             return Data([0])  // manual ISO by default

--- a/Tests/OpenZCineAndroidFacadeTests/PTPIPClientSessionTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/PTPIPClientSessionTests.swift
@@ -601,22 +601,35 @@ struct PTPIPClientSessionTests {
                 $0.operation == .getDevicePropDescEx
                     && $0.parameters.first == PTPPropertyCode.movieRecordScreenSize.rawValue
             }.count == screenSizeDescriptorReadsBeforeCodecChange + 1)
-        #expect(
-            Array(server.receivedRequests().dropFirst(requestBaseline).suffix(3))
-                == [
-                    FakeZRRequest(
-                        operation: .getDevicePropValueEx,
-                        parameters: [PTPPropertyCode.movieFileType.rawValue],
-                        dataPhase: .dataIn),
-                    FakeZRRequest(
-                        operation: .getDevicePropDescEx,
-                        parameters: [PTPPropertyCode.movieRecordScreenSize.rawValue],
-                        dataPhase: .dataIn),
-                    FakeZRRequest(
-                        operation: .getDevicePropValueEx,
-                        parameters: [PTPPropertyCode.movieRecordScreenSize.rawValue],
-                        dataPhase: .dataIn),
-                ])
+        // Codec change must re-read MovFileType then rebuild MovScreenSize. Extra follow-on
+        // screen-size samples (poll-index cadence) may trail the triple; match the sequence, not
+        // a hard-coded "last N" that breaks when the live poll order gains properties.
+        let afterBaseline = Array(server.receivedRequests().dropFirst(requestBaseline))
+        let expectedCodecThenScreenRebuild = [
+            FakeZRRequest(
+                operation: .getDevicePropValueEx,
+                parameters: [PTPPropertyCode.movieFileType.rawValue],
+                dataPhase: .dataIn),
+            FakeZRRequest(
+                operation: .getDevicePropDescEx,
+                parameters: [PTPPropertyCode.movieRecordScreenSize.rawValue],
+                dataPhase: .dataIn),
+            FakeZRRequest(
+                operation: .getDevicePropValueEx,
+                parameters: [PTPPropertyCode.movieRecordScreenSize.rawValue],
+                dataPhase: .dataIn),
+        ]
+        let hasCodecThenScreenRebuild: Bool = {
+            guard afterBaseline.count >= expectedCodecThenScreenRebuild.count else { return false }
+            let needle = expectedCodecThenScreenRebuild
+            for start in 0...(afterBaseline.count - needle.count) {
+                if Array(afterBaseline[start..<(start + needle.count)]) == needle {
+                    return true
+                }
+            }
+            return false
+        }()
+        #expect(hasCodecThenScreenRebuild)
     }
 
     @Test func rawImageAreaLabelsAreRestrictedToNikonZR() throws {
@@ -825,24 +838,39 @@ struct PTPIPClientSessionTests {
 
         let high = session.refreshAndroidPropertySnapshot(.bootstrap).controls
         #expect(high.isoValues == ISOPickerPolicy.highBaseOptions)
-        let highBaseline = server.receivedPropertyWrites().count
-        #expect(throws: PTPIPClientSessionError.unsupportedAndroidControl("iso", "800")) {
-            try session.applyAndroidControl(.iso, label: "800")
-        }
-        #expect(server.receivedPropertyWrites().count == highBaseline)
+        // Capability lists still track the active dual-base circuit for the UI ladder.
+        // Encoded numeric ISO is still written — the body is the range authority (and Auto
+        // can park outside the fixed ladder). Wrong-circuit labels are no longer hard-rejected
+        // as "not supported" after a successful body write.
         try session.applyAndroidControl(.iso, label: "1600")
+        try session.applyAndroidControl(.iso, label: "800")
         try session.applyAndroidControl(.baseISO, label: "Low")
 
         let low = session.refreshAndroidPropertySnapshot(
             .propertyChanged(PTPPropertyCode.movieBaseISO.rawValue)
         ).controls
         #expect(low.isoValues == ISOPickerPolicy.lowBaseOptions)
-        let lowBaseline = server.receivedPropertyWrites().count
-        #expect(throws: PTPIPClientSessionError.unsupportedAndroidControl("iso", "25600")) {
-            try session.applyAndroidControl(.iso, label: "25600")
-        }
-        #expect(server.receivedPropertyWrites().count == lowBaseline)
         try session.applyAndroidControl(.iso, label: "800")
+        try session.applyAndroidControl(.iso, label: "25600")
+    }
+
+    @Test func encodableISOOutsideCapabilityLadderIsStillWritten() throws {
+        // Auto can report 51200 while the manual UI ladder tops out at 25600. Capability
+        // membership must not flash "not supported" when the shared encoder can still write.
+        var options = FakeZRServer.Options()
+        options.movieFileTypeRaw = 0x0001_0A01  // H.265 — unified ladder
+        let server = try FakeZRServer(options: options)
+        defer { server.stop() }
+        let session = try connect(to: server)
+        defer { session.disconnect() }
+        _ = session.refreshAndroidPropertySnapshot(.bootstrap)
+
+        let before = server.receivedPropertyWrites().count
+        try session.applyAndroidControl(.iso, label: "51200")
+        #expect(server.receivedPropertyWrites().count == before + 1)
+        #expect(
+            server.receivedPropertyWrites().last?.property
+                == PTPPropertyCode.movieExposureIndex.rawValue)
     }
 
     @Test func electronicVRIsRejectedBeforeWritingForRawOrUnknownCodec() throws {

--- a/Tests/OpenZCineAndroidFacadeTests/PTPIPClientSessionTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/PTPIPClientSessionTests.swift
@@ -1040,9 +1040,10 @@ struct PTPIPClientSessionTests {
         try session.applyAndroidControl(.vibrationReduction, label: "ON")
 
         let writes = server.receivedPropertyWrites()
+        // Without a dual-base codec in the snapshot, ISO writes MovieExposureIndex (0xD1AA).
         #expect(
             writes.contains {
-                $0.property == PTPPropertyCode.movieISOSensitivity.rawValue
+                $0.property == PTPPropertyCode.movieExposureIndex.rawValue
             })
         #expect(
             writes.contains {
@@ -1082,6 +1083,7 @@ struct PTPIPClientSessionTests {
 
     @Test func acceptedControlWriteRequiresMatchingAuthoritativeReadback() throws {
         var options = FakeZRServer.Options()
+        // Default fake codec is R3D NE (dual-base) → ISO writes MovieISOSensitivity.
         options.ignoredPropertyWrites = [PTPPropertyCode.movieISOSensitivity.rawValue]
         let server = try FakeZRServer(options: options)
         defer { server.stop() }

--- a/Tests/OpenZCineCoreTests/CameraPropertyTests.swift
+++ b/Tests/OpenZCineCoreTests/CameraPropertyTests.swift
@@ -271,11 +271,37 @@ import Testing
 }
 
 @Test func cameraPropertyWriteRequestsEncodePickerValues() {
+    // Non dual-base path (default without snapshot): MovieExposureIndex 0xD1AA.
     #expect(
         PTPCameraPropertyWrite.request(control: .iso, label: "800")
             == PTPCameraPropertyWrite(
+                property: .movieExposureIndex,
+                data: Data([0x20, 0x03, 0x00, 0x00])
+            )
+    )
+    // Dual-base R3D NE: MovieISOSensitivity 0x0001_D09E.
+    #expect(
+        PTPCameraPropertyWrite.request(
+            control: .iso,
+            label: "800",
+            snapshot: PTPCameraPropertySnapshot(fileType: "R3D NE 12-bit R3D")
+        )
+            == PTPCameraPropertyWrite(
                 property: .movieISOSensitivity,
                 data: Data([0x20, 0x03, 0x00, 0x00])
+            )
+    )
+    // Manual ISO while auto is on: turn auto off first, then write ExposureIndex.
+    let autoOn = PTPCameraPropertySnapshot(isoAuto: true, fileType: "ProRes 422 HQ")
+    let isoWhileAuto = PTPCameraPropertyWrite.requests(
+        control: .iso, label: "1600", snapshot: autoOn)
+    #expect(isoWhileAuto.count == 2)
+    #expect(isoWhileAuto[0] == PTPCameraPropertyWrite.movieISOAuto(enabled: false))
+    #expect(
+        isoWhileAuto[1]
+            == PTPCameraPropertyWrite(
+                property: .movieExposureIndex,
+                data: Data([0x40, 0x06, 0x00, 0x00])
             )
     )
     #expect(

--- a/Tests/OpenZCineCoreTests/CameraPropertyTests.swift
+++ b/Tests/OpenZCineCoreTests/CameraPropertyTests.swift
@@ -127,6 +127,29 @@ import Testing
     #expect(snapshot.electronicVR == "ON")
 }
 
+@Test func movieISOAutoControlDecodesAndEncodesIndependentlyOfExposureMode() {
+    // MovISOAutoControl 0xD0AD — not exposure program Auto.
+    let autoOn = PTPCameraPropertySnapshot()
+        .applying(property: .movieISOAutoControl, data: Data([1]))
+    #expect(autoOn.isoAuto == true)
+    let autoOff = autoOn.applying(property: .movieISOAutoControl, data: Data([0]))
+    #expect(autoOff.isoAuto == false)
+
+    #expect(
+        PTPCameraPropertyWrite.movieISOAuto(enabled: true)
+            == PTPCameraPropertyWrite(property: .movieISOAutoControl, data: Data([1])))
+    #expect(
+        PTPCameraPropertyWrite.request(control: .isoAuto, label: "ON")
+            == PTPCameraPropertyWrite(property: .movieISOAutoControl, data: Data([1])))
+    #expect(
+        PTPCameraPropertyWrite.request(control: .isoAuto, label: "OFF")
+            == PTPCameraPropertyWrite(property: .movieISOAutoControl, data: Data([0])))
+
+    let display = CameraDisplayState.preview.applyingCameraProperties(
+        PTPCameraPropertySnapshot(iso: 800, isoAuto: true))
+    #expect(display.values.first(where: { $0.label == "ISO" })?.value == "Auto")
+}
+
 @Test func snapshotDecodesZRSoundProperties() {
     // ZR sound properties: input selection (1 Mic / 2 Line), INT8 sensitivity (0xFF Auto, 0–20),
     // 32-bit float on/off.

--- a/Tests/OpenZCineCoreTests/CameraPropertyTests.swift
+++ b/Tests/OpenZCineCoreTests/CameraPropertyTests.swift
@@ -147,7 +147,7 @@ import Testing
 
     let display = CameraDisplayState.preview.applyingCameraProperties(
         PTPCameraPropertySnapshot(iso: 800, isoAuto: true))
-    #expect(display.values.first(where: { $0.label == "ISO" })?.value == "Auto")
+    #expect(display.values.first(where: { $0.label == "ISO" })?.value == "A800")
 }
 
 @Test func snapshotDecodesZRSoundProperties() {

--- a/Tests/OpenZCineCoreTests/CameraPropertyTests.swift
+++ b/Tests/OpenZCineCoreTests/CameraPropertyTests.swift
@@ -404,7 +404,8 @@ import Testing
 
 @Test func cameraPropertySnapshotAppliesRawPropertyValues() {
     let snapshot = PTPCameraPropertySnapshot()
-        .applying(property: .movieISOSensitivity, data: Data([0x20, 0x03, 0x00, 0x00]))
+        // Effective ISO (0xD0B5) is the authoritative working readout.
+        .applying(property: .isoControlSensitivity, data: Data([0x20, 0x03, 0x00, 0x00]))
         .applying(property: .movieShutterAngle, data: Data([0x50, 0x46, 0x00, 0x00]))
         .applying(property: .movieFNumber, data: Data([0x18, 0x01]))
         .applying(property: .movieWBColorTemp, data: Data([0xE0, 0x15]))
@@ -422,6 +423,31 @@ import Testing
     #expect(snapshot.wbKelvin == UInt16(5_600))
     #expect(snapshot.resolution == "6048x4032")
     #expect(snapshot.fps == 25)
+}
+
+@Test func cameraPropertySnapshotPrefersEffectiveISOOverStaleDualBase() {
+    // Non-R3D: dual-base D09E often sticks at native base 800; effective D0B5 tracks Auto.
+    let staleDualBase = Data(ByteCoding.uint32LE(800))
+    let effective = Data(ByteCoding.uint32LE(51_200))
+    let snapshot = PTPCameraPropertySnapshot(fileType: "ProRes 422 HQ")
+        .applying(property: .movieISOSensitivity, data: staleDualBase)
+        .applying(property: .isoControlSensitivity, data: effective)
+        // A later dual-base poll must not clobber effective ISO on non-R3D.
+        .applying(property: .movieISOSensitivity, data: staleDualBase)
+    #expect(snapshot.iso == UInt32(51_200))
+
+    // R3D dual-base still updates from D09E.
+    let r3d = PTPCameraPropertySnapshot(fileType: "R3D NE 12-bit R3D")
+        .applying(property: .movieISOSensitivity, data: Data(ByteCoding.uint32LE(6_400)))
+    #expect(r3d.iso == UInt32(6_400))
+}
+
+@Test func liveMonitorPollOrderIncludesEffectiveISO() {
+    #expect(PTPPropertyCode.liveMonitorPollOrder.contains(.isoControlSensitivity))
+    let effectiveIdx = PTPPropertyCode.liveMonitorPollOrder.firstIndex(of: .isoControlSensitivity)
+    let dualBaseIdx = PTPPropertyCode.liveMonitorPollOrder.firstIndex(of: .movieISOSensitivity)
+    #expect(effectiveIdx != nil && dualBaseIdx != nil)
+    #expect(effectiveIdx! < dualBaseIdx!)
 }
 
 @Test func devicePropDescEnumParserReadsTrailingEnumValues() {

--- a/Tests/OpenZCineCoreTests/ISOPickerPolicyTests.swift
+++ b/Tests/OpenZCineCoreTests/ISOPickerPolicyTests.swift
@@ -13,7 +13,19 @@ import Testing
     #expect(ISOPickerPolicy.showsDualBaseCircuits(codec: "R3D NE"))
     #expect(!ISOPickerPolicy.showsDualBaseCircuits(codec: "N-RAW 12-bit NEV"))
     #expect(ISOPickerPolicy.pickerModes(codec: "R3D NE").count == 2)
-    #expect(ISOPickerPolicy.pickerModes(codec: "N-RAW").isEmpty)
+    #expect(ISOPickerPolicy.pickerModes(codec: "N-RAW").count == 2)
+    #expect(ISOPickerPolicy.pickerModes(codec: "N-RAW")[0].title == "Auto On")
+    #expect(ISOPickerPolicy.pickerModes(codec: "N-RAW")[1].title == "Auto Off")
+}
+
+@Test func isoPickerPolicyDetectsAutoISOExposureModes() {
+    #expect(ISOPickerPolicy.isAutoISOActive(exposureMode: "Auto"))
+    #expect(ISOPickerPolicy.isAutoISOActive(exposureMode: "A"))
+    #expect(ISOPickerPolicy.isAutoISOActive(exposureMode: "P"))
+    #expect(ISOPickerPolicy.isAutoISOActive(exposureMode: "S"))
+    #expect(!ISOPickerPolicy.isAutoISOActive(exposureMode: "M"))
+    #expect(ISOPickerPolicy.autoISOModeIndex(exposureMode: "Auto") == 0)
+    #expect(ISOPickerPolicy.autoISOModeIndex(exposureMode: "M") == 1)
 }
 
 @Test func isoPickerPolicyUnifiedDrumMarksBothNativeBases() {

--- a/Tests/OpenZCineCoreTests/ISOPickerPolicyTests.swift
+++ b/Tests/OpenZCineCoreTests/ISOPickerPolicyTests.swift
@@ -13,9 +13,13 @@ import Testing
     #expect(ISOPickerPolicy.showsDualBaseCircuits(codec: "R3D NE"))
     #expect(!ISOPickerPolicy.showsDualBaseCircuits(codec: "N-RAW 12-bit NEV"))
     #expect(ISOPickerPolicy.pickerModes(codec: "R3D NE").count == 2)
-    #expect(ISOPickerPolicy.pickerModes(codec: "N-RAW").count == 2)
-    #expect(ISOPickerPolicy.pickerModes(codec: "N-RAW")[0].title == "Auto On")
-    #expect(ISOPickerPolicy.pickerModes(codec: "N-RAW")[1].title == "Auto Off")
+    // Auto Off only when exposure mode is M.
+    #expect(ISOPickerPolicy.pickerModes(codec: "N-RAW", exposureMode: "M").count == 2)
+    #expect(ISOPickerPolicy.pickerModes(codec: "N-RAW", exposureMode: "M")[0].title == "Auto On")
+    #expect(ISOPickerPolicy.pickerModes(codec: "N-RAW", exposureMode: "M")[1].title == "Auto Off")
+    #expect(ISOPickerPolicy.pickerModes(codec: "N-RAW", exposureMode: "A").count == 1)
+    #expect(ISOPickerPolicy.pickerModes(codec: "N-RAW", exposureMode: "A")[0].title == "Auto On")
+    #expect(ISOPickerPolicy.pickerModes(codec: "N-RAW", exposureMode: nil).count == 1)
 }
 
 @Test func isoPickerPolicyDetectsMovieISOAutoControl() {
@@ -23,11 +27,62 @@ import Testing
     #expect(ISOPickerPolicy.isAutoISOActive(isoAuto: true))
     #expect(!ISOPickerPolicy.isAutoISOActive(isoAuto: false))
     #expect(!ISOPickerPolicy.isAutoISOActive(isoAuto: nil))
-    #expect(ISOPickerPolicy.autoISOModeIndex(isoAuto: true) == 0)
-    #expect(ISOPickerPolicy.autoISOModeIndex(isoAuto: false) == 1)
-    #expect(ISOPickerPolicy.autoISOModeIndex(isoAuto: nil) == 1)
+    #expect(
+        ISOPickerPolicy.autoISOModeIndex(codec: "N-RAW", isoAuto: true, exposureMode: "M") == 0)
+    #expect(
+        ISOPickerPolicy.autoISOModeIndex(codec: "N-RAW", isoAuto: false, exposureMode: "M") == 1)
+    #expect(
+        ISOPickerPolicy.autoISOModeIndex(codec: "N-RAW", isoAuto: nil, exposureMode: "M") == 1)
+    // Non-M on non-R3D: only Auto On tab, always index 0.
+    #expect(
+        ISOPickerPolicy.autoISOModeIndex(codec: "N-RAW", isoAuto: false, exposureMode: "A") == 0)
     #expect(ISOPickerPolicy.autoISOOnLabel == "ON")
     #expect(ISOPickerPolicy.autoISOOffLabel == "OFF")
+}
+
+@Test func isoPickerPolicyManualISOOnlyInMModeForNonR3D() {
+    // Non-R3D: manual / Auto Off only in M.
+    #expect(ISOPickerPolicy.allowsManualISO(codec: "N-RAW", exposureMode: "M"))
+    #expect(!ISOPickerPolicy.allowsManualISO(codec: "N-RAW", exposureMode: "A"))
+    #expect(!ISOPickerPolicy.allowsManualISO(codec: "ProRes 422 HQ", exposureMode: "S"))
+    #expect(!ISOPickerPolicy.allowsManualISO(codec: "H.265", exposureMode: "P"))
+    #expect(!ISOPickerPolicy.allowsManualISO(codec: "N-RAW", exposureMode: "Auto"))
+    #expect(!ISOPickerPolicy.allowsManualISO(codec: "N-RAW", exposureMode: nil))
+    #expect(
+        ISOPickerPolicy.isISOValueCameraOwned(
+            codec: "N-RAW", isoAuto: true, exposureMode: "M"))
+    #expect(
+        !ISOPickerPolicy.isISOValueCameraOwned(
+            codec: "N-RAW", isoAuto: false, exposureMode: "M"))
+    #expect(
+        ISOPickerPolicy.isISOValueCameraOwned(
+            codec: "N-RAW", isoAuto: false, exposureMode: "A"))
+}
+
+@Test func isoPickerPolicyR3DNEAlwaysAllowsManualISO() {
+    // R3D NE forces dual-base manual ISO in every exposure program (incl. A).
+    #expect(ISOPickerPolicy.allowsManualISO(codec: "R3D NE", exposureMode: "A"))
+    #expect(ISOPickerPolicy.allowsManualISO(codec: "R3D NE", exposureMode: "S"))
+    #expect(ISOPickerPolicy.allowsManualISO(codec: "R3D NE", exposureMode: "P"))
+    #expect(ISOPickerPolicy.allowsManualISO(codec: "R3D NE", exposureMode: nil))
+    #expect(ISOPickerPolicy.allowsManualISO(codec: "R3D NE 12-bit R3D", exposureMode: "A"))
+    #expect(
+        !ISOPickerPolicy.isISOValueCameraOwned(
+            codec: "R3D NE", isoAuto: nil, exposureMode: "A"))
+    #expect(
+        ISOPickerPolicy.pickerSubtitle(codec: "R3D NE", exposureMode: "A")
+            == "Sensitivity · dual base")
+}
+
+@Test func isoPickerPolicyInjectsLiveAutoISOOutsideLadder() {
+    let opts = ISOPickerPolicy.options(
+        codec: "N-RAW", modeIndex: 0, includingLiveISO: "51200")
+    #expect(opts.contains("51200"))
+    #expect(opts.last == "51200" || opts.contains("51200"))
+    // Already on ladder — no duplicate.
+    #expect(
+        ISOPickerPolicy.options(codec: "N-RAW", modeIndex: 0, includingLiveISO: "800")
+            .filter { $0 == "800" }.count == 1)
 }
 
 @Test func isoPickerPolicyUnifiedDrumMarksBothNativeBases() {

--- a/Tests/OpenZCineCoreTests/ISOPickerPolicyTests.swift
+++ b/Tests/OpenZCineCoreTests/ISOPickerPolicyTests.swift
@@ -7,6 +7,9 @@ import Testing
     #expect(ISOPickerPolicy.isR3DNECodec("R3D NE 10-bit R3D"))
     #expect(!ISOPickerPolicy.isR3DNECodec("N-RAW"))
     #expect(!ISOPickerPolicy.isR3DNECodec("ProRes RAW HQ"))
+    #expect(!ISOPickerPolicy.showsAutoISOControl(codec: ""))
+    #expect(ISOPickerPolicy.showsAutoISOControl(codec: "N-RAW"))
+    #expect(!ISOPickerPolicy.showsAutoISOControl(codec: "R3D NE"))
 }
 
 @Test func isoPickerPolicyUsesDualBaseOnlyForR3DNE() {

--- a/Tests/OpenZCineCoreTests/ISOPickerPolicyTests.swift
+++ b/Tests/OpenZCineCoreTests/ISOPickerPolicyTests.swift
@@ -18,14 +18,16 @@ import Testing
     #expect(ISOPickerPolicy.pickerModes(codec: "N-RAW")[1].title == "Auto Off")
 }
 
-@Test func isoPickerPolicyDetectsAutoISOExposureModes() {
-    #expect(ISOPickerPolicy.isAutoISOActive(exposureMode: "Auto"))
-    #expect(ISOPickerPolicy.isAutoISOActive(exposureMode: "A"))
-    #expect(ISOPickerPolicy.isAutoISOActive(exposureMode: "P"))
-    #expect(ISOPickerPolicy.isAutoISOActive(exposureMode: "S"))
-    #expect(!ISOPickerPolicy.isAutoISOActive(exposureMode: "M"))
-    #expect(ISOPickerPolicy.autoISOModeIndex(exposureMode: "Auto") == 0)
-    #expect(ISOPickerPolicy.autoISOModeIndex(exposureMode: "M") == 1)
+@Test func isoPickerPolicyDetectsMovieISOAutoControl() {
+    // Movie ISO auto is MovISOAutoControl (0xD0AD), not exposure program P/A/S/M/Auto.
+    #expect(ISOPickerPolicy.isAutoISOActive(isoAuto: true))
+    #expect(!ISOPickerPolicy.isAutoISOActive(isoAuto: false))
+    #expect(!ISOPickerPolicy.isAutoISOActive(isoAuto: nil))
+    #expect(ISOPickerPolicy.autoISOModeIndex(isoAuto: true) == 0)
+    #expect(ISOPickerPolicy.autoISOModeIndex(isoAuto: false) == 1)
+    #expect(ISOPickerPolicy.autoISOModeIndex(isoAuto: nil) == 1)
+    #expect(ISOPickerPolicy.autoISOOnLabel == "ON")
+    #expect(ISOPickerPolicy.autoISOOffLabel == "OFF")
 }
 
 @Test func isoPickerPolicyUnifiedDrumMarksBothNativeBases() {

--- a/Tests/OpenZCineCoreTests/OperatorPreferencesTests.swift
+++ b/Tests/OpenZCineCoreTests/OperatorPreferencesTests.swift
@@ -210,6 +210,7 @@ import Testing
     var configuration = AssistConfiguration.defaults
     configuration.grid = AssistConfiguration.Grid(thirds: true, phi: true, diagonal: false)
     configuration.desqueeze = AssistConfiguration.Desqueeze(
+        // factor is source of truth; ratio chip follows when it matches a preset
         enabled: true,
         ratio: .x165,
         orientation: .vertical

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,6 +84,9 @@ All new code in the iOS shell follows these conventions:
   rendering, and platform share surfaces.
 - JVM tests cover pure state/policy. Instrumentation tests cover critical Compose and Android
   platform integration, and UI changes require portrait/landscape edge inspection.
+- **Control writes:** facade owns encode + native confirm; Kotlin must not second-guess success
+  after a successful `applyControl`. Capability lists drive UI options; hard-reject only where
+  inventing raw packs is unsafe (codec/resolution). See [android-control-writes.md](android-control-writes.md).
 
 ## iOS orientation and unified monitor
 

--- a/docs/android-control-writes.md
+++ b/docs/android-control-writes.md
@@ -1,0 +1,37 @@
+# Android camera-control write authority
+
+Standing rules for Compose → Kotlin session → JNI → Swift facade → `OpenZCineCore`.
+Keep the bridge; do not grow a second decision brain in Kotlin.
+
+## Authority
+
+| Layer | Owns |
+| --- | --- |
+| **Shared core** | Encode labels, property codes, multi-write sequences, poll order, ISO policy |
+| **Swift facade** | Session, transport, `applyAndroidControl`, **native write + readback confirm** |
+| **Kotlin session / shell** | Lifecycle, Compose state, map exceptions to UI; **do not re-decide success** |
+
+If `applyControl` returns without throwing, the write is accepted. Surface only
+`CameraControlException` failures (rejected, transport, unsupported encode, native
+readback mismatch). Do **not** toast “did not confirm” from a post-write property
+refresh that lags dual-property ISO or similar.
+
+## Capability lists
+
+- Drive **picker options** and fail-closed UI (empty domain → no invented codec/resolution packs).
+- **Do not** hard-reject labels the shared core can encode for simple numeric/enum writes
+  (ISO is the reference case: Auto can park outside the fixed ladder; body is range authority).
+- **Do** hard-reject codec/resolution labels that lack an advertised raw pack — never invent
+  `MovFileType` / `MovScreenSize` values.
+
+## Product rules stay in core policy
+
+ISO Auto On/Off, M-mode manual gate, R3D dual-base always-manual, and recording locks live in
+`ISOPickerPolicy` (Swift + thin Kotlin mirror). Shells must not invent divergent Android-only
+product rules.
+
+## Soft confirm inventory (MonitorScreen)
+
+Post-write soft confirm was removed: every `session.applyControl` path already runs
+`confirmAndroidControlWrites` in the facade. Pre-write skip when live readback already matches
+the desired label remains (avoids redundant wire trips; REC/codec always write).

--- a/ios/Runner/MediaBrowser.swift
+++ b/ios/Runner/MediaBrowser.swift
@@ -2084,6 +2084,13 @@ struct MediaPlayerView: View {
         model.preferences.playbackVisibleAssistTools.contains(.audioMeters)
     }
 
+    /// Playback de-squeeze uses the shared factor, gated by playback-visible tools.
+    private var playbackDesqueeze: AssistConfiguration.Desqueeze {
+        var config = model.assistConfiguration.desqueeze
+        config.enabled = model.preferences.playbackVisibleAssistTools.contains(.desqueeze)
+        return config
+    }
+
     private var playbackScopeDerivationConfiguration: PlaybackScopeDerivationConfiguration {
         let scopes = model.assistConfiguration.scopes
         // Playback scopes measure source/log on the same anchored axis as live view; clips don't
@@ -2107,6 +2114,8 @@ struct MediaPlayerView: View {
 
                 ZStack {
                     PlayerLayerView(player: player)
+                        // Match live view: de-squeeze the raster, then apply pinch zoom.
+                        .scaleEffect(desqueezeScale(playbackDesqueeze), anchor: .center)
                         .scaleEffect(zoomScale)
                         .offset(panOffset)
                 }

--- a/ios/Runner/MonitorOverlays.swift
+++ b/ios/Runner/MonitorOverlays.swift
@@ -710,8 +710,8 @@ func rectForRatio(_ feed: CGRect, _ ratio: CGFloat) -> CGRect {
 /// The on-screen scale applied to the live image to de-squeeze anamorphic footage: shrink one axis
 /// by the squeeze factor (vertical = letterbox, horizontal = pillarbox), matching the prototype.
 func desqueezeScale(_ desqueeze: AssistConfiguration.Desqueeze) -> CGSize {
-    guard desqueeze.enabled, desqueeze.ratio.factor > 1 else { return CGSize(width: 1, height: 1) }
-    let factor = CGFloat(desqueeze.ratio.factor)
+    guard desqueeze.enabled, desqueeze.factor > 1 else { return CGSize(width: 1, height: 1) }
+    let factor = CGFloat(desqueeze.factor)
     return desqueeze.orientation == .horizontal
         ? CGSize(width: 1 / factor, height: 1)
         : CGSize(width: 1, height: 1 / factor)
@@ -720,8 +720,8 @@ func desqueezeScale(_ desqueeze: AssistConfiguration.Desqueeze) -> CGSize {
 /// The visible (de-squeezed) image rectangle inside the full feed rect — the same centred sub-rect
 /// the scale above produces, so framing overlays land on the de-squeezed image.
 func desqueezedRect(_ full: CGRect, _ desqueeze: AssistConfiguration.Desqueeze) -> CGRect {
-    guard desqueeze.enabled, desqueeze.ratio.factor > 1 else { return full }
-    let factor = CGFloat(desqueeze.ratio.factor)
+    guard desqueeze.enabled, desqueeze.factor > 1 else { return full }
+    let factor = CGFloat(desqueeze.factor)
     if desqueeze.orientation == .horizontal {
         let width = full.width / factor
         return CGRect(x: full.midX - width / 2, y: full.minY, width: width, height: full.height)

--- a/ios/Runner/MonitorPanels.swift
+++ b/ios/Runner/MonitorPanels.swift
@@ -878,8 +878,17 @@ struct PickerPanel: View {
         picker == .iso && model.isISORecordingLocked
     }
 
+    /// Auto ISO On: value drum is camera-owned; mode tabs stay usable to switch to Auto Off.
+    private var isISOAutoValueLocked: Bool {
+        picker == .iso && model.showsAutoISOPicker && model.isAutoISOActive
+    }
+
     private var isPickerInteractionLocked: Bool {
         isShutterControlLocked || isISORecordingLocked
+    }
+
+    private var isDrumInteractionLocked: Bool {
+        isPickerInteractionLocked || isISOAutoValueLocked
     }
 
     private var activePickerModes: [PickerMode] {
@@ -921,6 +930,9 @@ struct PickerPanel: View {
                 if isISORecordingLocked {
                     isoRecordingLockBanner
                 }
+                if isISOAutoValueLocked {
+                    isoAutoLockBanner
+                }
                 if isTintMode {
                     // The WB Tint tab swaps the drum for the fine-tune pad.
                     WhiteBalanceTintPad()
@@ -930,15 +942,15 @@ struct PickerPanel: View {
                         options: currentOptions,
                         selection: $selection,
                         markedValues: markedValues,
-                        isInteractive: !isPickerInteractionLocked,
+                        isInteractive: !isDrumInteractionLocked,
                         // −10 / +10 permanently flank the selected Kelvin value.
                         sideAdjust: isKelvinMode
                             ? DrumSideAdjust(
-                                minusEnabled: !isPickerInteractionLocked
+                                minusEnabled: !isDrumInteractionLocked
                                     && WhiteBalanceKelvinPolicy.canFineAdjust(
                                         from: selection,
                                         delta: -WhiteBalanceKelvinPolicy.fineStepKelvin),
-                                plusEnabled: !isPickerInteractionLocked
+                                plusEnabled: !isDrumInteractionLocked
                                     && WhiteBalanceKelvinPolicy.canFineAdjust(
                                         from: selection,
                                         delta: WhiteBalanceKelvinPolicy.fineStepKelvin),
@@ -1019,7 +1031,7 @@ struct PickerPanel: View {
         }
         // Confirm-on-snap: apply each newly-centred value to the active mode's target.
         .onChange(of: selection) { _, newValue in
-            guard !isPickerInteractionLocked else { return }
+            guard !isDrumInteractionLocked else { return }
             guard !newValue.isEmpty, newValue != lastApplied else { return }
             lastApplied = newValue
             model.applyPicker(picker, mode: selectedMode, value: newValue)
@@ -1165,10 +1177,32 @@ struct PickerPanel: View {
                     }
                 }
                 .buttonStyle(.zcTapTarget)
+                // Full locks (shutter / R3D record) freeze tabs; Auto ISO only freezes the drum.
                 .opacity(isPickerInteractionLocked ? 0.55 : 1)
                 .allowsHitTesting(!isPickerInteractionLocked)
             }
         }
+    }
+
+    private var isoAutoLockBanner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "lock.fill")
+                .font(.system(size: 11, weight: .semibold))
+            Text(
+                "Auto ISO is on — the camera sets sensitivity. "
+                    + "Switch to Auto Off to choose a value."
+            )
+            .font(.system(size: 11.5, weight: .medium))
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .foregroundStyle(LiveDesign.accent.opacity(0.9))
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            LiveDesign.accentDim,
+            in: RoundedRectangle(cornerRadius: LiveDesign.cornerRadius)
+        )
     }
 
     private var currentValue: String {

--- a/ios/Runner/MonitorPanels.swift
+++ b/ios/Runner/MonitorPanels.swift
@@ -1972,7 +1972,7 @@ struct AssistPanel: View {
                                 .font(.system(size: 12, weight: .semibold))
                                 .foregroundStyle(LiveDesign.muted)
                             Spacer()
-                            Text(String(format: "%.1f×", desqueezeSliderFactor))
+                            Text(String(format: "%.2f×", desqueezeSliderFactor))
                                 .font(.system(size: 12, weight: .semibold, design: .monospaced))
                                 .foregroundStyle(LiveDesign.text)
                         }

--- a/ios/Runner/MonitorPanels.swift
+++ b/ios/Runner/MonitorPanels.swift
@@ -1950,17 +1950,7 @@ struct AssistPanel: View {
                         }
                     }
                 case .desqueeze:
-                    Button {
-                        model.assistConfiguration.desqueeze.enabled.toggle()
-                        model.setAssist(
-                            .desqueeze,
-                            visible: model.assistConfiguration.desqueeze.enabled
-                        )
-                    } label: {
-                        ToggleRow(
-                            title: "Enable", isOn: model.assistConfiguration.desqueeze.enabled)
-                    }
-                    .buttonStyle(.zcTapTarget)
+                    // On/off is the assist-bar DESQ chip; this panel only configures factor/axis.
                     SegmentedButtons(
                         items: AssistConfiguration.Desqueeze.Ratio.allCases.map(\.rawValue),
                         selected:

--- a/ios/Runner/MonitorPanels.swift
+++ b/ios/Runner/MonitorPanels.swift
@@ -1117,10 +1117,15 @@ struct PickerPanel: View {
                     let value = model.pickerModeValue(picker, mode: index)
                     selection = value
                     lastApplied = value
-                    // ISO's circuits are the camera's dual base — switch the base on the camera
-                    // first, before the new ISO value is applied below.
+                    // ISO dual-base: switch Low/High on the body before applying the circuit value.
                     if picker == .iso, model.showsDualBaseISOPicker {
                         model.switchBaseISO(highBase: index == 1)
+                    }
+                    // ISO auto control (non-R3D NE): Auto On / Auto Off sets exposure mode.
+                    if picker == .iso, model.showsAutoISOPicker {
+                        model.switchAutoISO(enabled: index == 0)
+                        // Auto On: no ISO write. Auto Off: apply the drum value in manual mode.
+                        if index == 0 { return }
                     }
                     if picker == .shutter {
                         model.switchShutterMode(speedMode: index == 1)
@@ -1958,11 +1963,38 @@ struct AssistPanel: View {
                     .buttonStyle(.zcTapTarget)
                     SegmentedButtons(
                         items: AssistConfiguration.Desqueeze.Ratio.allCases.map(\.rawValue),
-                        selected: model.assistConfiguration.desqueeze.ratio.rawValue
+                        selected:
+                            AssistConfiguration.Desqueeze.Ratio.matching(
+                                factor: model.assistConfiguration.desqueeze.factor
+                            )?.rawValue ?? ""
                     ) { value in
                         if let ratio = AssistConfiguration.Desqueeze.Ratio(rawValue: value) {
-                            model.assistConfiguration.desqueeze.ratio = ratio
+                            model.assistConfiguration.desqueeze.select(ratio: ratio)
                         }
+                    }
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
+                            Text("Custom")
+                                .font(.system(size: 12, weight: .semibold))
+                                .foregroundStyle(LiveDesign.muted)
+                            Spacer()
+                            Text(
+                                String(
+                                    format: "%.1f×",
+                                    model.assistConfiguration.desqueeze.factor)
+                            )
+                            .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                            .foregroundStyle(LiveDesign.text)
+                        }
+                        Slider(
+                            value: Binding(
+                                get: { model.assistConfiguration.desqueeze.factor },
+                                set: { model.assistConfiguration.desqueeze.select(factor: $0) }
+                            ),
+                            in: AssistConfiguration.Desqueeze.factorRange,
+                            step: AssistConfiguration.Desqueeze.factorStep
+                        )
+                        .tint(LiveDesign.accent)
                     }
                     SegmentedButtons(
                         items: AssistConfiguration.Desqueeze.Orientation.allCases.map(\.rawValue),

--- a/ios/Runner/MonitorPanels.swift
+++ b/ios/Runner/MonitorPanels.swift
@@ -1863,6 +1863,9 @@ struct AssistPanel: View {
     let tool: MonitorAssistTool
     /// When set, the header close control calls this instead of the default panel dismiss path.
     var onClose: (() -> Void)? = nil
+    /// Local continuous factor while dragging the desqueeze custom slider (avoids thrashing
+    /// `assistConfiguration` / UserDefaults on every tick and keeps the thumb under the finger).
+    @State private var desqueezeSliderFactor: Double = 1.0
 
     var body: some View {
         GlassPanel(
@@ -1955,10 +1958,11 @@ struct AssistPanel: View {
                         items: AssistConfiguration.Desqueeze.Ratio.allCases.map(\.rawValue),
                         selected:
                             AssistConfiguration.Desqueeze.Ratio.matching(
-                                factor: model.assistConfiguration.desqueeze.factor
+                                factor: desqueezeSliderFactor
                             )?.rawValue ?? ""
                     ) { value in
                         if let ratio = AssistConfiguration.Desqueeze.Ratio(rawValue: value) {
+                            desqueezeSliderFactor = ratio.factor
                             model.assistConfiguration.desqueeze.select(ratio: ratio)
                         }
                     }
@@ -1968,23 +1972,33 @@ struct AssistPanel: View {
                                 .font(.system(size: 12, weight: .semibold))
                                 .foregroundStyle(LiveDesign.muted)
                             Spacer()
-                            Text(
-                                String(
-                                    format: "%.1f×",
-                                    model.assistConfiguration.desqueeze.factor)
-                            )
-                            .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                            .foregroundStyle(LiveDesign.text)
+                            Text(String(format: "%.1f×", desqueezeSliderFactor))
+                                .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                                .foregroundStyle(LiveDesign.text)
                         }
                         Slider(
-                            value: Binding(
-                                get: { model.assistConfiguration.desqueeze.factor },
-                                set: { model.assistConfiguration.desqueeze.select(factor: $0) }
-                            ),
+                            value: $desqueezeSliderFactor,
                             in: AssistConfiguration.Desqueeze.factorRange,
                             step: AssistConfiguration.Desqueeze.factorStep
-                        )
+                        ) { editing in
+                            // Commit on release so the thumb tracks smoothly while dragging.
+                            if !editing {
+                                model.assistConfiguration.desqueeze.select(
+                                    factor: desqueezeSliderFactor)
+                            }
+                        }
                         .tint(LiveDesign.accent)
+                        .onChange(of: desqueezeSliderFactor) { _, newValue in
+                            // Live preview while dragging without round-tripping every tick
+                            // through the persisted model binding.
+                            var next = model.assistConfiguration.desqueeze
+                            next.select(factor: newValue)
+                            if next.factor != model.assistConfiguration.desqueeze.factor
+                                || next.ratio != model.assistConfiguration.desqueeze.ratio
+                            {
+                                model.assistConfiguration.desqueeze = next
+                            }
+                        }
                     }
                     SegmentedButtons(
                         items: AssistConfiguration.Desqueeze.Orientation.allCases.map(\.rawValue),
@@ -2019,11 +2033,22 @@ struct AssistPanel: View {
                 }
             }
         }
-        // Swallow taps on the panel's own chrome so a mistap can't fall through to the backdrop
-        // tap-catcher and dismiss it — only a tap *outside* closes. Buttons and the drum still
-        // work: a child's own gesture takes priority over this container tap.
+        // Swallow bare taps on panel chrome so they don't fall through to the backdrop dismiss
+        // catcher. Must be simultaneous — a exclusive `onTapGesture` competes with Slider thumb
+        // drags and makes the custom desqueeze factor unusable.
         .contentShape(Rectangle())
-        .onTapGesture {}
+        .simultaneousGesture(TapGesture().onEnded {})
+        .onAppear {
+            desqueezeSliderFactor = model.assistConfiguration.desqueeze.factor
+        }
+        .onChange(of: model.assistConfiguration.desqueeze.factor) { _, newValue in
+            if abs(newValue - desqueezeSliderFactor) > 0.001 {
+                desqueezeSliderFactor = newValue
+            }
+        }
+        .onChange(of: tool) { _, _ in
+            desqueezeSliderFactor = model.assistConfiguration.desqueeze.factor
+        }
     }
 }
 

--- a/ios/Runner/MonitorPanels.swift
+++ b/ios/Runner/MonitorPanels.swift
@@ -878,9 +878,10 @@ struct PickerPanel: View {
         picker == .iso && model.isISORecordingLocked
     }
 
-    /// Auto ISO On: value drum is camera-owned; mode tabs stay usable to switch to Auto Off.
+    /// Auto ISO On or non-M (non-R3D): value drum is camera-owned.
+    /// R3D NE dual-base is always manual — never locked by exposure mode.
     private var isISOAutoValueLocked: Bool {
-        picker == .iso && model.showsAutoISOPicker && model.isAutoISOActive
+        picker == .iso && model.showsAutoISOPicker && model.isISOValueCameraOwned
     }
 
     private var isPickerInteractionLocked: Bool {
@@ -1028,6 +1029,14 @@ struct PickerPanel: View {
             let value = model.pickerModeValue(picker, mode: modeIndex)
             selection = value
             lastApplied = value
+        }
+        // Auto ISO: keep the locked drum centred on the body's effective ISO as it changes.
+        .onChange(of: model.cameraPropertySnapshot.iso) { _, iso in
+            guard picker == .iso, isISOAutoValueLocked, let iso, iso > 0 else { return }
+            let next = String(iso)
+            guard next != selection else { return }
+            selection = next
+            lastApplied = next
         }
         // Confirm-on-snap: apply each newly-centred value to the active mode's target.
         .onChange(of: selection) { _, newValue in
@@ -1188,12 +1197,9 @@ struct PickerPanel: View {
         HStack(spacing: 8) {
             Image(systemName: "lock.fill")
                 .font(.system(size: 11, weight: .semibold))
-            Text(
-                "Auto ISO is on — the camera sets sensitivity. "
-                    + "Switch to Auto Off to choose a value."
-            )
-            .font(.system(size: 11.5, weight: .medium))
-            .fixedSize(horizontal: false, vertical: true)
+            Text(isoAutoLockBannerText)
+                .font(.system(size: 11.5, weight: .medium))
+                .fixedSize(horizontal: false, vertical: true)
         }
         .foregroundStyle(LiveDesign.accent.opacity(0.9))
         .padding(.horizontal, 12)
@@ -1203,6 +1209,17 @@ struct PickerPanel: View {
             LiveDesign.accentDim,
             in: RoundedRectangle(cornerRadius: LiveDesign.cornerRadius)
         )
+    }
+
+    private var isoAutoLockBannerText: String {
+        if model.allowsManualISO {
+            return
+                "Auto ISO is on — the camera sets sensitivity. "
+                + "Switch to Auto Off to choose a value."
+        }
+        return
+            "Manual ISO needs exposure mode M. "
+            + "The camera is setting sensitivity."
     }
 
     private var currentValue: String {
@@ -1223,8 +1240,18 @@ struct PickerPanel: View {
         if picker == .resolution, !screenModes.isEmpty { return screenModes }
         if picker == .codec, !codecModes.isEmpty { return codecModes }
         if picker == .iso {
+            // Inject live Auto ISO when it sits outside the fixed ladder (e.g. 51200).
+            let liveISO: String? = {
+                guard model.showsAutoISOPicker else { return nil }
+                if let iso = model.cameraPropertySnapshot.iso, iso > 0 {
+                    return String(iso)
+                }
+                return nil
+            }()
             return ISOPickerPolicy.options(
-                codec: model.cameraState.codec, modeIndex: selectedMode)
+                codec: model.cameraState.codec,
+                modeIndex: selectedMode,
+                includingLiveISO: liveISO)
         }
         // Kelvin dial ladder, with the live / fine-tuned value inserted when off-ladder.
         if isKelvinMode {

--- a/ios/Runner/MonitorPanels.swift
+++ b/ios/Runner/MonitorPanels.swift
@@ -1121,10 +1121,10 @@ struct PickerPanel: View {
                     if picker == .iso, model.showsDualBaseISOPicker {
                         model.switchBaseISO(highBase: index == 1)
                     }
-                    // ISO auto control (non-R3D NE): Auto On / Auto Off sets exposure mode.
+                    // ISO auto control (non-R3D NE): Auto On/Off toggles MovISOAutoControl.
                     if picker == .iso, model.showsAutoISOPicker {
                         model.switchAutoISO(enabled: index == 0)
-                        // Auto On: no ISO write. Auto Off: apply the drum value in manual mode.
+                        // Auto On: no ISO write. Auto Off: apply the drum value in manual ISO.
                         if index == 0 { return }
                     }
                     if picker == .shutter {

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -5475,7 +5475,10 @@ final class NativeAppModel {
             return cameraPropertySnapshot.baseISO == "High" ? 1 : 0
         }
         if showsAutoISOPicker {
-            return ISOPickerPolicy.autoISOModeIndex(isoAuto: commandISOAuto)
+            return ISOPickerPolicy.autoISOModeIndex(
+                codec: cameraState.codec,
+                isoAuto: commandISOAuto,
+                exposureMode: commandExposureMode)
         }
         return 0
     }
@@ -5493,6 +5496,21 @@ final class NativeAppModel {
     /// True when movie ISO auto is on (`MovISOAutoControl`) — not exposure program Auto.
     var isAutoISOActive: Bool {
         ISOPickerPolicy.isAutoISOActive(isoAuto: commandISOAuto)
+    }
+
+    /// True when the ISO drum is camera-owned (Auto On, or non-R3D mode is not M).
+    /// Always false for R3D NE dual-base (manual in every exposure program).
+    var isISOValueCameraOwned: Bool {
+        ISOPickerPolicy.isISOValueCameraOwned(
+            codec: cameraState.codec,
+            isoAuto: commandISOAuto,
+            exposureMode: commandExposureMode)
+    }
+
+    /// True when this codec/mode allows manual ISO writes (R3D always; others only in M).
+    var allowsManualISO: Bool {
+        ISOPickerPolicy.allowsManualISO(
+            codec: cameraState.codec, exposureMode: commandExposureMode)
     }
 
     /// Optimistic/polled movie ISO auto flag for the Auto On/Off tab and ISO tile.
@@ -5514,10 +5532,12 @@ final class NativeAppModel {
         return commandGridOrder
     }
 
-    /// Segmented mode tabs for a picker (ISO layout follows the active codec).
+    /// Segmented mode tabs for a picker (ISO layout follows the active codec + mode).
     func pickerModes(for picker: CameraPicker) -> [PickerMode] {
         guard picker == .iso else { return picker.modes }
-        return ISOPickerPolicy.pickerModes(codec: cameraState.codec).map {
+        return ISOPickerPolicy.pickerModes(
+            codec: cameraState.codec, exposureMode: commandExposureMode
+        ).map {
             PickerMode(title: $0.title, detail: $0.detail, options: $0.options, base: $0.base)
         }
     }
@@ -5525,7 +5545,9 @@ final class NativeAppModel {
     /// Picker header subtitle (ISO reflects dual-base vs unified layout).
     func pickerSubtitle(for picker: CameraPicker) -> String {
         picker == .iso
-            ? ISOPickerPolicy.pickerSubtitle(codec: cameraState.codec) : picker.subtitle
+            ? ISOPickerPolicy.pickerSubtitle(
+                codec: cameraState.codec, exposureMode: commandExposureMode)
+            : picker.subtitle
     }
 
     private func shouldSuppressShutterModePoll() -> Bool {
@@ -5566,7 +5588,7 @@ final class NativeAppModel {
     /// belongs to that mode, otherwise the mode's base.
     func pickerModeValue(_ picker: CameraPicker, mode: Int) -> String {
         if picker == .iso, showsAutoISOPicker {
-            // Drum needs a numeric step even when auto is on (tile may show Auto / A800).
+            // Drum needs a numeric step even when auto is on (tile may show Auto / A51200).
             if let iso = cameraPropertySnapshot.iso, iso > 0 {
                 return String(iso)
             }
@@ -5631,6 +5653,8 @@ final class NativeAppModel {
             return
         }
         if picker == .iso {
+            // Manual ISO only in exposure mode M (Auto Off path).
+            guard allowsManualISO else { return }
             // Leaving Auto ISO by choosing a drum value (or Auto Off tab already switched M).
             prepareManualISOIfNeeded()
             applyPickerValue(value, for: picker)
@@ -5816,6 +5840,8 @@ final class NativeAppModel {
     /// Toggles movie ISO auto (`MovISOAutoControl`) — not exposure-program Auto/M.
     func switchAutoISO(enabled: Bool) {
         guard showsAutoISOPicker, !isISORecordingLocked else { return }
+        // Auto Off / manual only in M; ignore attempts from non-M modes.
+        if !enabled, !allowsManualISO { return }
         let write = PTPCameraPropertyWrite.movieISOAuto(enabled: enabled)
         cameraPropertySnapshot = cameraPropertySnapshot.applying(
             property: write.property, data: write.data)
@@ -5833,7 +5859,9 @@ final class NativeAppModel {
 
     /// Ensures ISO writes can stick: when movie ISO auto is on, switch to manual first.
     func prepareManualISOIfNeeded() {
-        guard showsAutoISOPicker, isAutoISOActive, !isISORecordingLocked else { return }
+        guard showsAutoISOPicker, isAutoISOActive, !isISORecordingLocked, allowsManualISO else {
+            return
+        }
         switchAutoISO(enabled: false)
     }
 

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -2250,6 +2250,8 @@ final class NativeAppModel {
     private var pendingShutterLockState: Bool?
     /// Optimistic dual-base ISO circuit while a `movieBaseISO` write is queued or in flight.
     private var pendingBaseISOHigh: Bool?
+    /// Optimistic movie ISO auto flag while a `movieISOAutoControl` write is queued or in flight.
+    private var pendingISOAuto: Bool?
     /// AF point requested by a feed tap, in the camera's live-view coordinate space. Sent at the
     /// next live-view control safe point via `ChangeAfArea`.
     private var pendingFocusPoint: (x: UInt32, y: UInt32)?
@@ -2338,6 +2340,7 @@ final class NativeAppModel {
         pendingShutterMode = nil
         pendingShutterLockState = nil
         pendingBaseISOHigh = nil
+        pendingISOAuto = nil
         pendingFocusPoint = nil
         focusResetStep = nil
         cameraApertures = []
@@ -4309,11 +4312,14 @@ final class NativeAppModel {
         let pending = pendingCameraWrites.removeFirst()
         let isShutterModeWrite = pending.write.property == .movieShutterMode
         let isBaseISOWrite = pending.write.property == .movieBaseISO
+        let isISOAutoWrite = pending.write.property == .movieISOAutoControl
         let isFocusModeWrite = pending.write.property == .movieFocusMode
         let isShutterLockWrite = pending.write.property == .movieTVLockSetting
         do {
             try await session.writeCameraProperty(pending.write)
-            if isShutterModeWrite || isBaseISOWrite || isFocusModeWrite || isShutterLockWrite {
+            if isShutterModeWrite || isBaseISOWrite || isISOAutoWrite || isFocusModeWrite
+                || isShutterLockWrite
+            {
                 if let actual = try? await session.readCameraProperty(pending.write.property) {
                     cameraPropertySnapshot = cameraPropertySnapshot.applying(
                         property: pending.write.property, data: actual)
@@ -4337,6 +4343,9 @@ final class NativeAppModel {
                 }
                 if isBaseISOWrite {
                     pendingBaseISOHigh = nil
+                }
+                if isISOAutoWrite {
+                    pendingISOAuto = nil
                 }
                 if isShutterLockWrite {
                     pendingShutterLockState = nil
@@ -4363,6 +4372,11 @@ final class NativeAppModel {
             } else if isShutterModeWrite {
                 connectionMessage =
                     "Shutter mode set to \(pending.value.lowercased())."
+            } else if isISOAutoWrite {
+                connectionMessage =
+                    pending.value == "Auto On"
+                    ? "ISO set to Auto."
+                    : "ISO set to Manual."
             } else if isFocusModeWrite {
                 connectionMessage = focusModeWriteMessage(
                     requested: pending.value,
@@ -4379,6 +4393,9 @@ final class NativeAppModel {
             }
             if isBaseISOWrite {
                 pendingBaseISOHigh = nil
+            }
+            if isISOAutoWrite {
+                pendingISOAuto = nil
             }
             if isShutterLockWrite {
                 pendingShutterLockState = nil
@@ -5458,7 +5475,7 @@ final class NativeAppModel {
             return cameraPropertySnapshot.baseISO == "High" ? 1 : 0
         }
         if showsAutoISOPicker {
-            return ISOPickerPolicy.autoISOModeIndex(exposureMode: commandExposureMode)
+            return ISOPickerPolicy.autoISOModeIndex(isoAuto: commandISOAuto)
         }
         return 0
     }
@@ -5473,9 +5490,14 @@ final class NativeAppModel {
         ISOPickerPolicy.showsAutoISOControl(codec: cameraState.codec)
     }
 
-    /// True when the body is driving ISO (Auto/P/A/S) rather than the operator drum.
+    /// True when movie ISO auto is on (`MovISOAutoControl`) — not exposure program Auto.
     var isAutoISOActive: Bool {
-        ISOPickerPolicy.isAutoISOActive(exposureMode: commandExposureMode)
+        ISOPickerPolicy.isAutoISOActive(isoAuto: commandISOAuto)
+    }
+
+    /// Optimistic/polled movie ISO auto flag for the Auto On/Off tab and ISO tile.
+    var commandISOAuto: Bool? {
+        pendingISOAuto ?? cameraPropertySnapshot.isoAuto
     }
 
     /// ISO is locked while recording in R3D NE; other codecs allow mid-roll ISO changes.
@@ -5544,7 +5566,13 @@ final class NativeAppModel {
     /// belongs to that mode, otherwise the mode's base.
     func pickerModeValue(_ picker: CameraPicker, mode: Int) -> String {
         if picker == .iso, showsAutoISOPicker {
-            return cameraValue(for: picker)
+            // Drum needs a numeric step even when auto is on (tile may show Auto / A800).
+            if let iso = cameraPropertySnapshot.iso, iso > 0 {
+                return String(iso)
+            }
+            let live = cameraValue(for: picker)
+            if live.allSatisfy(\.isNumber) { return live }
+            return ISOPickerPolicy.unifiedOptions.first ?? "800"
         }
         if picker == .iso, !showsDualBaseISOPicker {
             return cameraValue(for: picker)
@@ -5784,16 +5812,25 @@ final class NativeAppModel {
         )
     }
 
-    /// Toggles camera-managed ISO (Auto On) vs manual ISO (Auto Off → exposure mode M).
+    /// Toggles movie ISO auto (`MovISOAutoControl`) — not exposure-program Auto/M.
     func switchAutoISO(enabled: Bool) {
         guard showsAutoISOPicker, !isISORecordingLocked else { return }
-        let mode =
-            enabled
-            ? ISOPickerPolicy.autoISOOnExposureMode : ISOPickerPolicy.autoISOOffExposureMode
-        applyPickerValue(mode, for: .mode)
+        let write = PTPCameraPropertyWrite.movieISOAuto(enabled: enabled)
+        cameraPropertySnapshot = cameraPropertySnapshot.applying(
+            property: write.property, data: write.data)
+        pendingISOAuto = enabled
+        publishCameraDisplayState()
+        guard !isDemoSession else { return }
+        enqueueCameraWrite(
+            PendingCameraWrite(
+                picker: .iso,
+                value: enabled ? "Auto On" : "Auto Off",
+                write: write
+            )
+        )
     }
 
-    /// Ensures ISO writes can stick: when Auto ISO is active, leave Auto by switching to M first.
+    /// Ensures ISO writes can stick: when movie ISO auto is on, switch to manual first.
     func prepareManualISOIfNeeded() {
         guard showsAutoISOPicker, isAutoISOActive, !isISORecordingLocked else { return }
         switchAutoISO(enabled: false)

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -5451,18 +5451,31 @@ final class NativeAppModel {
         return mode == .speed ? 1 : 0
     }
 
-    /// Active ISO picker tab: 0 = low base, 1 = high base. Driven by `movieBaseISO`, not the
-    /// sensitivity value — overlapping ISO steps exist on both circuits. Unified-drum codecs
-    /// always report 0 (no LOW/HIGH tabs).
+    /// Active ISO picker tab: R3D NE → low/high base; other codecs → Auto On (0) / Auto Off (1).
     var isoPickerModeIndex: Int {
-        guard showsDualBaseISOPicker else { return 0 }
-        if let pending = pendingBaseISOHigh { return pending ? 1 : 0 }
-        return cameraPropertySnapshot.baseISO == "High" ? 1 : 0
+        if showsDualBaseISOPicker {
+            if let pending = pendingBaseISOHigh { return pending ? 1 : 0 }
+            return cameraPropertySnapshot.baseISO == "High" ? 1 : 0
+        }
+        if showsAutoISOPicker {
+            return ISOPickerPolicy.autoISOModeIndex(exposureMode: commandExposureMode)
+        }
+        return 0
     }
 
     /// Whether the ISO picker shows separate LOW/HIGH base circuits (R3D NE only).
     var showsDualBaseISOPicker: Bool {
         ISOPickerPolicy.showsDualBaseCircuits(codec: cameraState.codec)
+    }
+
+    /// Whether the ISO picker shows Auto On / Auto Off (non-R3D NE movie codecs).
+    var showsAutoISOPicker: Bool {
+        ISOPickerPolicy.showsAutoISOControl(codec: cameraState.codec)
+    }
+
+    /// True when the body is driving ISO (Auto/P/A/S) rather than the operator drum.
+    var isAutoISOActive: Bool {
+        ISOPickerPolicy.isAutoISOActive(exposureMode: commandExposureMode)
     }
 
     /// ISO is locked while recording in R3D NE; other codecs allow mid-roll ISO changes.
@@ -5530,6 +5543,9 @@ final class NativeAppModel {
     /// their own stored value; alternative circuits (ISO/shutter/WB) use the live value when it
     /// belongs to that mode, otherwise the mode's base.
     func pickerModeValue(_ picker: CameraPicker, mode: Int) -> String {
+        if picker == .iso, showsAutoISOPicker {
+            return cameraValue(for: picker)
+        }
         if picker == .iso, !showsDualBaseISOPicker {
             return cameraValue(for: picker)
         }
@@ -5583,6 +5599,12 @@ final class NativeAppModel {
                 default: nil
                 }
             if let control { applyAudioControl(control, value: value) }
+            return
+        }
+        if picker == .iso {
+            // Leaving Auto ISO by choosing a drum value (or Auto Off tab already switched M).
+            prepareManualISOIfNeeded()
+            applyPickerValue(value, for: picker)
             return
         }
         guard picker == .focus else {
@@ -5760,6 +5782,21 @@ final class NativeAppModel {
                 write: write
             )
         )
+    }
+
+    /// Toggles camera-managed ISO (Auto On) vs manual ISO (Auto Off → exposure mode M).
+    func switchAutoISO(enabled: Bool) {
+        guard showsAutoISOPicker, !isISORecordingLocked else { return }
+        let mode =
+            enabled
+            ? ISOPickerPolicy.autoISOOnExposureMode : ISOPickerPolicy.autoISOOffExposureMode
+        applyPickerValue(mode, for: .mode)
+    }
+
+    /// Ensures ISO writes can stick: when Auto ISO is active, leave Auto by switching to M first.
+    func prepareManualISOIfNeeded() {
+        guard showsAutoISOPicker, isAutoISOActive, !isISORecordingLocked else { return }
+        switchAutoISO(enabled: false)
     }
 
     func switchShutterMode(speedMode: Bool) {

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -5570,8 +5570,9 @@ final class NativeAppModel {
             if let iso = cameraPropertySnapshot.iso, iso > 0 {
                 return String(iso)
             }
-            let live = cameraValue(for: picker)
-            if live.allSatisfy(\.isNumber) { return live }
+            let live = cameraValue(for: picker).trimmingCharacters(in: .whitespaces)
+            let numeric = live.hasPrefix("A") ? String(live.dropFirst()) : live
+            if numeric.allSatisfy(\.isNumber), !numeric.isEmpty { return numeric }
             return ISOPickerPolicy.unifiedOptions.first ?? "800"
         }
         if picker == .iso, !showsDualBaseISOPicker {

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,12 +1,12 @@
 What's changed
 
-- Playback de-squeeze now scales the video itself (not only guides), including a 1.6× chip and a custom 1.0–2.0× control in 0.01 steps on live and playback.
-- Auto ISO (non-R3D NE: N-RAW, ProRes, H.264/H.265) now toggles movie ISO auto/manual on the camera — not exposure program Auto/M. Use Auto On / Auto Off under the ISO picker, or pick an ISO value to leave ISO Auto and set a manual ISO.
-- R3D NE still uses Low / High base ISO circuits; recording lock for R3D NE is unchanged.
+- Playback and live desqueeze scale the picture itself (not only guides), with a 1.6× chip and a custom 1.00–2.00× control in fine 0.01 steps.
+- On non-R3D formats (N-RAW, ProRes, H.264/H.265), ISO Auto On/Off controls movie ISO auto — not the P/A/S/M exposure dial. While Auto is on, the tile shows the live working ISO (e.g. A51200) and the value drum is locked.
+- Manual ISO / Auto Off is available only in exposure mode M on those formats. R3D NE still uses Low/High base circuits and stays manual in every exposure mode (including A).
 
 Please test
 
-- In media playback, enable Desqueeze, try 1.6× and the custom slider, and confirm the picture (not only overlays) changes. Repeat on live view.
-- On ProRes or H.265 in Manual (or any) exposure mode: open ISO, confirm Auto On/Off controls ISO sensitivity auto (ISO tile shows Auto when on), that choosing a drum ISO value turns ISO auto off without changing P/A/S/M, and that picking an ISO value is accepted (no "camera rejected" error).
-- Confirm exposure MODE (Auto/P/A/S/M) is unchanged when toggling ISO Auto On/Off.
-- On R3D NE, confirm Low/High base tabs still work and ISO remains locked only while recording.
+- Enable Desqueeze on playback and live; try 1.6× and the custom slider; confirm the image (not only overlays) changes.
+- On ProRes or H.265 in M: open ISO, switch Auto On/Off, confirm the tile tracks live Auto ISO, then set a manual ISO with no false error toast.
+- On ProRes or H.265 in A or S: confirm Auto Off / manual ISO is not offered and the drum stays locked.
+- On R3D NE in A: confirm Low/High base still works and ISO is not blocked by an “needs M mode” message.

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,6 +1,6 @@
 What's changed
 
-- Playback de-squeeze now scales the video itself (not only guides), including a 1.6× chip and a custom 1.0–2.0× control in 0.1 steps on live and playback.
+- Playback de-squeeze now scales the video itself (not only guides), including a 1.6× chip and a custom 1.0–2.0× control in 0.01 steps on live and playback.
 - Auto ISO (non-R3D NE: N-RAW, ProRes, H.264/H.265) now toggles movie ISO auto/manual on the camera — not exposure program Auto/M. Use Auto On / Auto Off under the ISO picker, or pick an ISO value to leave ISO Auto and set a manual ISO.
 - R3D NE still uses Low / High base ISO circuits; recording lock for R3D NE is unchanged.
 

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,13 +1,11 @@
 What's changed
 
-- Live view keeps updating while you record (from the app or the camera body) and after you stop — the feed should not freeze for the whole take.
-- Downloading RED IPP2 look tables is more reliable: the archive imports cleanly, slight float rounding from RED no longer rejects every LUT, and Close leaves the download screen immediately.
-- After a download that left the camera network for internet, the monitor shows clear reconnect progress instead of a bare “No camera” while the app searches and rejoins.
-- Joining the camera’s Wi‑Fi network is faster and more reliable after pairing Confirm, including when the system network picker needs a short search.
+- Playback de-squeeze now scales the video itself (not only guides), including a 1.6× chip and a custom 1.0–2.0× control in 0.1 steps on live and playback.
+- On non-R3D NE codecs (N-RAW, ProRes, H.264/H.265), ISO no longer stays locked under Auto: use Auto On / Auto Off under the ISO picker, or pick an ISO value to leave Auto and set manual ISO.
+- R3D NE still uses Low / High base ISO circuits; recording lock for R3D NE is unchanged.
 
 Please test
 
-- Start and stop recording from the app and from the camera body. Confirm live view keeps moving through the take and recovers cleanly when you stop.
-- From the LUT picker, run RED download: accept terms, download, confirm LUTs appear under RED, then Close and reconnect to the camera if you hopped off its Wi‑Fi.
-- Pair or reconnect over the camera’s Wi‑Fi after Confirm; the app should reach live view without hanging on Connecting.
-- Drag analysis scopes in landscape and confirm they move freely except at the side control rails.
+- In media playback, enable Desqueeze, try 1.6× and the custom slider, and confirm the picture (not only overlays) changes. Repeat on live view.
+- On ProRes or H.265 with Auto exposure, open ISO: confirm Auto On/Off tabs, that choosing an ISO value exits Auto, and that ISO can be changed.
+- On R3D NE, confirm Low/High base tabs still work and ISO remains locked only while recording.

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -7,6 +7,6 @@ What's changed
 Please test
 
 - In media playback, enable Desqueeze, try 1.6× and the custom slider, and confirm the picture (not only overlays) changes. Repeat on live view.
-- On ProRes or H.265 in Manual (or any) exposure mode: open ISO, confirm Auto On/Off controls ISO sensitivity auto (ISO tile shows Auto when on), that choosing a drum ISO value turns ISO auto off without changing P/A/S/M, and that ISO can be set manually.
+- On ProRes or H.265 in Manual (or any) exposure mode: open ISO, confirm Auto On/Off controls ISO sensitivity auto (ISO tile shows Auto when on), that choosing a drum ISO value turns ISO auto off without changing P/A/S/M, and that picking an ISO value is accepted (no "camera rejected" error).
 - Confirm exposure MODE (Auto/P/A/S/M) is unchanged when toggling ISO Auto On/Off.
 - On R3D NE, confirm Low/High base tabs still work and ISO remains locked only while recording.

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,11 +1,12 @@
 What's changed
 
 - Playback de-squeeze now scales the video itself (not only guides), including a 1.6× chip and a custom 1.0–2.0× control in 0.1 steps on live and playback.
-- On non-R3D NE codecs (N-RAW, ProRes, H.264/H.265), ISO no longer stays locked under Auto: use Auto On / Auto Off under the ISO picker, or pick an ISO value to leave Auto and set manual ISO.
+- Auto ISO (non-R3D NE: N-RAW, ProRes, H.264/H.265) now toggles movie ISO auto/manual on the camera — not exposure program Auto/M. Use Auto On / Auto Off under the ISO picker, or pick an ISO value to leave ISO Auto and set a manual ISO.
 - R3D NE still uses Low / High base ISO circuits; recording lock for R3D NE is unchanged.
 
 Please test
 
 - In media playback, enable Desqueeze, try 1.6× and the custom slider, and confirm the picture (not only overlays) changes. Repeat on live view.
-- On ProRes or H.265 with Auto exposure, open ISO: confirm Auto On/Off tabs, that choosing an ISO value exits Auto, and that ISO can be changed.
+- On ProRes or H.265 in Manual (or any) exposure mode: open ISO, confirm Auto On/Off controls ISO sensitivity auto (ISO tile shows Auto when on), that choosing a drum ISO value turns ISO auto off without changing P/A/S/M, and that ISO can be set manually.
+- Confirm exposure MODE (Auto/P/A/S/M) is unchanged when toggling ISO Auto On/Off.
 - On R3D NE, confirm Low/High base tabs still work and ISO remains locked only while recording.


### PR DESCRIPTION
## Summary

Beta feedback on **iOS and Android**:

1. **Playback / live desqueeze** — scales the picture itself (not only guides). Shared **1.6×** chip and **custom 1.00–2.00× in 0.01 steps**.
2. **Auto ISO** (N-RAW / ProRes / H.264 / H.265) — **Auto On / Auto Off** control movie ISO auto (`MovISOAutoControl`), not P/A/S/M exposure program. While Auto is on, the tile shows live working ISO (e.g. A51200) and the drum is locked. **Manual / Auto Off only in exposure mode M.**
3. **R3D NE** — Low/High dual-base unchanged; manual ISO in every exposure mode (including A). Recording lock for R3D NE unchanged.
4. **Android write authority** — no false “not supported” / “did not confirm” after a successful body write; see `docs/android-control-writes.md`.

Kaneo: **OPE-110** → in-review with this PR.

## Test plan

- [ ] **Playback + live:** Desqueeze 1.6× and custom slider; picture (not only overlays) scales (iOS + Android)
- [ ] **ProRes/H.265 in M:** Auto On/Off; live A-ISO; manual ISO without false error toast
- [ ] **ProRes/H.265 in A/S:** no Auto Off / manual; drum locked
- [ ] **R3D NE in A:** Low/High still work; no “needs M mode” banner
- [ ] `just native-check` / Android unit tests for touched surfaces