### PR TITLE
feat: add subtle landing-page community field notes

### DIFF
--- a/.github/workflows/play-internal.yml
+++ b/.github/workflows/play-internal.yml
@@ -63,8 +63,8 @@ jobs:
       github.repository == 'erik-sutton95/openzcine' &&
       vars.PLAY_UPLOAD_ENABLED == 'true' &&
       (needs.changes.outputs.code == 'true' ||
-       github.event_name == 'workflow_dispatch' ||
-       startsWith(github.ref, 'refs/tags/android-v'))
+        github.event_name == 'workflow_dispatch' ||
+        startsWith(github.ref, 'refs/tags/android-v'))
     runs-on: ubuntu-latest
     environment: play
     steps:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -334,6 +334,9 @@ Feature work tracked as its own tasks on the Kaneo board, outside the Phase 0–
   links to it directly. Android stays presented as clearly unavailable until it ships.
 - **Landing-page camera compatibility** (in progress): identify the Nikon ZR, Z9, and Z5II as
   working, and the Z6, Z6II, Z6III, Zf, Z8, Z7, and Z7II as untested.
+- **Landing-page community reactions** (OPE-111, in progress): add a concise, accessible social-
+  proof strip using faithful excerpts from beta feedback and public community posts, with source-
+  level attribution and no private tester identities.
 - **Model-agnostic Nikon Z camera-AP onboarding** (OPE-105, in progress): recognize conservative
   Nikon Z SSID shapes without rebuilding unknown model names, share that classifier across scanning
   and reconnect policy, and provide exact manual SSID/key entry when OCR or a future body format

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -334,9 +334,9 @@ Feature work tracked as its own tasks on the Kaneo board, outside the Phase 0–
   links to it directly. Android stays presented as clearly unavailable until it ships.
 - **Landing-page camera compatibility** (in progress): identify the Nikon ZR, Z9, and Z5II as
   working, and the Z6, Z6II, Z6III, Zf, Z8, Z7, and Z7II as untested.
-- **Landing-page community reactions** (OPE-111, in progress): add a concise, accessible social-
-  proof strip using faithful excerpts from beta feedback and public community posts, with source-
-  level attribution and no private tester identities.
+- **Landing-page community reactions** (OPE-111, in progress): place concise, accessible field-note
+  quotes throughout the feature tour using faithful excerpts from beta feedback and public community
+  posts, with source-level attribution and no private tester identities.
 - **Model-agnostic Nikon Z camera-AP onboarding** (OPE-105, in progress): recognize conservative
   Nikon Z SSID shapes without rebuilding unknown model names, share that classifier across scanning
   and reconnect policy, and provide exact manual SSID/key entry when OCR or a future body format

--- a/site/assets/app.css
+++ b/site/assets/app.css
@@ -563,6 +563,72 @@ h3 { font-size: clamp(20px, 2.4vw, 26px); line-height: 1.2; letter-spacing: -0.0
 .statement__text .w--gold { color: var(--accent); }
 
 /* ================================================================ */
+/* VOICES - beta and community reactions in a continuous film crawl */
+/* ================================================================ */
+.voices {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(24px, 3vw, 34px) 0;
+  border-top: 1px solid var(--hairline);
+  border-bottom: 1px solid var(--hairline);
+  background: rgba(4, 4, 4, .18);
+  -webkit-mask-image: linear-gradient(90deg, transparent, #000 6%, #000 94%, transparent);
+  mask-image: linear-gradient(90deg, transparent, #000 6%, #000 94%, transparent);
+}
+.voices__track {
+  display: flex;
+  width: max-content;
+  animation: ticker-roll 72s linear infinite;
+}
+.voices__group {
+  display: flex;
+  align-items: center;
+  list-style: none;
+}
+.voices__group li {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  padding: 0 clamp(34px, 4.5vw, 72px);
+  color: var(--muted);
+  font: 400 clamp(16px, 1.55vw, 20px)/1.35 var(--mono);
+  letter-spacing: .01em;
+  white-space: nowrap;
+}
+.voices q { quotes: "\201C" "\201D"; }
+.voices cite {
+  color: var(--accent);
+  font: 600 11px/1 var(--mono);
+  font-style: normal;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.voices cite a {
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  text-underline-offset: 4px;
+  transition: text-decoration-color .2s ease;
+}
+.voices cite a:hover,
+.voices cite a:focus-visible { text-decoration-color: currentColor; }
+.voices:hover .voices__track,
+.voices:focus-within .voices__track { animation-play-state: paused; }
+@media (max-width: 560px) {
+  .voices__group li { gap: 12px; padding: 0 24px; font-size: 15px; }
+  .voices cite { font-size: 10px; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .voices {
+    overflow-x: auto;
+    -webkit-mask-image: none;
+    mask-image: none;
+  }
+  .voices__track { animation: none; }
+  .voices__group[aria-hidden="true"] { display: none; }
+}
+
+/* ================================================================ */
 /* FEATURE ROWS - copy + real device render, scroll-revealed         */
 /* ================================================================ */
 .feat-row { align-items: center; }

--- a/site/assets/app.css
+++ b/site/assets/app.css
@@ -563,69 +563,52 @@ h3 { font-size: clamp(20px, 2.4vw, 26px); line-height: 1.2; letter-spacing: -0.0
 .statement__text .w--gold { color: var(--accent); }
 
 /* ================================================================ */
-/* VOICES - beta and community reactions in a continuous film crawl */
+/* FIELD NOTES - quiet reactions scattered through the feature tour */
 /* ================================================================ */
-.voices {
-  position: relative;
-  overflow: hidden;
-  padding: clamp(24px, 3vw, 34px) 0;
-  border-top: 1px solid var(--hairline);
-  border-bottom: 1px solid var(--hairline);
-  background: rgba(4, 4, 4, .18);
-  -webkit-mask-image: linear-gradient(90deg, transparent, #000 6%, #000 94%, transparent);
-  mask-image: linear-gradient(90deg, transparent, #000 6%, #000 94%, transparent);
+.field-note { padding: clamp(12px, 2.5vw, 30px) 0; }
+.field-note .container { display: flex; }
+.field-note--left .field-note__quote {
+  margin-left: clamp(0px, 4vw, 64px);
+  margin-right: auto;
 }
-.voices__track {
-  display: flex;
-  width: max-content;
-  animation: ticker-roll 72s linear infinite;
+.field-note--right .field-note__quote {
+  margin-right: clamp(0px, 6vw, 96px);
+  margin-left: auto;
 }
-.voices__group {
-  display: flex;
-  align-items: center;
-  list-style: none;
+.field-note__quote {
+  width: min(520px, 78vw);
+  padding-left: clamp(14px, 2vw, 20px);
+  border-left: 1px solid var(--hairline-2);
 }
-.voices__group li {
-  display: flex;
-  align-items: baseline;
-  gap: 16px;
-  padding: 0 clamp(34px, 4.5vw, 72px);
-  color: var(--muted);
-  font: 400 clamp(16px, 1.55vw, 20px)/1.35 var(--mono);
+.field-note blockquote {
+  color: var(--faint);
+  font: 400 clamp(14px, 1.35vw, 17px)/1.6 var(--mono);
   letter-spacing: .01em;
-  white-space: nowrap;
 }
-.voices q { quotes: "\201C" "\201D"; }
-.voices cite {
+.field-note figcaption {
+  margin-top: 9px;
   color: var(--accent);
-  font: 600 11px/1 var(--mono);
-  font-style: normal;
-  letter-spacing: .14em;
+  font: 600 10px/1.4 var(--mono);
+  letter-spacing: .13em;
+  opacity: .7;
   text-transform: uppercase;
-  white-space: nowrap;
 }
-.voices cite a {
+.field-note figcaption a {
   text-decoration: underline;
   text-decoration-color: transparent;
   text-underline-offset: 4px;
-  transition: text-decoration-color .2s ease;
+  transition: opacity .2s ease, text-decoration-color .2s ease;
 }
-.voices cite a:hover,
-.voices cite a:focus-visible { text-decoration-color: currentColor; }
-.voices:hover .voices__track,
-.voices:focus-within .voices__track { animation-play-state: paused; }
+.field-note figcaption a:hover,
+.field-note figcaption a:focus-visible {
+  opacity: 1;
+  text-decoration-color: currentColor;
+}
 @media (max-width: 560px) {
-  .voices__group li { gap: 12px; padding: 0 24px; font-size: 15px; }
-  .voices cite { font-size: 10px; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .voices {
-    overflow-x: auto;
-    -webkit-mask-image: none;
-    mask-image: none;
-  }
-  .voices__track { animation: none; }
-  .voices__group[aria-hidden="true"] { display: none; }
+  .field-note { padding: 10px 0; }
+  .field-note__quote { width: 100%; }
+  .field-note--left .field-note__quote,
+  .field-note--right .field-note__quote { margin-right: 0; margin-left: 0; }
 }
 
 /* ================================================================ */

--- a/site/index.html
+++ b/site/index.html
@@ -126,63 +126,15 @@
       </p>
     </section>
 
-    <!-- ============ VOICES - verified beta and community reactions ============ -->
-    <section class="voices" aria-label="What filmmakers are saying about OpenZCine">
-      <div class="voices__track">
-        <ul class="voices__group">
-          <li>
-            <q>On iPad, it&rsquo;s a totally different experience.</q>
-            <cite>TestFlight tester</cite>
-          </li>
-          <li>
-            <q>The UI is very impressive and responsive. I love it.</q>
-            <cite>TestFlight tester</cite>
-          </li>
-          <li>
-            <q>Your app definitely connects faster than the others.</q>
-            <cite>TestFlight tester</cite>
-          </li>
-          <li>
-            <q>It looks and feels great compared to the other ones around.</q>
-            <cite><a href="https://www.reddit.com/r/NikonFilmmakers/comments/1uytrln/sneak_peek_followup_ios_testflights_open/" target="_blank" rel="noopener">r/NikonFilmmakers</a></cite>
-          </li>
-          <li>
-            <q>This would be an amazing alternative for on the go shooting.</q>
-            <cite><a href="https://www.reddit.com/r/nikon_Zseries/comments/1uufr87/sneak_peek_introducing_openzcine_a_free_and_open/" target="_blank" rel="noopener">r/nikon_Zseries</a></cite>
-          </li>
-          <li>
-            <q>A brilliant app for controlling Nikon Z cameras.</q>
-            <cite><a href="https://www.facebook.com/groups/nikonzcinema/posts/1038396715505198/" target="_blank" rel="noopener">Nikon ZR Cinema User Experience (PRO Group)</a></cite>
-          </li>
-        </ul>
-        <ul class="voices__group" aria-hidden="true">
-          <li>
-            <q>On iPad, it&rsquo;s a totally different experience.</q>
-            <cite>TestFlight tester</cite>
-          </li>
-          <li>
-            <q>The UI is very impressive and responsive. I love it.</q>
-            <cite>TestFlight tester</cite>
-          </li>
-          <li>
-            <q>Your app definitely connects faster than the others.</q>
-            <cite>TestFlight tester</cite>
-          </li>
-          <li>
-            <q>It looks and feels great compared to the other ones around.</q>
-            <cite>r/NikonFilmmakers</cite>
-          </li>
-          <li>
-            <q>This would be an amazing alternative for on the go shooting.</q>
-            <cite>r/nikon_Zseries</cite>
-          </li>
-          <li>
-            <q>A brilliant app for controlling Nikon Z cameras.</q>
-            <cite>Nikon ZR Cinema User Experience (PRO Group)</cite>
-          </li>
-        </ul>
+    <!-- ============ FIELD NOTE - quiet beta feedback ============ -->
+    <aside class="field-note field-note--right" aria-label="OpenZCine beta feedback">
+      <div class="container">
+        <figure class="field-note__quote">
+          <blockquote>The UI is very impressive and responsive. I love it.</blockquote>
+          <figcaption>TestFlight tester</figcaption>
+        </figure>
       </div>
-    </section>
+    </aside>
 
     <!-- ============ SCOPES ============ -->
     <section class="section feat-section" id="scopes">
@@ -250,6 +202,16 @@
       </div>
     </section>
 
+    <aside class="field-note field-note--left" aria-label="OpenZCine beta feedback">
+      <div class="container">
+        <figure class="field-note__quote">
+          <blockquote>On iPad, it&rsquo;s a totally different experience&mdash;you can use all the
+            functions you need without losing focus on the image.</blockquote>
+          <figcaption>TestFlight tester</figcaption>
+        </figure>
+      </div>
+    </aside>
+
     <!-- ============ COMMANDER ============ -->
     <section class="section feat-section" id="commander">
       <div class="container grid grid--2 feat-row feat-row--reverse">
@@ -268,6 +230,18 @@
       </div>
     </section>
 
+    <aside class="field-note field-note--right" aria-label="OpenZCine community feedback">
+      <div class="container">
+        <figure class="field-note__quote">
+          <blockquote>A brilliant app for controlling Nikon Z cameras.</blockquote>
+          <figcaption>
+            <a href="https://www.facebook.com/groups/nikonzcinema/posts/1038396715505198/"
+              target="_blank" rel="noopener">Nikon ZR Cinema User Experience (PRO Group)</a>
+          </figcaption>
+        </figure>
+      </div>
+    </aside>
+
     <!-- ============ PLAYBACK ============ -->
     <section class="section feat-section" id="playback">
       <div class="container grid grid--2 feat-row">
@@ -284,6 +258,18 @@
         </div>
       </div>
     </section>
+
+    <aside class="field-note field-note--left" aria-label="OpenZCine community feedback">
+      <div class="container">
+        <figure class="field-note__quote">
+          <blockquote>The monitoring works great over USB-C.</blockquote>
+          <figcaption>
+            <a href="https://www.reddit.com/r/NikonFilmmakers/comments/1uytrln/sneak_peek_followup_ios_testflights_open/"
+              target="_blank" rel="noopener">r/NikonFilmmakers</a>
+          </figcaption>
+        </figure>
+      </div>
+    </aside>
 
     <!-- ============ EXPORT / C2C ============ -->
     <section class="section feat-section" id="export">
@@ -324,6 +310,18 @@
         </div>
       </div>
     </section>
+
+    <aside class="field-note field-note--right" aria-label="OpenZCine community feedback">
+      <div class="container">
+        <figure class="field-note__quote">
+          <blockquote>I&rsquo;m loving the smart watch support&mdash;that is amazing.</blockquote>
+          <figcaption>
+            <a href="https://www.reddit.com/r/NikonFilmmakers/comments/1uufq0r/sneak_peek_introducing_openzcine_a_free_and_open/"
+              target="_blank" rel="noopener">r/NikonFilmmakers</a>
+          </figcaption>
+        </figure>
+      </div>
+    </aside>
 
     <!-- ============ OPEN SOURCE (spotlight) ============ -->
     <section class="section section--spot spot" id="open-source">

--- a/site/index.html
+++ b/site/index.html
@@ -126,6 +126,64 @@
       </p>
     </section>
 
+    <!-- ============ VOICES - verified beta and community reactions ============ -->
+    <section class="voices" aria-label="What filmmakers are saying about OpenZCine">
+      <div class="voices__track">
+        <ul class="voices__group">
+          <li>
+            <q>On iPad, it&rsquo;s a totally different experience.</q>
+            <cite>TestFlight tester</cite>
+          </li>
+          <li>
+            <q>The UI is very impressive and responsive. I love it.</q>
+            <cite>TestFlight tester</cite>
+          </li>
+          <li>
+            <q>Your app definitely connects faster than the others.</q>
+            <cite>TestFlight tester</cite>
+          </li>
+          <li>
+            <q>It looks and feels great compared to the other ones around.</q>
+            <cite><a href="https://www.reddit.com/r/NikonFilmmakers/comments/1uytrln/sneak_peek_followup_ios_testflights_open/" target="_blank" rel="noopener">r/NikonFilmmakers</a></cite>
+          </li>
+          <li>
+            <q>This would be an amazing alternative for on the go shooting.</q>
+            <cite><a href="https://www.reddit.com/r/nikon_Zseries/comments/1uufr87/sneak_peek_introducing_openzcine_a_free_and_open/" target="_blank" rel="noopener">r/nikon_Zseries</a></cite>
+          </li>
+          <li>
+            <q>A brilliant app for controlling Nikon Z cameras.</q>
+            <cite><a href="https://www.facebook.com/groups/nikonzcinema/posts/1038396715505198/" target="_blank" rel="noopener">Nikon ZR Cinema User Experience (PRO Group)</a></cite>
+          </li>
+        </ul>
+        <ul class="voices__group" aria-hidden="true">
+          <li>
+            <q>On iPad, it&rsquo;s a totally different experience.</q>
+            <cite>TestFlight tester</cite>
+          </li>
+          <li>
+            <q>The UI is very impressive and responsive. I love it.</q>
+            <cite>TestFlight tester</cite>
+          </li>
+          <li>
+            <q>Your app definitely connects faster than the others.</q>
+            <cite>TestFlight tester</cite>
+          </li>
+          <li>
+            <q>It looks and feels great compared to the other ones around.</q>
+            <cite>r/NikonFilmmakers</cite>
+          </li>
+          <li>
+            <q>This would be an amazing alternative for on the go shooting.</q>
+            <cite>r/nikon_Zseries</cite>
+          </li>
+          <li>
+            <q>A brilliant app for controlling Nikon Z cameras.</q>
+            <cite>Nikon ZR Cinema User Experience (PRO Group)</cite>
+          </li>
+        </ul>
+      </div>
+    </section>
+
     <!-- ============ SCOPES ============ -->
     <section class="section feat-section" id="scopes">
       <div class="container grid grid--2 feat-row">


### PR DESCRIPTION
## What changed

- Place five quiet community field notes between relevant landing-page feature sections.
- Attribute feedback at source level (`TestFlight tester`, `r/NikonFilmmakers`, and the Nikon ZR Cinema User Experience (PRO Group)) without publishing individual identities.
- Keep public Reddit and Facebook sources linked from their attribution labels.
- Remove the earlier scrolling ticker and every comparison with competing apps.
- Use subtle typography, hairlines, and alternating left/right placement so the product imagery remains dominant.
- Mirror the approved deliverable in `docs/ROADMAP.md` as OPE-111.
- Fix the existing two-line Play workflow indentation issue that blocked the repository-wide editorconfig gate.

## Why

The landing page benefits from real operator feedback, but the product should remain the strongest voice. Scattered field notes add human context without turning testimonials into a sales banner or making comparative quality claims.

## Validation

- `just check`
- 871 Swift tests passed
- Landing-page source and local asset validation passed
- Repository hygiene, secret, Markdown, link, workflow, and editorconfig checks passed
- Maintainer reviewed and approved the local browser preview
