### PR TITLE
fix(android): stop USB-C connect NoSuchMethodError on release

### DIFF
--- a/Apps/Android/app/proguard-rules.pro
+++ b/Apps/Android/app/proguard-rules.pro
@@ -10,3 +10,10 @@
 # names (`Java_com_opencapture_…` / GetMethodID). R8 must not rename or remove
 # either side of that contract from a release package.
 -keep class com.opencapture.openzcine.bridge.** { *; }
+
+# USB-C PTP byte transport is only called from Swift via GetMethodID on
+# writeBulk/readBulk/readEvent/isClosed/close. R8 cannot see those native
+# call sites and otherwise strips the methods as unused, which surfaces as
+# NoSuchMethodError inside sessionConnectUsb on release/minified builds.
+-keep class com.opencapture.openzcine.transport.UsbPtpTransport { *; }
+-keep class * implements com.opencapture.openzcine.transport.UsbPtpTransport { *; }

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,3 +1,4 @@
+- Fix immediate crash when connecting a camera over USB-C on release builds.
 - Internal phone and Wear beta builds update automatically when Android changes merge to main.
 - Playback and live desqueeze scale the picture (1.6× and custom fine steps).
 - Auto ISO On/Off for non-R3D formats; live working ISO while Auto is on; manual ISO in M mode.

--- a/Sources/OpenZCineAndroidFacade/AndroidUSBPTPTransport.swift
+++ b/Sources/OpenZCineAndroidFacade/AndroidUSBPTPTransport.swift
@@ -44,12 +44,20 @@
                 return nil
             }
             defer { fns.DeleteLocalRef!(env, type) }
+            // Resolve each method independently and clear a pending
+            // NoSuchMethodError on miss. Without ExceptionClear, a single
+            // missing (e.g. R8-stripped) method crashes the Kotlin caller of
+            // sessionConnectUsb even though this initializer returns nil.
             guard
-                let writeBulkMethod = fns.GetMethodID!(env, type, "writeBulk", "([BI)I"),
-                let readBulkMethod = fns.GetMethodID!(env, type, "readBulk", "(II)[B"),
-                let readEventMethod = fns.GetMethodID!(env, type, "readEvent", "(II)[B"),
-                let isClosedMethod = fns.GetMethodID!(env, type, "isClosed", "()Z"),
-                let closeMethod = fns.GetMethodID!(env, type, "close", "()V")
+                let writeBulkMethod = requiredInstanceMethod(
+                    env, type, "writeBulk", "([BI)I"),
+                let readBulkMethod = requiredInstanceMethod(
+                    env, type, "readBulk", "(II)[B"),
+                let readEventMethod = requiredInstanceMethod(
+                    env, type, "readEvent", "(II)[B"),
+                let isClosedMethod = requiredInstanceMethod(
+                    env, type, "isClosed", "()Z"),
+                let closeMethod = requiredInstanceMethod(env, type, "close", "()V")
             else {
                 fns.DeleteGlobalRef!(env, global)
                 return nil
@@ -223,6 +231,27 @@
     /// table to every native entry point, and attached threads inherit it.
     private func jniTable(_ env: UnsafeMutablePointer<JNIEnv?>) -> JNINativeInterface {
         env.pointee!.pointee
+    }
+
+    /// Resolves a required instance method and clears a pending
+    /// `NoSuchMethodError` when lookup fails so the Kotlin caller is not
+    /// aborted by a left-over JNI exception.
+    private func requiredInstanceMethod(
+        _ env: UnsafeMutablePointer<JNIEnv?>,
+        _ type: jclass?,
+        _ name: String,
+        _ signature: String
+    ) -> jmethodID? {
+        let fns = jniTable(env)
+        let method = name.withCString { namePointer in
+            signature.withCString { signaturePointer in
+                fns.GetMethodID!(env, type, namePointer, signaturePointer)
+            }
+        }
+        if method == nil {
+            fns.ExceptionClear!(env)
+        }
+        return method
     }
 
     private func swiftBytes(

--- a/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
+++ b/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
@@ -140,7 +140,7 @@
         let fns = table(env)
         guard let type = fns.GetObjectClass!(env, transport) else { return }
         defer { fns.DeleteLocalRef!(env, type) }
-        guard let close = fns.GetMethodID!(env, type, "close", "()V") else { return }
+        guard let close = optionalInstanceMethod(env, type, "close", "()V") else { return }
         var arguments = jvalue()
         fns.CallVoidMethodA!(env, transport, close, &arguments)
     }
@@ -739,9 +739,10 @@
         guard fns.GetJavaVM!(env, &vm) == JNI_OK, let vm else { return }
         guard let listener, let global = fns.NewGlobalRef!(env, listener) else { return }
         guard let cls = fns.GetObjectClass!(env, global),
-            let method = fns.GetMethodID!(
+            let method = optionalInstanceMethod(
                 env, cls, "onPhase", "(Ljava/lang/String;Ljava/lang/String;)V")
         else {
+            fns.ExceptionClear!(env)
             fns.DeleteGlobalRef!(env, global)
             return
         }
@@ -921,13 +922,17 @@
         guard fns.GetJavaVM!(env, &vm) == JNI_OK, let vm else { return }
         guard let listener, let global = fns.NewGlobalRef!(env, listener) else { return }
         guard let cls = fns.GetObjectClass!(env, global),
-            let onPhase = fns.GetMethodID!(
+            let onPhase = optionalInstanceMethod(
                 env, cls, "onPhase", "(Ljava/lang/String;Ljava/lang/String;)V"),
-            let onConnected = fns.GetMethodID!(
+            let onConnected = optionalInstanceMethod(
                 env, cls, "onConnected",
                 "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V"),
-            let onFailed = fns.GetMethodID!(env, cls, "onFailed", "(Ljava/lang/String;)V")
+            let onFailed = optionalInstanceMethod(
+                env, cls, "onFailed", "(Ljava/lang/String;)V")
         else {
+            // Clear any pending NoSuchMethodError so a listener-resolution miss
+            // cannot abort the Kotlin caller of sessionConnect.
+            fns.ExceptionClear!(env)
             fns.DeleteGlobalRef!(env, global)
             return
         }
@@ -979,13 +984,17 @@
             return
         }
         guard let cls = fns.GetObjectClass!(env, global),
-            let onPhase = fns.GetMethodID!(
+            let onPhase = optionalInstanceMethod(
                 env, cls, "onPhase", "(Ljava/lang/String;Ljava/lang/String;)V"),
-            let onConnected = fns.GetMethodID!(
+            let onConnected = optionalInstanceMethod(
                 env, cls, "onConnected",
                 "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V"),
-            let onFailed = fns.GetMethodID!(env, cls, "onFailed", "(Ljava/lang/String;)V")
+            let onFailed = optionalInstanceMethod(
+                env, cls, "onFailed", "(Ljava/lang/String;)V")
         else {
+            // Clear any pending NoSuchMethodError so a listener-resolution miss
+            // cannot abort the Kotlin caller of sessionConnectUsb.
+            fns.ExceptionClear!(env)
             fns.DeleteGlobalRef!(env, global)
             closeKotlinUSBTransport(env, transport)
             return
@@ -1003,6 +1012,9 @@
             return
         }
         guard let transportHandle = JNIUSBPTPTransportHandle(env: env, transport: transport) else {
+            // Transport GetMethodID failures clear their own pending exceptions;
+            // still clear here so a future miss cannot escape to Kotlin.
+            fns.ExceptionClear!(env)
             closeKotlinUSBTransport(env, transport)
             let message = javaString(env, "Android could not initialize the USB camera transport.")
             var arguments = [jvalue(l: message)]
@@ -1283,9 +1295,11 @@
         guard fns.GetJavaVM!(env, &vm) == JNI_OK, let vm else { return }
         guard let listener, let global = fns.NewGlobalRef!(env, listener) else { return }
         guard let cls = fns.GetObjectClass!(env, global),
-            let onEvent = fns.GetMethodID!(env, cls, "onEvent", "(IJ[J)V"),
-            let onEnded = fns.GetMethodID!(env, cls, "onEnded", "(Ljava/lang/String;)V")
+            let onEvent = optionalInstanceMethod(env, cls, "onEvent", "(IJ[J)V"),
+            let onEnded = optionalInstanceMethod(
+                env, cls, "onEnded", "(Ljava/lang/String;)V")
         else {
+            fns.ExceptionClear!(env)
             fns.DeleteGlobalRef!(env, global)
             return
         }
@@ -1862,13 +1876,14 @@
         guard fns.GetJavaVM!(env, &vm) == JNI_OK, let vm else { return }
         guard let listener, let global = fns.NewGlobalRef!(env, listener) else { return }
         guard let cls = fns.GetObjectClass!(env, global),
-            let onStarted = fns.GetMethodID!(env, cls, "onStarted", "(J)V"),
-            let onChunk = fns.GetMethodID!(env, cls, "onChunk", "(J[B)Z"),
-            let onCompleted = fns.GetMethodID!(env, cls, "onCompleted", "(J)V"),
-            let onStopped = fns.GetMethodID!(env, cls, "onStopped", "(J)V"),
-            let onFailed = fns.GetMethodID!(
+            let onStarted = optionalInstanceMethod(env, cls, "onStarted", "(J)V"),
+            let onChunk = optionalInstanceMethod(env, cls, "onChunk", "(J[B)Z"),
+            let onCompleted = optionalInstanceMethod(env, cls, "onCompleted", "(J)V"),
+            let onStopped = optionalInstanceMethod(env, cls, "onStopped", "(J)V"),
+            let onFailed = optionalInstanceMethod(
                 env, cls, "onFailed", "(Ljava/lang/String;)V")
         else {
+            fns.ExceptionClear!(env)
             fns.DeleteGlobalRef!(env, global)
             return
         }

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -6,7 +6,7 @@ What's changed
 
 Please test
 
+- USB-C connect to a ZR and confirm the session reaches connected without an immediate crash, then open live view.
 - Enable Desqueeze on playback and live; try 1.6× and the custom slider; confirm the image (not only overlays) changes.
 - On ProRes or H.265 in M: open ISO, switch Auto On/Off, confirm the tile tracks live Auto ISO, then set a manual ISO with no false error toast.
-- On ProRes or H.265 in A or S: confirm Auto Off / manual ISO is not offered and the drum stays locked.
 - On R3D NE in A: confirm Low/High base still works and ISO is not blocked by a “needs M mode” message.


### PR DESCRIPTION
## Summary
- **Root cause:** R8/minified release builds treated `UsbPtpTransport.writeBulk` / `readBulk` / `readEvent` / `isClosed` as unused (only called from Swift via `GetMethodID`). Stripped methods → pending `NoSuchMethodError` → crash at `SwiftCore.sessionConnectUsb` on USB connect.
- **Fix:** Keep the USB PTP transport JNI surface in `proguard-rules.pro`.
- **Defense in depth:** clear pending exceptions on JNI method lookup failures for USB transport + session listeners so a miss cannot abort the Kotlin caller.

## Evidence
- Play Vitals stack: `sessionConnectUsb` → `NoSuchMethodError` on closed/internal release builds (version 1 and 106).
- Local release mapping before fix listed `writeBulk`/`readBulk`/`readEvent` under R8 **usage** (removed). After the keep rule, they appear in **seeds** and in the minified DEX strings.

## Test plan
- [x] `./gradlew :app:minifyReleaseWithR8` — `writeBulk`/`readBulk`/`readEvent` present in release DEX
- [x] `just android-test`
- [x] Play + TestFlight notes checks
- [ ] After merge/Play Internal upload: USB-C connect to ZR on a release/internal build; session reaches connected without crash
- [ ] Wi-Fi connect still works