### PR TITLE
ci(android): auto-upload Play internal on main like TestFlight

### DIFF
--- a/.github/workflows/play-internal.yml
+++ b/.github/workflows/play-internal.yml
@@ -1,15 +1,17 @@
 name: Play Internal
 
-# Uploads the signed phone and Wear OS bundles to their Google Play internal
-# testing tracks. Deliberate releases only: manual dispatch or an `android-v*`
-# tag, never plain merges.
-# Prerequisites (Play console app, `play` environment secrets, and the first
-# MANUAL .aab upload Google requires) are in docs/android-distribution.md.
+# Uploads signed phone + Wear OS bundles to Google Play internal testing tracks.
+# Mirrors TestFlight automation: runs on push to main when Android-relevant paths
+# change, plus manual dispatch and optional android-v* tags.
+# Gated by repository variable PLAY_UPLOAD_ENABLED (must be exactly "true").
+# Prerequisites: docs/android-distribution.md
 on:
-  workflow_dispatch:
   push:
+    branches:
+      - main
     tags:
       - "android-v*"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -25,11 +27,44 @@ env:
   ANDROID_VERSION_CODE_OFFSET: "100"
 
 jobs:
-  play-internal:
-    name: Build & upload
+  changes:
+    name: Detect changes
+    # Uploads stay off until the repo variable is explicitly set; the repo-name
+    # guard alone would re-arm on rename.
     if: >-
       ${{ github.repository == 'erik-sutton95/openzcine' &&
           vars.PLAY_UPLOAD_ENABLED == 'true' }}
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dorny/paths-filter@fbd0ab8f3e80693af611ebaee6363fc25e6d187d # v4
+        id: filter
+        with:
+          # Product paths that affect the Android phone/Wear app. Shared Swift core
+          # is included so protocol/UI parity merges also ship to internal testers.
+          filters: |
+            code:
+              - 'Sources/**'
+              - 'Tests/**'
+              - 'Apps/Android/**'
+              - 'Package.swift'
+              - '.swift-format'
+              - 'scripts/android-*.sh'
+              - 'scripts/verify-android-*.sh'
+              - 'justfile'
+              - '.github/workflows/play-internal.yml'
+
+  play-internal:
+    name: Build & upload
+    needs: changes
+    if: >-
+      github.repository == 'erik-sutton95/openzcine' &&
+      vars.PLAY_UPLOAD_ENABLED == 'true' &&
+      (needs.changes.outputs.code == 'true' ||
+       github.event_name == 'workflow_dispatch' ||
+       startsWith(github.ref, 'refs/tags/android-v'))
     runs-on: ubuntu-latest
     environment: play
     steps:
@@ -171,4 +206,10 @@ jobs:
             echo "- **Phone version code:** ${{ steps.version.outputs.version_code }}"
             echo "- **Wear version code:** $((1000000000 + ${{ steps.version.outputs.version_code }}))"
             echo "- **Commit:** \`${{ github.sha }}\`"
+            echo ""
+            echo "<details><summary>What's new</summary>"
+            echo ""
+            cat Apps/Android/distribution/whatsnew/whatsnew-en-US
+            echo ""
+            echo "</details>"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,3 +1,4 @@
-- Internal preview of OpenZCine for Nikon Z cameras.
-- Connect to a camera, monitor live view, control recording, and use the Wear OS companion.
-- Please report connection, control, or display issues from your camera setup.
+- Internal beta now updates automatically when Android changes merge to main.
+- Playback and live desqueeze scale the picture (1.6× and custom fine steps).
+- Auto ISO On/Off for non-R3D formats; live working ISO while Auto is on; manual ISO in M mode.
+- R3D NE still uses Low/High base ISO and stays manual in every exposure mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ All notable changes to this project are documented here. The format is based on
 
 ### Changed
 
+- Google Play **internal** uploads automate like TestFlight: merge Android-relevant paths to `main`
+  builds and uploads phone + Wear AABs when `PLAY_UPLOAD_ENABLED=true` (see
+  `docs/android-distribution.md`). Manual dispatch and `android-v*` tags remain.
 - Android control writes: facade owns encode + native confirm; shell no longer soft-fails after a
   successful apply (see `docs/android-control-writes.md`).
 - TestFlight notes are now reviewed, tester-written copy with concrete test steps. CI rejects stale

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,10 +41,17 @@ committed to this repo**.
 - Open a pull request into `main`. CI must pass and the PR template must be filled in.
 - When native iOS changes merge to `main`, CI uploads a TestFlight build automatically (maintainers
   only — see [`docs/testflight-ci.md`](docs/testflight-ci.md)).
+- When Android-relevant changes merge to `main`, CI uploads signed phone + Wear bundles to Google
+  Play **internal testing** (maintainers only — see
+  [`docs/android-distribution.md`](docs/android-distribution.md)). Gated by
+  `PLAY_UPLOAD_ENABLED=true`.
 - Any PR that can trigger a TestFlight build must replace
   [`ios/TestFlight/WhatToTest.en-US.txt`](ios/TestFlight/WhatToTest.en-US.txt) with concise copy for
   non-developer camera operators. Describe visible outcomes, exclude implementation details, and
   give concrete steps under **Please test**. CI rejects stale or developer-centric notes.
+- Any PR that can trigger a Play internal upload must refresh
+  [`Apps/Android/distribution/whatsnew/whatsnew-en-US`](Apps/Android/distribution/whatsnew/whatsnew-en-US)
+  with plain-language tester notes (1–5 bullets).
 
 ## Code standards
 

--- a/docs/android-distribution.md
+++ b/docs/android-distribution.md
@@ -2,21 +2,25 @@
 
 Signed phone and Wear OS Android App Bundles are built and uploaded to their Google Play
 **internal testing** tracks by [`play-internal.yml`](../.github/workflows/play-internal.yml).
-Releases are deliberate: the workflow runs on manual dispatch or an `android-v*` tag, never on
-plain merges. The repository variable `PLAY_UPLOAD_ENABLED` is an emergency/bootstrap switch; it
-must be exactly `true` or the upload job is skipped.
+Automation mirrors iOS TestFlight: when Android-relevant paths land on `main`, CI builds signed
+AABs and uploads them to the phone **internal** and Wear **wear:qa** tracks. Manual dispatch and
+`android-v*` tags remain available. The repository variable `PLAY_UPLOAD_ENABLED` must be exactly
+`true` or the upload job is skipped (kill switch / bootstrap gate).
 
 ## Flow
 
 ```text
 feature PR → CI (Gradle build + tests + lint) → merge to main
-→ tag android-v<openzcine.versionName> (or run Play Internal from main)
+→ (path filter: Android / shared core / Play scripts) Play Internal workflow
 → signed phone + Wear .aab files → Play phone + Wear internal tracks
 ```
 
+Optional: tag `android-v<openzcine.versionName>` or **Actions → Play Internal → Run workflow** on
+`main` for a deliberate upload without a product path change.
+
 The track goes live only after the [one-time Play console setup](#one-time-play-console-setup)
 below. Keep `PLAY_UPLOAD_ENABLED=false` until the app, upload key, service account, and first manual
-phone/Wear releases all exist.
+phone/Wear releases all exist; then set it to `true` for automated main uploads.
 
 ## Version numbers
 
@@ -64,8 +68,9 @@ Erik's checklist, in order:
    `main` and `android-v*` tags. Add the five secrets below. Add required reviewers in the GitHub
    UI if uploads should require a human approval after the job starts.
 7. **Activate automation last** — verify the manual phone and Wear releases install, then change
-   the repository variable `PLAY_UPLOAD_ENABLED` from `false` to `true`. Run **Play Internal** from
-   `main` once; leave tag-driven releases for reviewed version bumps.
+   the repository variable `PLAY_UPLOAD_ENABLED` from `false` to `true`. Subsequent merges to
+   `main` that touch Android-relevant paths upload automatically (same idea as TestFlight). Use
+   **Play Internal** manual dispatch or an `android-v*` tag for an out-of-band upload.
 
 ## GitHub `play` environment secrets
 
@@ -86,12 +91,16 @@ Federation is the follow-up path when the Play publisher tooling and GitHub iden
 
 ## Running the workflow
 
+- **Automatic (default)** — merge to `main` with changes under `Sources/`, `Tests/`,
+  `Apps/Android/`, `Package.swift`, Android play scripts, `justfile`, or
+  `.github/workflows/play-internal.yml`. Path filter matches TestFlight’s “only when product code
+  moves” idea.
+- **Manual** — **Actions → Play Internal → Run workflow**, selecting `main`.
 - **Tag release** — if `openzcine.versionName=0.1.0`, use
   `git tag android-v0.1.0 && git push origin android-v0.1.0`. The workflow rejects a tag whose
   version differs from `Apps/Android/gradle.properties` or whose commit is not on `main`.
-- **Manual** — **Actions → Play Internal → Run workflow**, selecting `main`.
 
-Either way the workflow runs Gradle tests + lint, computes both unique version codes, decodes the
+In every case the workflow runs Gradle tests + lint, computes both unique version codes, decodes the
 keystore secret to a runner temp file, builds both `bundleRelease` outputs signed via the same
 `ANDROID_KEYSTORE_*` environment variables, verifies both AAB signatures against the configured
 upload-key alias, and uploads the bundles, R8 mapping files, and reviewed notes from
@@ -126,8 +135,8 @@ unsigned or both carry the same signing certificate. The debug path (`just andro
 
 | Symptom | Likely cause |
 | --- | --- |
-| Workflow skipped | Fork, or repository variable `PLAY_UPLOAD_ENABLED` is not `true` |
-| Release-ref guard fails | Manual run did not select `main`, or tag/version/main ancestry do not match |
+| Workflow skipped | Fork, `PLAY_UPLOAD_ENABLED` is not `true`, or path filter saw no Android-relevant files |
+| Release-ref guard fails | Manual/tag run did not use `main` / matching `android-v*` tag, or tag is not on main |
 | Missing `play` environment secrets | One or more of the five required values above is absent |
 | Upload fails with 403 / "not found" | Service account lacks release permission, or the app was never created in the console |
 | "Package not found" on first CI upload | The mandatory manual first uploads (step 5) haven't happened yet |

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,7 +1,7 @@
 What's changed
 
 - Playback and live desqueeze scale the picture itself (not only guides), with a 1.6× chip and a custom 1.00–2.00× control in fine 0.01 steps.
-- On non-R3D formats (N-RAW, ProRes, H.264/H.265), ISO Auto On/Off controls movie ISO auto — not the P/A/S/M exposure dial. While Auto is on, the tile shows the live working ISO (for example A51200) and the value drum is locked.
+- On non-R3D formats (N-RAW, ProRes, H.264/H.265), ISO Auto On/Off controls movie ISO auto — not the P/A/S/M exposure dial. While Auto is on, the tile shows the live working ISO (e.g. A51200) and the value drum is locked.
 - Manual ISO / Auto Off is available only in exposure mode M on those formats. R3D NE still uses Low/High base circuits and stays manual in every exposure mode (including A).
 
 Please test

--- a/scripts/android-play-release-guard.sh
+++ b/scripts/android-play-release-guard.sh
@@ -17,9 +17,15 @@ case "${EVENT_NAME:-}" in
     [[ "${REF_NAME:-}" == "main" ]] || fail "manual releases must run from main, not ${REF_NAME:-an unknown ref}"
     ;;
   push)
-    expected_tag="android-v${version_name}"
-    [[ "${REF_NAME:-}" == "$expected_tag" ]] || fail "tag must be ${expected_tag}, not ${REF_NAME:-an unknown ref}"
-    git merge-base --is-ancestor HEAD origin/main || fail "release tag commit is not on main"
+    # Automated main uploads (TestFlight-style) or deliberate android-v* tags.
+    if [[ "${REF_NAME:-}" == "main" ]]; then
+      :
+    else
+      expected_tag="android-v${version_name}"
+      [[ "${REF_NAME:-}" == "$expected_tag" ]] ||
+        fail "tag must be ${expected_tag} or main, not ${REF_NAME:-an unknown ref}"
+      git merge-base --is-ancestor HEAD origin/main || fail "release tag commit is not on main"
+    fi
     ;;
   *)
     fail "unsupported event ${EVENT_NAME:-unknown}"


### PR DESCRIPTION
## Summary

Make Google Play **internal testing** uploads automatic on merge to `main`, matching the TestFlight model.

- Trigger: push to `main` when Android-relevant paths change (`Sources/`, `Apps/Android/`, shared package, Play scripts, etc.)
- Still supports **manual dispatch** and `android-v*` tags
- Kill switch remains: `PLAY_UPLOAD_ENABLED` must be `true`
- Docs + CONTRIBUTING + Play whatsnew updated

## After merge

1. Ensure `PLAY_UPLOAD_ENABLED=true` (repo variable).
2. First automated run will upload phone + Wear to internal / wear:qa with the next version code.

## Test plan

- [ ] actionlint / meta checks on the workflow
- [ ] Guard: main + workflow_dispatch OK; off-main dispatch fails
- [ ] After merge + flag true: Play Internal runs on next Android-touching main commit (or manual dispatch once)