### PR TITLE
feat: share diagnostics from first-run connection setup

### DIFF
--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
@@ -7,6 +7,7 @@ import android.net.nsd.NsdManager
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.WindowManager
+import android.widget.Toast
 import androidx.activity.SystemBarStyle
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -451,6 +452,16 @@ class MainActivity : ComponentActivity() {
                                             startupSurface = StartupSurface.PAIRING
                                         }
                                     },
+                                    onShareDiagnostics = {
+                                        if (!systemSettingsActions.shareDiagnostics()) {
+                                            Toast.makeText(
+                                                    this@MainActivity,
+                                                    getString(R.string.system_action_unavailable),
+                                                    Toast.LENGTH_SHORT,
+                                                )
+                                                .show()
+                                        }
+                                    },
                                 )
                             StartupSurface.PAIRING ->
                                 PairingExperience(
@@ -465,6 +476,16 @@ class MainActivity : ComponentActivity() {
                                         } else {
                                             { startupSurface = StartupSurface.SAVED_CAMERAS }
                                         },
+                                    onShareDiagnostics = {
+                                        if (!systemSettingsActions.shareDiagnostics()) {
+                                            Toast.makeText(
+                                                    this@MainActivity,
+                                                    getString(R.string.system_action_unavailable),
+                                                    Toast.LENGTH_SHORT,
+                                                )
+                                                .show()
+                                        }
+                                    },
                                 )
                         }
                         if (standaloneSettingsPresented) {

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/ConnectionProgressPopup.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/ConnectionProgressPopup.kt
@@ -84,6 +84,7 @@ public fun ConnectionProgressPopup(
     phase: ConnectionPopupPhase,
     onConnect: () -> Unit,
     onDismiss: () -> Unit,
+    onShareDiagnostics: (() -> Unit)? = null,
 ) {
     val failed = phase is ConnectionPopupPhase.Failed
     Box(
@@ -158,6 +159,12 @@ public fun ConnectionProgressPopup(
                         label = stringResource(R.string.conn_failed_title),
                         badge = { PopupBadge(PopupColors.failure, "!") },
                     )
+                    onShareDiagnostics?.let { share ->
+                        PopupFilledButton(
+                            stringResource(R.string.conn_share_diagnostics),
+                            share,
+                        )
+                    }
                     PopupCancelButton(stringResource(R.string.action_close), onDismiss)
                 }
                 else -> {

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/PairingExperience.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/PairingExperience.kt
@@ -54,6 +54,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -528,6 +532,8 @@ public fun PairingExperience(
     onPairingProfilePrepared: (SavedCameraRecord) -> Unit = {},
     onOpenSettings: (() -> Unit)? = null,
     onShowSavedCameras: (() -> Unit)? = null,
+    /** Explicit local report handoff when pairing cannot complete (no automatic upload). */
+    onShareDiagnostics: (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
     val resources = LocalResources.current
@@ -1125,6 +1131,7 @@ public fun PairingExperience(
                             flow = flow,
                             condensed = condensedIntro,
                             onShowSavedCameras = onShowSavedCameras,
+                            onShareDiagnostics = onShareDiagnostics,
                             modifier = Modifier.width(introWidth).fillMaxSize(),
                         )
                         StepCard(
@@ -1155,6 +1162,7 @@ public fun PairingExperience(
                         PortraitIntroHeader(
                             flow = flow,
                             onShowSavedCameras = onShowSavedCameras,
+                            onShareDiagnostics = onShareDiagnostics,
                         )
                         StartupWizardProgress(
                             currentStep = flow.displayStepNumber,
@@ -1206,6 +1214,8 @@ public fun PairingExperience(
                     }
                 },
                 onDismiss = ::cancelWork,
+                onShareDiagnostics =
+                    onShareDiagnostics.takeIf { popup is ConnectionPopupPhase.Failed },
             )
         }
         if (cameraWifiScannerPresented) {
@@ -1250,6 +1260,7 @@ public fun PairingExperience(
 private fun PortraitIntroHeader(
     flow: PairingFlowState,
     onShowSavedCameras: (() -> Unit)?,
+    onShareDiagnostics: (() -> Unit)?,
 ) {
     // Sizes mirror iOS's compactPortrait profile (StartupDesign.swift
     // `portraitIntroHeader`): 11pt eyebrow / 22pt title / 12pt body / 11pt helper.
@@ -1295,6 +1306,10 @@ private fun PortraitIntroHeader(
             fontSize = 11.sp,
             lineHeight = 15.sp,
         )
+        onShareDiagnostics?.let { share ->
+            Spacer(Modifier.height(8.dp))
+            PairingShareDiagnosticsLink(onClick = share)
+        }
     }
 }
 
@@ -1303,6 +1318,7 @@ private fun IntroCard(
     flow: PairingFlowState,
     condensed: Boolean = false,
     onShowSavedCameras: (() -> Unit)? = null,
+    onShareDiagnostics: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     // Vertical budget is tight in the ~360dp-tall landscape band — sizes are
@@ -1361,7 +1377,44 @@ private fun IntroCard(
                 modifier = Modifier.fillMaxWidth(),
             )
         }
+        onShareDiagnostics?.let { share ->
+            Spacer(Modifier.height(if (condensed) 6.dp else 8.dp))
+            PairingShareDiagnosticsLink(
+                onClick = share,
+                compact = condensed,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
     }
+}
+
+/**
+ * Quiet support handoff on the first-run intro. Same local report as Settings →
+ * Share Diagnostics — operator reviews and chooses where to send it.
+ */
+@Composable
+private fun PairingShareDiagnosticsLink(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    compact: Boolean = false,
+) {
+    val label = stringResource(R.string.pairing_share_diagnostics)
+    val description = stringResource(R.string.pairing_share_diagnostics_description)
+    Text(
+        text = label,
+        color = StartupColors.accent,
+        fontSize = if (compact) 11.sp else 12.sp,
+        fontWeight = FontWeight.SemiBold,
+        modifier =
+            modifier
+                .clip(RoundedCornerShape(8.dp))
+                .clickable(onClick = onClick)
+                .padding(vertical = 4.dp)
+                .clearAndSetSemantics {
+                    contentDescription = description
+                    role = Role.Button
+                },
+    )
 }
 
 // MARK: - Right column

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/SavedCamerasExperience.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/SavedCamerasExperience.kt
@@ -152,6 +152,7 @@ public fun SavedCamerasExperience(
     onReconnectRequestConsumed: () -> Unit = {},
     suppressedUsbAutoReconnectHosts: Set<String> = emptySet(),
     onUsbAutoReconnectSuppressionCleared: (String) -> Unit = {},
+    onShareDiagnostics: (() -> Unit)? = null,
 ) {
     val scope = rememberCoroutineScope()
     val work = remember { mutableStateOf<Job?>(null) }
@@ -811,6 +812,8 @@ public fun SavedCamerasExperience(
                 phase = popup,
                 onConnect = ::confirmCameraApJoin,
                 onDismiss = ::cancelWork,
+                onShareDiagnostics =
+                    onShareDiagnostics.takeIf { popup is ConnectionPopupPhase.Failed },
             )
         }
     }

--- a/Apps/Android/app/src/main/res/values/strings.xml
+++ b/Apps/Android/app/src/main/res/values/strings.xml
@@ -129,6 +129,9 @@
     <string name="pairing_intro_compact">Choose the connection path that fits the shoot.</string>
     <string name="pairing_intro_full">We\'ll walk you through it — your camera is connected in about a minute.</string>
     <string name="pairing_change_path_later">You can change this path later in Settings.</string>
+    <string name="pairing_share_diagnostics">Share diagnostics</string>
+    <string name="pairing_share_diagnostics_description">Share a local diagnostics report you can review and send for support</string>
+    <string name="conn_share_diagnostics">Share diagnostics</string>
     <string name="pairing_step_counter">STEP %1$d OF %2$d</string>
     <string name="pairing_connect_my_camera">Connect my camera</string>
     <string name="pairing_permission_required">Both are required to connect to your camera — grant them to continue.</string>

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,5 +1,5 @@
+- First-run and failed-connect screens offer Share diagnostics for support.
 - Fix immediate crash when connecting a camera over USB-C on release builds.
-- Internal phone and Wear beta builds update automatically when Android changes merge to main.
 - Playback and live desqueeze scale the picture (1.6× and custom fine steps).
 - Auto ISO On/Off for non-R3D formats; live working ISO while Auto is on; manual ISO in M mode.
 - R3D NE still uses Low/High base ISO and stays manual in every exposure mode.

--- a/ios/Runner/ConnectionProgressSheet.swift
+++ b/ios/Runner/ConnectionProgressSheet.swift
@@ -10,6 +10,10 @@ struct ConnectionProgressSheet: View {
     private let cardCornerRadius: CGFloat = 24
     private let cardMaxWidth: CGFloat = 360
 
+    @State private var isPreparingDiagnostics = false
+    @State private var diagnosticsShareItem: DiagnosticsShareItem?
+    @State private var diagnosticsErrorMessage: String?
+
     var body: some View {
         ZStack {
             backdrop
@@ -22,6 +26,20 @@ struct ConnectionProgressSheet: View {
         }
         .interactiveDismissDisabled(phase != .failed)
         .presentationBackground(.clear)
+        .sheet(item: $diagnosticsShareItem) { item in
+            DiagnosticsShareSheet(url: item.url)
+        }
+        .alert(
+            "Couldn’t Share Diagnostics",
+            isPresented: Binding(
+                get: { diagnosticsErrorMessage != nil },
+                set: { if !$0 { diagnosticsErrorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(diagnosticsErrorMessage ?? "Please try again.")
+        }
     }
 
     private var phase: CameraConnectionPhase {
@@ -130,6 +148,17 @@ struct ConnectionProgressSheet: View {
                     .foregroundStyle(.primary)
             }
             .font(.body)
+            Button {
+                prepareDiagnosticsReport()
+            } label: {
+                Text(isPreparingDiagnostics ? "Preparing…" : "Share diagnostics")
+                    .font(.body.weight(.semibold))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+            .disabled(isPreparingDiagnostics)
+            .accessibilityLabel("Share diagnostics")
             cancelButton
         default:
             HStack(spacing: 8) {
@@ -218,5 +247,19 @@ struct ConnectionProgressSheet: View {
             phase == .failed
                 ? "Dismisses this connection attempt"
                 : "Cancels connecting to this camera")
+    }
+
+    private func prepareDiagnosticsReport() {
+        guard !isPreparingDiagnostics else { return }
+        isPreparingDiagnostics = true
+        Task {
+            defer { isPreparingDiagnostics = false }
+            do {
+                diagnosticsShareItem = DiagnosticsShareItem(
+                    url: try await AppDiagnostics.shared.makeReport())
+            } catch {
+                diagnosticsErrorMessage = error.localizedDescription
+            }
+        }
     }
 }

--- a/ios/Runner/StartupDesign.swift
+++ b/ios/Runner/StartupDesign.swift
@@ -1436,6 +1436,9 @@ struct StartupFirstPairWizardView: View {
     // Owned here (not inside the step) so the shell's Continue can gate on it — the operator must
     // grant the required permissions before leaving the permissions step.
     @State private var permissions = StartupPermissionsCoordinator()
+    @State private var isPreparingDiagnostics = false
+    @State private var diagnosticsShareItem: DiagnosticsShareItem?
+    @State private var diagnosticsErrorMessage: String?
 
     private var style: WizardCompactStyle {
         WizardCompactStyle.make(profile: contentLayout.profile)
@@ -1483,6 +1486,20 @@ struct StartupFirstPairWizardView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .sheet(item: $diagnosticsShareItem) { item in
+            DiagnosticsShareSheet(url: item.url)
+        }
+        .alert(
+            "Couldn’t Share Diagnostics",
+            isPresented: Binding(
+                get: { diagnosticsErrorMessage != nil },
+                set: { if !$0 { diagnosticsErrorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(diagnosticsErrorMessage ?? "Please try again.")
+        }
     }
 
     // MARK: - Left column: goal + progress
@@ -1527,6 +1544,9 @@ struct StartupFirstPairWizardView: View {
                 yourCamerasButton
                     .padding(.top, 12)
             }
+
+            shareDiagnosticsButton
+                .padding(.top, 12)
         }
         .padding(20)
         .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -1551,6 +1571,36 @@ struct StartupFirstPairWizardView: View {
         }
         .buttonStyle(StartupWizardOutlineButtonStyle())
         .fixedSize()
+    }
+
+    /// Local diagnostics handoff for operators who cannot complete any connect path.
+    private var shareDiagnosticsButton: some View {
+        Button {
+            prepareDiagnosticsReport()
+        } label: {
+            Text(isPreparingDiagnostics ? "Preparing…" : "Share diagnostics")
+                .font(.system(size: 12, weight: .semibold, design: .rounded))
+                .foregroundStyle(StartupColors.accent)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .buttonStyle(.plain)
+        .disabled(isPreparingDiagnostics)
+        .accessibilityLabel("Share diagnostics")
+        .accessibilityHint("Creates a local report you can review and send for support")
+    }
+
+    private func prepareDiagnosticsReport() {
+        guard !isPreparingDiagnostics else { return }
+        isPreparingDiagnostics = true
+        Task {
+            defer { isPreparingDiagnostics = false }
+            do {
+                diagnosticsShareItem = DiagnosticsShareItem(
+                    url: try await AppDiagnostics.shared.makeReport())
+            } catch {
+                diagnosticsErrorMessage = error.localizedDescription
+            }
+        }
     }
 
     /// Compact intro for the stacked (portrait) wizard — keeps the walkthrough framing and the
@@ -1586,6 +1636,8 @@ struct StartupFirstPairWizardView: View {
                 .lineSpacing(2)
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(.top, 6)
+            shareDiagnosticsButton
+                .padding(.top, 8)
         }
     }
 

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,12 +1,13 @@
 What's changed
 
+- First-run pairing and the failed-connect card now offer Share diagnostics so you can send a local report if connection never completes.
 - Playback and live desqueeze scale the picture itself (not only guides), with a 1.6× chip and a custom 1.00–2.00× control in fine 0.01 steps.
 - On non-R3D formats (N-RAW, ProRes, H.264/H.265), ISO Auto On/Off controls movie ISO auto — not the P/A/S/M exposure dial. While Auto is on, the tile shows the live working ISO (e.g. A51200) and the value drum is locked.
 - Manual ISO / Auto Off is available only in exposure mode M on those formats. R3D NE still uses Low/High base circuits and stays manual in every exposure mode (including A).
 
 Please test
 
-- USB-C connect to a ZR and confirm the session reaches connected without an immediate crash, then open live view.
+- On first-run pairing, confirm Share diagnostics appears and opens a local report share sheet; try USB-C connect without an immediate crash.
+- Force a failed connect if you can; confirm Share diagnostics appears on the failure card.
 - Enable Desqueeze on playback and live; try 1.6× and the custom slider; confirm the image (not only overlays) changes.
 - On ProRes or H.265 in M: open ISO, switch Auto On/Off, confirm the tile tracks live Auto ISO, then set a manual ISO with no false error toast.
-- On R3D NE in A: confirm Low/High base still works and ISO is not blocked by a “needs M mode” message.


### PR DESCRIPTION
## Summary
- Add **Share diagnostics** on the first-run connection intro (landscape intro card + portrait header) so stuck pairing operators can export a local report without opening Settings.
- On **failed connect** popups (first-run and saved-camera reconnect), offer the same handoff as a primary action above Close.
- iOS parity: first-run wizard intro + failed `ConnectionProgressSheet`.
- Reuses the existing privacy-bounded local report (`AndroidAppDiagnostics` / `AppDiagnostics.makeReport`) — no automatic upload; the system share sheet lets the operator review and send.

## Test plan
- [x] `just android-test`
- [x] Play + TestFlight notes checks
- [ ] First-run pairing: tap **Share diagnostics** → share sheet with `OpenZCine-…Diagnostics…txt`
- [ ] Force a failed USB/Wi-Fi connect → **Share diagnostics** on the failure card
- [ ] Saved cameras failed reconnect → same action
- [ ] iOS first-run intro + failed connect sheet