### PR TITLE
ci: fix dorny/paths-filter pin for Play auto-upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
       # git credentials — so this job keeps them (unlike the others). It runs no repository code, so
       # the token is never exposed to untrusted code.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/play-internal.yml
+++ b/.github/workflows/play-internal.yml
@@ -63,8 +63,8 @@ jobs:
       github.repository == 'erik-sutton95/openzcine' &&
       vars.PLAY_UPLOAD_ENABLED == 'true' &&
       (needs.changes.outputs.code == 'true' ||
-       github.event_name == 'workflow_dispatch' ||
-       startsWith(github.ref, 'refs/tags/android-v'))
+        github.event_name == 'workflow_dispatch' ||
+        startsWith(github.ref, 'refs/tags/android-v'))
     runs-on: ubuntu-latest
     environment: play
     steps:

--- a/.github/workflows/play-internal.yml
+++ b/.github/workflows/play-internal.yml
@@ -39,7 +39,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dorny/paths-filter@fbd0ab8f3e80693af611ebaee6363fc25e6d187d # v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: filter
         with:
           # Product paths that affect the Android phone/Wear app. Shared Swift core

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -36,7 +36,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
+      - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## Summary

Play Internal Detect changes failed with `unable to find version fbd0ab8…` for `dorny/paths-filter`. Point workflows at the real v4 tip (`7b450fff…`) so main-merge Play uploads can run.

Also updates the same pin in `testflight.yml` and `ci.yml` for consistency.

## Test plan

- [ ] Meta checks / action resolve on PR
- [ ] After merge: Play Internal Detect changes succeeds when `PLAY_UPLOAD_ENABLED=true`