### PR TITLE
fix(android): soft-fail Wi-Fi credential scan when ML Kit cannot start

### DIFF
--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/CameraWifiScanner.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/CameraWifiScanner.kt
@@ -455,6 +455,20 @@ private fun CameraWifiScannerFailurePanel(
     }
 }
 
+/**
+ * Opens the bundled Latin text recognizer, or null when ML Kit cannot initialize
+ * (missing model, broken native load). Callers must treat null as
+ * [CameraWifiScannerFailure.RECOGNIZER_UNAVAILABLE] — never crash the scanner UI.
+ */
+internal fun openCameraWifiTextRecognizer(): TextRecognizer? =
+    try {
+        TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+    } catch (_: Throwable) {
+        // ML Kit has been observed to throw NullPointerException inside getClient
+        // when the on-device stack is unavailable; also catch Error (e.g. UnsatisfiedLink).
+        null
+    }
+
 /** Binds a temporary rear-camera preview and releases it when the scanner leaves composition. */
 @Composable
 private fun CameraWifiCameraPreview(
@@ -466,7 +480,21 @@ private fun CameraWifiCameraPreview(
     val lifecycleOwner = LocalLifecycleOwner.current
     val mainExecutor = remember(context) { ContextCompat.getMainExecutor(context) }
     val analysisExecutor = remember { Executors.newSingleThreadExecutor() }
-    val recognizer = remember { TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS) }
+    val recognizer = remember { openCameraWifiTextRecognizer() }
+    val currentFailure by rememberUpdatedState(onFailure)
+
+    // Surface a soft failure once if the recognizer never opens — do not throw
+    // during composition (Play Vitals: NPE in TextRecognition.getClient).
+    LaunchedEffect(recognizer) {
+        if (recognizer == null) {
+            currentFailure(CameraWifiScannerFailure.RECOGNIZER_UNAVAILABLE)
+        }
+    }
+    if (recognizer == null) {
+        // Failure panel is owned by the overlay state machine via [onFailure].
+        return
+    }
+
     val previewView =
         remember(context) {
             PreviewView(context).apply {
@@ -476,7 +504,6 @@ private fun CameraWifiCameraPreview(
         }
     val viewfinderDescription = stringResource(R.string.wifi_scanner_viewfinder_description)
     val currentTranscript by rememberUpdatedState(onTranscript)
-    val currentFailure by rememberUpdatedState(onFailure)
 
     DisposableEffect(lifecycleOwner, previewView, recognizer, analysisExecutor) {
         var disposed = false

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/pairing/CameraWifiScannerControllerTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/pairing/CameraWifiScannerControllerTest.kt
@@ -74,4 +74,12 @@ class CameraWifiScannerControllerTest {
         assertFalse(shouldOpenCameraPermissionSettings(denialCount = 2, canRequestAgain = true))
         assertTrue(shouldOpenCameraPermissionSettings(denialCount = 2, canRequestAgain = false))
     }
+
+    @Test
+    fun `opening the text recognizer never throws into the scanner UI`() {
+        // On JVM unit tests ML Kit may return a client or fail soft (null). Either is fine —
+        // the production scanner must not crash when getClient throws NullPointerException.
+        val client = openCameraWifiTextRecognizer()
+        client?.close()
+    }
 }

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,5 +1,5 @@
-- Shared diagnostics now record closed connection phases and failure kinds (USB, Wi‑Fi join, PTP).
+- Camera Wi‑Fi credential scan no longer crashes when on-device text recognition fails to start.
+- Shared diagnostics record closed connection phases and failure kinds (USB, Wi‑Fi join, PTP).
 - First-run and failed-connect screens offer Share diagnostics for support.
 - Fix immediate crash when connecting a camera over USB-C on release builds.
-- Playback and live desqueeze scale the picture (1.6× and custom fine steps).
-- Auto ISO On/Off for non-R3D formats; live working ISO while Auto is on; manual ISO in M mode.
+- Playback and live desqueeze; Auto ISO On/Off for non-R3D formats.

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,13 +1,13 @@
 What's changed
 
-- Shared diagnostics now record closed connection phases and failure kinds (USB, Wi‑Fi join, PTP) without Wi‑Fi names or camera identities.
+- Camera Wi‑Fi credential scan fails softly when on-device text recognition cannot start (shows a recoverable error instead of quitting).
+- Shared diagnostics record closed connection phases and failure kinds without Wi‑Fi names or camera identities.
 - First-run pairing and the failed-connect card still offer Share diagnostics for a local report.
-- Playback and live desqueeze scale the picture itself (not only guides), with a 1.6× chip and a custom 1.00–2.00× control in fine 0.01 steps.
-- On non-R3D formats, ISO Auto On/Off and live Auto ISO work as before; R3D NE stays manual base ISO.
+- Playback desqueeze and Auto ISO behavior for non-R3D / R3D NE remain as before.
 
 Please test
 
-- Attempt a failed USB or Wi‑Fi connect, then Share diagnostics and confirm the report lists codes such as connection.path.usb and error.connection.usb.failed (no SSIDs or serials).
-- Successful connect should show connection.handshaking / connection.connected style events without free-form errors.
+- Open camera-AP pairing and the SSID scan view; if recognition cannot start, confirm a recoverable error (not an app crash), then Try again or leave the flow.
+- Attempt a failed USB or Wi‑Fi connect, Share diagnostics, and confirm closed codes without SSIDs or serials.
 - Enable Desqueeze on playback and live; try 1.6× and the custom slider.
 - On ProRes or H.265 in M: ISO Auto On/Off and manual ISO still behave correctly.


### PR DESCRIPTION
## Summary
Play Vitals stack from closed testing:

\`\`\`
NullPointerException
  at com.google.mlkit.vision.text…TextRecognition.getClient
  at CameraWifiScannerKt.CameraWifiCameraPreview (CameraWifiScanner.kt:469)
\`\`\`

This is the **known Wi‑Fi credential scanner crash** (separate from the USB \`NoSuchMethodError\` fixed in #244). \`getClient\` is no longer called unguarded during composition; failure maps to the existing **Recognizer unavailable** panel.

## Test plan
- [x] \`just android-test\`
- [x] Play + TestFlight notes checks
- [ ] Open camera-AP path → scan SSID screen; on devices without a working ML Kit stack, confirm recoverable error (not crash)
- [ ] On healthy devices, scan still fills SSID/key when pointed at the camera wizard