### PR TITLE
chore: start the 0.2.5 version train

### DIFF
--- a/Apps/Android/gradle.properties
+++ b/Apps/Android/gradle.properties
@@ -12,4 +12,4 @@ android.suppressUnsupportedCompileSdk=37
 # name here in a reviewed PR when starting a new version train.
 # See docs/android-distribution.md.
 openzcine.versionCode=1
-openzcine.versionName=0.1.0
+openzcine.versionName=0.2.5

--- a/ios/Config/Version.xcconfig
+++ b/ios/Config/Version.xcconfig
@@ -2,5 +2,5 @@
 //
 // Keep MARKETING_VERSION stable across TestFlight builds; bump it only for a new version train.
 // CI overwrites CURRENT_PROJECT_VERSION on each TestFlight upload (monotonic build numbers).
-MARKETING_VERSION = 0.2.0
+MARKETING_VERSION = 0.2.5
 CURRENT_PROJECT_VERSION = 9


### PR DESCRIPTION
Bumps both single sources of truth — `ios/Config/Version.xcconfig` and `Apps/Android/gradle.properties` — which had drifted apart at 0.2.0 and 0.1.0 despite the Android file documenting itself as mirroring the iOS one. They now agree.

Build numbers are untouched: CI overwrites `CURRENT_PROJECT_VERSION` per TestFlight upload and passes `-PversionCode=<n>` per Play build, so pinning either here would only fight the pipeline.

The changelog stays on `[Unreleased]`. Both files describe a name bump as STARTING a train rather than cutting a release, so the Keep a Changelog section gets its heading and date when a build actually ships.

Verified the toolchains resolve it rather than trusting the edit: `gradlew :app:properties` reports versionName 0.2.5 and `xcodebuild -showBuildSettings` reports MARKETING_VERSION 0.2.5 (no pbxproj override shadowing the xcconfig).

## What & why

<!-- What does this PR change, and why? Link any related issue. -->

## TestFlight notes

<!--
If this PR changes Sources/, Tests/, ios/, Package.swift, scripts/, or justfile, replace
ios/TestFlight/WhatToTest.en-US.txt with short copy for non-developer camera operators:
- 1-5 visible changes, written as outcomes rather than implementation details.
- 1-4 concrete actions under "Please test".
For an internal-only build, say that there are no tester-facing app changes and ask testers to
continue their normal camera workflow.
-->

## Google Play notes

<!--
If this PR changes the Android app/core or its build and release tooling, update
Apps/Android/distribution/whatsnew/whatsnew-en-US with 1-5 short, tester-facing bullets.
For internal-only work, say that there are no visible app changes and ask testers to continue
their normal camera workflow.
-->

## Checklist

- [x] `just check` passes.
- [x] Native production changes: `just native-check` passes, or the relevant platform check is noted.
- [x] Legacy prototype/reference changes are intentionally included or left local.
- [x] Commits follow Conventional Commits.
- [x] No proprietary assets (`vendor/`, `ref/`) are included.
- [x] Docs/CHANGELOG updated if behavior or setup changed.
- [x] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy.
- [x] Play-triggering changes include reviewed `Apps/Android/distribution/whatsnew/whatsnew-en-US` copy.
- [x] iOS release PRs: bump `MARKETING_VERSION` in `ios/Config/Version.xcconfig` when appropriate.
