### PR TITLE
Playback clean view, photo-mode de-squeeze, conform preview, and live-view magnification

### DIFF
--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/AssistToolbar.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/AssistToolbar.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalView
@@ -85,6 +86,8 @@ enum class AssistTool(val label: String, val settingsTitle: String) {
     /** Camera-fed exposure indicator (the body's own metering needle). */
     EV("EV", "EV Meter"),
     DESQ("DE-SQ", "Desqueeze"),
+    /** Live-view punch-in for checking critical focus. */
+    MAG("MAG", "Magnification"),
     /** Photography-only instant playback of the just-captured still. */
     PLAY("PLAY", "Instant Playback"),
     AUDIO("AUDIO", "Audio Levels"),
@@ -111,7 +114,7 @@ enum class AssistTool(val label: String, val settingsTitle: String) {
     val appliesToPhotography: Boolean
         get() =
             when (this) {
-                PEAK, FALSE, ZEBRA, HISTO, GRID, LEVEL, EV, PLAY, DESQ -> true
+                PEAK, FALSE, ZEBRA, HISTO, GRID, LEVEL, EV, PLAY, DESQ, MAG -> true
                 else -> false
             }
 
@@ -130,7 +133,7 @@ enum class AssistTool(val label: String, val settingsTitle: String) {
          * feed-effect state. EV rides with the framing group: its visibility is
          * a local presentation choice, while the value stays camera-fed.
          */
-        val framingTools: Set<AssistTool> = setOf(GUIDES, GRID, CROSS, LEVEL, EV, DESQ)
+        val framingTools: Set<AssistTool> = setOf(GUIDES, GRID, CROSS, LEVEL, EV, DESQ, MAG)
 
         /** Independently selectable scope panels subject to the portrait fit-mode cap. */
         val scopeTools: Set<AssistTool> = setOf(WAVE, PARADE, HISTO, VECTOR, LIGHTS)
@@ -235,6 +238,7 @@ internal fun AssistTool.labelResource(): Int =
         AssistTool.LEVEL -> R.string.assist_label_level
         AssistTool.EV -> R.string.assist_label_ev_meter
         AssistTool.DESQ -> R.string.assist_label_desqueeze
+        AssistTool.MAG -> R.string.assist_label_magnification
         AssistTool.PLAY -> R.string.assist_label_play
         AssistTool.AUDIO -> R.string.assist_label_audio
     }
@@ -257,6 +261,7 @@ internal fun AssistTool.titleResource(): Int =
         AssistTool.LEVEL -> R.string.assist_title_horizon
         AssistTool.EV -> R.string.assist_title_ev_meter
         AssistTool.DESQ -> R.string.assist_title_desqueeze
+        AssistTool.MAG -> R.string.assist_title_magnification
         AssistTool.PLAY -> R.string.assist_title_instant_playback
         AssistTool.AUDIO -> R.string.assist_title_audio_levels
     }
@@ -363,6 +368,7 @@ class AssistState(
             AssistTool.LEVEL,
             AssistTool.EV,
             AssistTool.DESQ,
+            AssistTool.MAG,
             -> false
         }
 
@@ -421,6 +427,7 @@ class AssistState(
             AssistTool.LEVEL,
             AssistTool.EV,
             AssistTool.DESQ,
+            AssistTool.MAG,
             -> false
         }
     }
@@ -1001,6 +1008,7 @@ private fun LocalFramingAssistConfiguration.isToolEnabled(tool: AssistTool): Boo
         AssistTool.LEVEL -> levelEnabled
         AssistTool.EV -> evMeterEnabled
         AssistTool.DESQ -> desqueezeEnabled
+        AssistTool.MAG -> magnificationEnabled
         else -> false
     }
 
@@ -1322,6 +1330,8 @@ internal fun AssistToolGlyph(tool: AssistTool, tint: Color, modifier: Modifier =
                 drawLine(tint, Offset(size.width - inset, y), Offset(size.width - inset - head, y - head), 1.7.dp.toPx(), StrokeCap.Round)
                 drawLine(tint, Offset(size.width - inset, y), Offset(size.width - inset - head, y + head), 1.7.dp.toPx(), StrokeCap.Round)
             }
+            // SF `plus.magnifyingglass`: loupe with a plus in the lens.
+            AssistTool.MAG -> drawMagnifyingGlass(tint, plus = true)
             // SF `photo.badge.checkmark`: photo frame with a check tick.
             AssistTool.PLAY -> {
                 val stroke2 = Stroke(1.6.dp.toPx(), cap = StrokeCap.Round, join = StrokeJoin.Round)
@@ -1362,6 +1372,51 @@ internal fun AssistToolGlyph(tool: AssistTool, tint: Color, modifier: Modifier =
             }
         }
     }
+}
+
+/**
+ * Canvas stand-in for SF `plus.magnifyingglass` / `minus.magnifyingglass`.
+ *
+ * Shared by the assist-toolbar chip and the on-feed punch-in key so the two read as the same
+ * instrument — the key is the tool, moved to where focus is being judged.
+ */
+internal fun DrawScope.drawMagnifyingGlass(tint: Color, plus: Boolean) {
+    val stroke = 1.7.dp.toPx()
+    val radius = size.minDimension * 0.30f
+    val centre = Offset(size.width * 0.42f, size.height * 0.42f)
+    drawCircle(tint, radius, centre, style = Stroke(stroke))
+    val arm = radius * 0.48f
+    drawLine(
+        tint,
+        Offset(centre.x - arm, centre.y),
+        Offset(centre.x + arm, centre.y),
+        stroke,
+        StrokeCap.Round,
+    )
+    if (plus) {
+        drawLine(
+            tint,
+            Offset(centre.x, centre.y - arm),
+            Offset(centre.x, centre.y + arm),
+            stroke,
+            StrokeCap.Round,
+        )
+    }
+    // Handle, on the loupe's own diagonal so it reads as one instrument.
+    val diagonal = radius * 0.7071f
+    drawLine(
+        tint,
+        Offset(centre.x + diagonal, centre.y + diagonal),
+        Offset(size.width * 0.92f, size.height * 0.92f),
+        stroke,
+        StrokeCap.Round,
+    )
+}
+
+/** The on-feed punch-in key's icon: plus to enter, minus to leave. */
+@Composable
+internal fun MagnifyKeyGlyph(tint: Color, active: Boolean, modifier: Modifier = Modifier) {
+    Canvas(modifier) { drawMagnifyingGlass(tint, plus = !active) }
 }
 
 /** Canvas stand-in for SF `slider.horizontal.3` (the fill-rail collapsed pill). */

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/AssistToolbar.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/AssistToolbar.kt
@@ -102,11 +102,16 @@ enum class AssistTool(val label: String, val settingsTitle: String) {
      * the exposure aids plus the composition aids photographers actually use.
      * Everything else is cinema-only, keeping the photo toolbar deliberately
      * shorter so the stills strip gets the bar width.
+     *
+     * DESQ is here because anamorphic lenses are used for stills too, and a
+     * squeezed preview makes faces, framing and edge behaviour impossible to
+     * judge on a tethered shoot. It is a display transform everywhere it
+     * reaches — the camera original is never touched.
      */
     val appliesToPhotography: Boolean
         get() =
             when (this) {
-                PEAK, FALSE, ZEBRA, HISTO, GRID, LEVEL, EV, PLAY -> true
+                PEAK, FALSE, ZEBRA, HISTO, GRID, LEVEL, EV, PLAY, DESQ -> true
                 else -> false
             }
 

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/InstantReview.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/InstantReview.kt
@@ -17,7 +17,9 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.ui.layout.ContentScale
+import com.opencapture.openzcine.settings.LocalFramingAssistConfiguration
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -211,6 +213,8 @@ internal fun InstantReviewOverlay(
     onDismiss: () -> Unit,
     onToggleStar: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
+    /** De-squeeze configuration; the ratio is derived here, where the still's size is known. */
+    desqueeze: LocalFramingAssistConfiguration? = null,
 ) {
     // The countdown starts only once the full image (or its failure fallback)
     // lands — the operator gets the whole duration with the real image.
@@ -220,6 +224,8 @@ internal fun InstantReviewOverlay(
             onDismiss()
         }
     }
+    val desqueezeAspectRatio =
+        desqueeze?.desqueezedAspectRatio(review.image.width, review.image.height)
     Box(
         modifier
             .fillMaxSize()
@@ -231,9 +237,18 @@ internal fun InstantReviewOverlay(
         Image(
             bitmap = review.image,
             contentDescription = null,
-            contentScale = ContentScale.Fit,
+            // With a ratio the parent Box's max constraints make `aspectRatio` the fit, and
+            // FillBounds stretches the squeezed pixels into it; without one nothing changes.
+            contentScale =
+                if (desqueezeAspectRatio != null) ContentScale.FillBounds else ContentScale.Fit,
             modifier =
-                Modifier.fillMaxSize().blur(if (review.isFullResolution) 0.dp else 16.dp),
+                (
+                    if (desqueezeAspectRatio != null) {
+                        Modifier.aspectRatio(desqueezeAspectRatio)
+                    } else {
+                        Modifier.fillMaxSize()
+                    }
+                ).blur(if (review.isFullResolution) 0.dp else 16.dp),
         )
         if (!review.isFullResolution) {
             CircularProgressIndicator(

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorAnalysisPanelPlacement.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorAnalysisPanelPlacement.kt
@@ -122,6 +122,39 @@ internal fun splitComparisonKeyFrame(
 }
 
 /**
+ * The punch-in key's slot: the focus-reset lane mirrored to the OTHER side of the feed.
+ *
+ * Sharing the lane's vertical position keeps the on-feed keys on one line, and taking the opposite
+ * horizontal edge clears the recenter/50-50 stack entirely — so the magnify key never lifts or
+ * shifts as those two come and go, which matters for a control the operator reaches for by muscle
+ * memory while watching focus rather than the button.
+ */
+internal fun magnificationKeyFrame(
+    feed: ZoneFrame,
+    isPortrait: Boolean,
+    bottomChromeInset: Float,
+): ZoneFrame {
+    val lane = focusResetButtonBaseFrame(feed, isPortrait, bottomChromeInset)
+    // focusResetButtonBaseFrame hugs the trailing edge in portrait and the leading edge in
+    // landscape, so the mirror is the opposite edge in each.
+    val x =
+        if (isPortrait) {
+            feed.x + FOCUS_RESET_PANEL_GAP_DP
+        } else {
+            feed.x + feed.width - FOCUS_RESET_PANEL_GAP_DP - FOCUS_RESET_BUTTON_SIZE_DP
+        }
+    return clampScopeFrame(
+        ZoneFrame(
+            x = x,
+            y = lane.y,
+            width = FOCUS_RESET_BUTTON_SIZE_DP,
+            height = FOCUS_RESET_BUTTON_SIZE_DP,
+        ),
+        feed,
+    )
+}
+
+/**
  * Lifts the focus-reset affordance above overlapping movable analysis panels.
  *
  * Panels are considered from lowest to highest so a crowded stack is climbed one panel at a time.

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorPreviewPolicy.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorPreviewPolicy.kt
@@ -137,6 +137,7 @@ internal fun renderedFramingAssists(
         levelEnabled = configuration.levelEnabled && keeps(AssistTool.LEVEL),
         evMeterEnabled = configuration.evMeterEnabled && keeps(AssistTool.EV),
         desqueezeEnabled = configuration.desqueezeEnabled && keeps(AssistTool.DESQ),
+        magnificationEnabled = configuration.magnificationEnabled && keeps(AssistTool.MAG),
     )
 }
 

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorPreviewPolicy.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorPreviewPolicy.kt
@@ -124,7 +124,7 @@ internal fun renderedFramingAssists(
     pinnedToCleanView: Set<AssistTool>,
     photography: Boolean,
 ): LocalFramingAssistConfiguration {
-    // Photography drops the cinema-only aids (guides, crosshair, desqueeze) even in LIVE, so the
+    // Photography drops the cinema-only aids (guides, crosshair) even in LIVE, so the
     // early return has to be conditional on it — otherwise they ride into the photo feed.
     if (mode == MonitorDisplayMode.LIVE && !photography) return configuration
     fun keeps(tool: AssistTool) =

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
@@ -1704,6 +1704,18 @@ internal fun MonitorScreen(
         LaunchedEffect(operatorSettings.splitComparisonEnabled.value) {
             if (operatorSettings.splitComparisonEnabled.value) splitComparisonMuted = false
         }
+        // The punch-in is session-only for the same reason: it is a focus check, not a setting, and
+        // a monitor that reopens already magnified is a monitor that lies about the framing.
+        var magnificationActive by remember { mutableStateOf(false) }
+        // Switching the tool off clears the punch-in. Leaving it armed behind a disabled tool is
+        // how the key and the transform desynchronise — a magnified feed with no visible control
+        // that explains it (shared core `Magnification.activeAfterDisabling`).
+        LaunchedEffect(operatorSettings.magnificationEnabled.value) {
+            if (!operatorSettings.magnificationEnabled.value) magnificationActive = false
+        }
+        // Read off `renderedFraming`, so a DISP mode that suppresses the tool drops the punch-in
+        // with it — the same rule that takes the key away.
+        val punchIn = renderedFraming.magnificationScale(magnificationActive)
         val renderedEffects =
             renderedFeedEffects(
                 assist.effects.copy(
@@ -2077,9 +2089,13 @@ internal fun MonitorScreen(
                 } else if (monitorFrameSource != null) {
                     LiveFeedView(
                         monitorFrameSource,
+                        // Punch-in multiplies into the de-squeeze scales rather than sitting in its
+                        // own layer, which is exactly the composition iOS gets from stacking the two
+                        // `scaleEffect`s: shape settles first, then the settled result is scaled
+                        // about its centre. The parent Box already clips.
                         Modifier.fillMaxSize().graphicsLayer {
-                            scaleX = localFraming.horizontalPresentationScale
-                            scaleY = localFraming.verticalPresentationScale
+                            scaleX = localFraming.horizontalPresentationScale * punchIn
+                            scaleY = localFraming.verticalPresentationScale * punchIn
                         },
                         onPresentedFrame = { frame, bitmap, baker ->
                             // TC is owned by the stream collector above; present
@@ -2126,8 +2142,10 @@ internal fun MonitorScreen(
                     FeedTextureOverlay(
                         presentationState = liveFeedPresentation,
                         aspectFill = isPortraitFill,
-                        horizontalPresentationScale = localFraming.horizontalPresentationScale,
-                        verticalPresentationScale = localFraming.verticalPresentationScale,
+                        horizontalPresentationScale =
+                            localFraming.horizontalPresentationScale * punchIn,
+                        verticalPresentationScale =
+                            localFraming.verticalPresentationScale * punchIn,
                     )
                 } else {
                     // Hop-aware status: after RED/Frame.io internet hop the session is
@@ -2910,6 +2928,47 @@ internal fun MonitorScreen(
                     text = "50/50",
                     style = chromeStyle(11f, FontWeight.Bold),
                     color = if (splitComparisonMuted) LiveDesign.muted else LiveDesign.accent,
+                )
+            }
+        }
+        // Punch-in quick key, opposite the recenter/50-50 lane so it never lifts or shifts as those
+        // two come and go. One tap in, one tap out — reopening a popup to leave a magnified view
+        // would defeat the point of a focus check. The accent state is read off the same flag that
+        // drives the transform, so the two cannot disagree.
+        if (renderedFraming.magnificationEnabled && !locked && chromeEditorMode == null) {
+            val bottomChromeInset = with(density) { levelGaugeBottomChromeInset.toDp().value }
+            val factorLabel = operatorSettings.magnificationFactor.label
+            val magnifyDescription =
+                stringResource(
+                    if (magnificationActive) R.string.magnification_key_exit
+                    else R.string.magnification_key_enter,
+                    factorLabel,
+                )
+            Box(
+                Modifier
+                    .zone(
+                        magnificationKeyFrame(
+                            feed = effectiveFeed,
+                            isPortrait = isPortrait,
+                            bottomChromeInset = bottomChromeInset,
+                        ),
+                    )
+                    .background(Color.Black.copy(alpha = 0.55f), CircleShape)
+                    .border(
+                        1.dp,
+                        if (magnificationActive) LiveDesign.accent else LiveDesign.hairline,
+                        CircleShape,
+                    )
+                    .chromeClickable { magnificationActive = !magnificationActive }
+                    .testTag("magnification_key")
+                    .semantics { contentDescription = magnifyDescription },
+                contentAlignment = Alignment.Center,
+            ) {
+                // iOS `plus.magnifyingglass` / `minus.magnifyingglass` in a 40pt black circle.
+                MagnifyKeyGlyph(
+                    tint = if (magnificationActive) LiveDesign.accent else LiveDesign.text,
+                    active = magnificationActive,
+                    modifier = Modifier.size(20.dp),
                 )
             }
         }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
@@ -3015,6 +3015,7 @@ internal fun MonitorScreen(
                 review = review,
                 onDismiss = instantReview::dismiss,
                 onToggleStar = { starred -> instantReview.setStarred(recordScope, starred) },
+                desqueeze = operatorSettings.localFramingAssistConfiguration,
             )
         }
 

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaBrowseScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaBrowseScreen.kt
@@ -1659,6 +1659,7 @@ internal fun MediaBrowseScreen(
                 val owner = ownerCameraID(clip)
                 MediaStillViewer(
                     clip = clip,
+                    desqueeze = operatorSettings.localFramingAssistConfiguration,
                     cameraID = owner,
                     cameraTransferAvailable = cameraConnected,
                     rawSibling = rawSibling(loadedClips, clip, ::ownerCameraID),
@@ -1747,6 +1748,7 @@ internal fun MediaBrowseScreen(
             val owner = ownerCameraID(clip)
             MediaStillViewer(
                 clip = clip,
+                desqueeze = operatorSettings.localFramingAssistConfiguration,
                 cameraID = owner,
                 cameraTransferAvailable = cameraConnected,
                 rawSibling = rawSibling(loadedClips, clip, ::ownerCameraID),

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Replay
 import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.SlowMotionVideo
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.StarBorder
 import androidx.compose.material.icons.filled.VolumeOff
@@ -812,6 +813,11 @@ private fun ProgressivePlayer(
     var pan by remember(entry) { mutableStateOf(PlaybackPan()) }
     var viewport by remember(entry) { mutableStateOf(IntSize.Zero) }
     var videoSize by remember(entry) { mutableStateOf(VideoSize.UNKNOWN) }
+    // Conform preview: what the track says it was shot at, and the target the operator picked.
+    // Real time (null) is always the default — this is a preview transform, never the clip.
+    var conformCaptureRate by remember(entry) { mutableStateOf<Float?>(null) }
+    var conformVariableRate by remember(entry) { mutableStateOf(false) }
+    var conformTarget by remember(entry) { mutableStateOf<Double?>(null) }
     var videoColorMode by
         remember(entry, player) {
             mutableStateOf(selectedPlaybackVideoColorMode(player.currentTracks))
@@ -861,6 +867,21 @@ private fun ProgressivePlayer(
     fun restoreChrome() {
         cleanViewHintShownAt = 0L
         onChromeVisibleChanged(true)
+    }
+
+    val conformAvailability =
+        conformPreviewAvailability(conformCaptureRate?.toDouble(), conformVariableRate)
+    val conformSpeed =
+        conformPreviewSpeed(conformCaptureRate?.toDouble(), conformTarget)
+
+    // The conform is a clock change, so it rides on the player's speed rather than on the media.
+    LaunchedEffect(conformSpeed) {
+        player.setPlaybackSpeed(conformSpeed.toFloat())
+    }
+    // Audio at 40% without pitch correction still SOUNDS like audio, just wrong — the request
+    // rules that out, so a conform forces silence regardless of the mute toggle.
+    LaunchedEffect(conformTarget, audioMode) {
+        player.volume = if (conformTarget != null) 0f else audioMode.volume
     }
 
     fun togglePlayback(showFlash: Boolean = false) {
@@ -974,6 +995,12 @@ private fun ProgressivePlayer(
 
                 override fun onTracksChanged(tracks: Tracks) {
                     videoColorMode = selectedPlaybackVideoColorMode(tracks)
+                    // The container's nominal rate is all a proxy MP4 carries. `NO_VALUE` means
+                    // the demuxer never established one, which the policy treats as unknown and
+                    // refuses — better than conforming against a guess.
+                    val rate = selectedPlaybackVideoFrameRate(tracks)
+                    conformCaptureRate = rate
+                    if (rate == null) conformTarget = null
                 }
 
                 override fun onPlayerError(error: PlaybackException) {
@@ -1586,6 +1613,22 @@ private fun ProgressivePlayer(
                             onClick = {
                                 audioMode = audioMode.toggled()
                                 player.volume = audioMode.volume
+                            },
+                        )
+                        // Conform preview cycles Real time -> each offered target -> Real time.
+                        // A cycle rather than a menu because the list is short and ordered, and
+                        // the current state is spelled out in full on the transport above.
+                        PlaybackIconButton(
+                            icon = Icons.Filled.SlowMotionVideo,
+                            contentDescription =
+                                conformAvailability.unavailableReason
+                                    ?: "Conform preview",
+                            enabled = conformAvailability.isAvailable,
+                            highlighted = conformTarget != null,
+                            action = true,
+                            onClick = {
+                                conformTarget =
+                                    nextConformTarget(conformTarget, conformAvailability.targets)
                             },
                         )
                         // The swipe-down gesture has always hidden the chrome, but an

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Replay
@@ -803,6 +804,8 @@ private fun ProgressivePlayer(
     var reachedEnd by remember(entry) { mutableStateOf(false) }
     var scrubPosition by remember(entry) { mutableFloatStateOf(0f) }
     var scrubbing by remember(entry) { mutableStateOf(false) }
+    // When the clean-view hint was raised; 0 once it has been dismissed or expired.
+    var cleanViewHintShownAt by remember(entry) { mutableLongStateOf(0L) }
     var wasPlayingBeforeScrub by remember(entry) { mutableStateOf(false) }
     var lastPreviewSeekAt by remember(entry) { mutableLongStateOf(0L) }
     var zoom by remember(entry) { mutableFloatStateOf(1f) }
@@ -836,6 +839,28 @@ private fun ProgressivePlayer(
     fun resetZoom() {
         zoom = 1f
         pan = PlaybackPan()
+    }
+
+    /**
+     * Hides the chrome and says how to get it back. The hint is shown every time the BUTTON is
+     * used rather than once ever: it costs nothing to re-read, it is self-limiting (only the
+     * button raises it, and only the operator who wanted clean view presses that), and a
+     * once-ever tutorial is forgotten long before the one time it is needed.
+     */
+    LaunchedEffect(cleanViewHintShownAt) {
+        if (cleanViewHintShownAt == 0L) return@LaunchedEffect
+        delay(PLAYBACK_CLEAN_VIEW_HINT_MILLIS)
+        cleanViewHintShownAt = 0L
+    }
+
+    fun enterCleanView() {
+        onChromeVisibleChanged(false)
+        cleanViewHintShownAt = SystemClock.elapsedRealtime()
+    }
+
+    fun restoreChrome() {
+        cleanViewHintShownAt = 0L
+        onChromeVisibleChanged(true)
     }
 
     fun togglePlayback(showFlash: Boolean = false) {
@@ -1251,11 +1276,32 @@ private fun ProgressivePlayer(
                 .transformable(transformState)
                 .pointerInput(zoom, scrubbing, reachedEnd) {
                     detectTapGestures(
-                        onTap = { if (!scrubbing) togglePlayback(showFlash = true) },
+                        onTap = {
+                            if (scrubbing) return@detectTapGestures
+                            when (playbackFrameTapAction(chromeVisible, reachedEnd)) {
+                                PlaybackFrameTap.RESTORE_CHROME -> restoreChrome()
+                                else -> togglePlayback(showFlash = true)
+                            }
+                        },
                         onDoubleTap = { resetZoom() },
                     )
                 },
         )
+        if (!chromeVisible && cleanViewHintShownAt != 0L) {
+            Text(
+                "Tap to show controls",
+                modifier =
+                    Modifier.align(Alignment.BottomCenter)
+                        .windowInsetsPadding(
+                            WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom),
+                        )
+                        .padding(bottom = 24.dp)
+                        .glass(CircleShape)
+                        .padding(horizontal = 12.dp, vertical = 7.dp),
+                style = chromeStyle(12f, FontWeight.Medium),
+                color = LiveDesign.text,
+            )
+        }
         if (framingAssistsVisible) {
             LocalFramingAssistOverlay(
                 configuration = playbackFramingConfiguration,
@@ -1541,6 +1587,16 @@ private fun ProgressivePlayer(
                                 audioMode = audioMode.toggled()
                                 player.volume = audioMode.volume
                             },
+                        )
+                        // The swipe-down gesture has always hidden the chrome, but an
+                        // undisclosed gesture is indistinguishable from a missing feature — so
+                        // the capability gets a control you can see. The gesture stays for
+                        // operators who already know it.
+                        PlaybackIconButton(
+                            icon = Icons.Filled.Fullscreen,
+                            contentDescription = "Hide playback controls",
+                            action = true,
+                            onClick = { enterCleanView() },
                         )
                         PlaybackIconButton(
                             icon = Icons.Outlined.CenterFocusWeak,

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.rememberTransformableState
 import androidx.compose.foundation.gestures.transformable
@@ -1453,8 +1452,8 @@ private fun ProgressivePlayer(
             // to sit above the transport, costing a permanent band of picture for a control only
             // wanted while actually rating. The handle is not decoration: a pull-down nobody knows
             // about is the mistake the clean-view button exists to correct, so the shade always
-            // shows where to grab it — and the handle is a tap target too, since a tap is easier
-            // than a drag on a moving picture.
+            // shows where to reach it. Tap only: pulling a shade down over a moving picture is
+            // fussy on a handheld rig, and the scrub is the gesture that has to stay reliable.
             // Nothing at all without a camera-read rating: null means the clip has no handle or
             // there is no session, so the rating could not be written either and the handle would
             // advertise a control that cannot work (iOS `ratingShade`).
@@ -1467,12 +1466,7 @@ private fun ProgressivePlayer(
                         ),
                     )
                     .padding(top = 54.dp)
-                    .fillMaxWidth()
-                    .pointerInput(ratingShadeOpen) {
-                        detectVerticalDragGestures { _, delta ->
-                            ratingShadePull(delta)?.let(onRatingShadeOpenChanged)
-                        }
-                    },
+                    .fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 if (ratingShadeOpen) {
@@ -1490,13 +1484,6 @@ private fun ProgressivePlayer(
                         .glass(CircleShape)
                         .alpha(0.9f)
                         .chromeClickable(onClick = { onRatingShadeOpenChanged(!ratingShadeOpen) })
-                        // The handle owns the pull as well as the tap. Without this the clickable
-                        // consumes the pointer and the handle can only ever be tapped.
-                        .pointerInput(ratingShadeOpen) {
-                            detectVerticalDragGestures { _, delta ->
-                                ratingShadePull(delta)?.let(onRatingShadeOpenChanged)
-                            }
-                        }
                         .semantics {
                             contentDescription =
                                 if (ratingShadeOpen) "Hide star rating" else "Show star rating"

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.rememberTransformableState
 import androidx.compose.foundation.gestures.transformable
@@ -39,6 +40,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.material.icons.filled.FullscreenExit
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Replay
@@ -168,10 +171,16 @@ import kotlinx.coroutines.withContext
 private const val PLAYBACK_ZOOM_MAX = 4f
 
 /** iOS `PlaybackChrome` — compact transport metrics. */
+/**
+ * Sized so the full transport row fits the narrowest supported width, matching iOS
+ * `MediaClipPlayerView.PlaybackChrome`. The row grew to eight controls when the conform preview
+ * landed; on iOS that overflow dragged the top bar off screen, and the same arithmetic applies
+ * here. Visual size only — the buttons keep their 44dp minimum touch target.
+ */
 private object PlaybackChrome {
-    val transportButtonWidth = 40.dp
+    val transportButtonWidth = 38.dp
     val transportButtonHeight = 36.dp
-    val actionButtonWidth = 38.dp
+    val actionButtonWidth = 32.dp
     val actionButtonHeight = 36.dp
     val transportIconSize = 18.dp
     val primaryTransportIconSize = 22.dp
@@ -330,6 +339,9 @@ private fun PlaybackClipSession(
     val latestDeliveryJob = rememberUpdatedState(deliveryJob)
     val actionInProgress = pendingAction != null
     var chromeVisible by remember(clip.handle) { mutableStateOf(true) }
+    // Pulled down to rate, and left open across clips until pushed back up — so NOT keyed to the
+    // clip, unlike the rating value itself (iOS `ratingShadeOpen`).
+    var ratingShadeOpen by remember { mutableStateOf(false) }
     // Camera-read star rating (null until read, or unreachable — row hidden).
     // Seeded by read, confirmed by the entry point's built-in readback: the
     // camera stays source of truth for every write.
@@ -579,6 +591,8 @@ private fun PlaybackClipSession(
                     lutLibrary = lutLibrary,
                     chromeVisible = chromeVisible,
                     onChromeVisibleChanged = { chromeVisible = it },
+                    ratingShadeOpen = ratingShadeOpen,
+                    onRatingShadeOpenChanged = { ratingShadeOpen = it },
                     onPlayerChanged = { activePlayer = it },
                     shareReady = shareState == PlaybackShareState.READY,
                     deliveryInProgress = deliveryInProgress,
@@ -729,6 +743,9 @@ private fun ProgressivePlayer(
     lutLibrary: AndroidLutLibrary?,
     chromeVisible: Boolean,
     onChromeVisibleChanged: (Boolean) -> Unit,
+    /** Owned by the parent so it survives clip changes, like the operator left it. */
+    ratingShadeOpen: Boolean,
+    onRatingShadeOpenChanged: (Boolean) -> Unit,
     onPlayerChanged: (Player?) -> Unit,
     shareReady: Boolean = false,
     deliveryInProgress: Boolean = false,
@@ -1429,6 +1446,63 @@ private fun ProgressivePlayer(
         }
 
         if (chromeVisible) {
+            // Star rating, pulled down from the top and left there until pushed back up. It used
+            // to sit above the transport, costing a permanent band of picture for a control only
+            // wanted while actually rating. The handle is not decoration: a pull-down nobody knows
+            // about is the mistake the clean-view button exists to correct, so the shade always
+            // shows where to grab it — and the handle is a tap target too, since a tap is easier
+            // than a drag on a moving picture.
+            Column(
+                Modifier.align(Alignment.TopCenter)
+                    .windowInsetsPadding(
+                        WindowInsets.safeDrawing.only(
+                            WindowInsetsSides.Horizontal + WindowInsetsSides.Top,
+                        ),
+                    )
+                    .padding(top = 62.dp)
+                    .fillMaxWidth()
+                    .pointerInput(ratingShadeOpen) {
+                        detectVerticalDragGestures { _, delta ->
+                            ratingShadePull(delta)?.let(onRatingShadeOpenChanged)
+                        }
+                    },
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                if (ratingShadeOpen && ratingStars != null) {
+                    StarRatingRow(
+                        stars = ratingStars,
+                        modifier =
+                            Modifier.padding(bottom = 6.dp)
+                                .glass(CircleShape)
+                                .padding(horizontal = 14.dp, vertical = 8.dp),
+                        onSelect = onSelectRating,
+                    )
+                }
+                Box(
+                    Modifier.size(width = 44.dp, height = 20.dp)
+                        .glass(CircleShape)
+                        .alpha(0.9f)
+                        .chromeClickable(onClick = { onRatingShadeOpenChanged(!ratingShadeOpen) })
+                        .semantics {
+                            contentDescription =
+                                if (ratingShadeOpen) "Hide star rating" else "Show star rating"
+                        },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(
+                        imageVector =
+                            if (ratingShadeOpen) {
+                                Icons.Filled.KeyboardArrowUp
+                            } else {
+                                Icons.Filled.KeyboardArrowDown
+                            },
+                        contentDescription = null,
+                        tint = LiveDesign.muted,
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+            }
+
             Column(
                 Modifier.align(Alignment.BottomCenter)
                     .fillMaxWidth()
@@ -1450,13 +1524,6 @@ private fun ProgressivePlayer(
                             Modifier.padding(bottom = 6.dp, start = 16.dp, end = 16.dp)
                                 .glass(RoundedCornerShape(LiveDesign.CORNER_RADIUS_DP.dp))
                                 .padding(horizontal = 14.dp, vertical = 8.dp),
-                    )
-                }
-                if (ratingStars != null) {
-                    StarRatingRow(
-                        stars = ratingStars,
-                        modifier = Modifier.padding(bottom = 2.dp),
-                        onSelect = onSelectRating,
                     )
                 }
                 Column(

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
@@ -750,7 +750,10 @@ private fun ProgressivePlayer(
     shareReady: Boolean = false,
     deliveryInProgress: Boolean = false,
     onShare: () -> Unit = {},
-    /** Camera-read clip star rating; null hides the row (offline/unreadable). */
+    /**
+     * Camera-read clip star rating; null means offline or unreadable. The shade shows zero stars
+     * in that case rather than nothing — an opened shade that renders empty reads as broken.
+     */
     ratingStars: Int? = null,
     /** Transient rating-write refusal line (with the body's response code); null hides it. */
     ratingMessage: String? = null,
@@ -1459,7 +1462,7 @@ private fun ProgressivePlayer(
                             WindowInsetsSides.Horizontal + WindowInsetsSides.Top,
                         ),
                     )
-                    .padding(top = 62.dp)
+                    .padding(top = 54.dp)
                     .fillMaxWidth()
                     .pointerInput(ratingShadeOpen) {
                         detectVerticalDragGestures { _, delta ->
@@ -1468,9 +1471,9 @@ private fun ProgressivePlayer(
                     },
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                if (ratingShadeOpen && ratingStars != null) {
+                if (ratingShadeOpen) {
                     StarRatingRow(
-                        stars = ratingStars,
+                        stars = ratingStars ?: 0,
                         modifier =
                             Modifier.padding(bottom = 6.dp)
                                 .glass(CircleShape)
@@ -1478,8 +1481,8 @@ private fun ProgressivePlayer(
                         onSelect = onSelectRating,
                     )
                 }
-                Box(
-                    Modifier.size(width = 44.dp, height = 20.dp)
+                Row(
+                    Modifier.size(width = 52.dp, height = 20.dp)
                         .glass(CircleShape)
                         .alpha(0.9f)
                         .chromeClickable(onClick = { onRatingShadeOpenChanged(!ratingShadeOpen) })
@@ -1487,8 +1490,15 @@ private fun ProgressivePlayer(
                             contentDescription =
                                 if (ratingShadeOpen) "Hide star rating" else "Show star rating"
                         },
-                    contentAlignment = Alignment.Center,
+                    horizontalArrangement = Arrangement.spacedBy(3.dp, Alignment.CenterHorizontally),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
+                    Icon(
+                        imageVector = Icons.Filled.Star,
+                        contentDescription = null,
+                        tint = LiveDesign.muted,
+                        modifier = Modifier.size(11.dp),
+                    )
                     Icon(
                         imageVector =
                             if (ratingShadeOpen) {
@@ -1498,7 +1508,7 @@ private fun ProgressivePlayer(
                             },
                         contentDescription = null,
                         tint = LiveDesign.muted,
-                        modifier = Modifier.size(16.dp),
+                        modifier = Modifier.size(13.dp),
                     )
                 }
             }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Fullscreen
+import androidx.compose.material.icons.filled.FullscreenExit
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Replay
@@ -68,6 +69,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
@@ -805,8 +807,6 @@ private fun ProgressivePlayer(
     var reachedEnd by remember(entry) { mutableStateOf(false) }
     var scrubPosition by remember(entry) { mutableFloatStateOf(0f) }
     var scrubbing by remember(entry) { mutableStateOf(false) }
-    // When the clean-view hint was raised; 0 once it has been dismissed or expired.
-    var cleanViewHintShownAt by remember(entry) { mutableLongStateOf(0L) }
     var wasPlayingBeforeScrub by remember(entry) { mutableStateOf(false) }
     var lastPreviewSeekAt by remember(entry) { mutableLongStateOf(0L) }
     var zoom by remember(entry) { mutableFloatStateOf(1f) }
@@ -847,25 +847,11 @@ private fun ProgressivePlayer(
         pan = PlaybackPan()
     }
 
-    /**
-     * Hides the chrome and says how to get it back. The hint is shown every time the BUTTON is
-     * used rather than once ever: it costs nothing to re-read, it is self-limiting (only the
-     * button raises it, and only the operator who wanted clean view presses that), and a
-     * once-ever tutorial is forgotten long before the one time it is needed.
-     */
-    LaunchedEffect(cleanViewHintShownAt) {
-        if (cleanViewHintShownAt == 0L) return@LaunchedEffect
-        delay(PLAYBACK_CLEAN_VIEW_HINT_MILLIS)
-        cleanViewHintShownAt = 0L
-    }
-
     fun enterCleanView() {
         onChromeVisibleChanged(false)
-        cleanViewHintShownAt = SystemClock.elapsedRealtime()
     }
 
     fun restoreChrome() {
-        cleanViewHintShownAt = 0L
         onChromeVisibleChanged(true)
     }
 
@@ -1305,29 +1291,34 @@ private fun ProgressivePlayer(
                     detectTapGestures(
                         onTap = {
                             if (scrubbing) return@detectTapGestures
-                            when (playbackFrameTapAction(chromeVisible, reachedEnd)) {
-                                PlaybackFrameTap.RESTORE_CHROME -> restoreChrome()
-                                else -> togglePlayback(showFlash = true)
-                            }
+                            togglePlayback(showFlash = true)
                         },
                         onDoubleTap = { resetZoom() },
                     )
                 },
         )
-        if (!chromeVisible && cleanViewHintShownAt != 0L) {
-            Text(
-                "Tap to show controls",
-                modifier =
-                    Modifier.align(Alignment.BottomCenter)
-                        .windowInsetsPadding(
-                            WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom),
-                        )
-                        .padding(bottom = 24.dp)
-                        .glass(CircleShape)
-                        .padding(horizontal = 12.dp, vertical = 7.dp),
-                style = chromeStyle(12f, FontWeight.Medium),
-                color = LiveDesign.text,
-            )
+        if (!chromeVisible) {
+            // The one control clean view keeps. Every other affordance is hidden, but the way back
+            // cannot be: the swipe restores it for operators who know the gesture, and this is
+            // here for everyone who does not. Dimmed so it is findable without competing with the
+            // picture, which is the whole reason the rest was hidden.
+            Box(
+                Modifier.align(Alignment.BottomEnd)
+                    .windowInsetsPadding(
+                        WindowInsets.safeDrawing.only(
+                            WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom,
+                        ),
+                    )
+                    .padding(end = 16.dp, bottom = 24.dp)
+                    .alpha(0.85f),
+            ) {
+                PlaybackIconButton(
+                    icon = Icons.Filled.FullscreenExit,
+                    contentDescription = "Show playback controls",
+                    circular = true,
+                    onClick = { restoreChrome() },
+                )
+            }
         }
         if (framingAssistsVisible) {
             LocalFramingAssistOverlay(

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
@@ -1455,6 +1455,10 @@ private fun ProgressivePlayer(
             // about is the mistake the clean-view button exists to correct, so the shade always
             // shows where to grab it — and the handle is a tap target too, since a tap is easier
             // than a drag on a moving picture.
+            // Nothing at all without a camera-read rating: null means the clip has no handle or
+            // there is no session, so the rating could not be written either and the handle would
+            // advertise a control that cannot work (iOS `ratingShade`).
+            if (ratingStars != null) {
             Column(
                 Modifier.align(Alignment.TopCenter)
                     .windowInsetsPadding(
@@ -1473,7 +1477,7 @@ private fun ProgressivePlayer(
             ) {
                 if (ratingShadeOpen) {
                     StarRatingRow(
-                        stars = ratingStars ?: 0,
+                        stars = ratingStars,
                         modifier =
                             Modifier.padding(bottom = 6.dp)
                                 .glass(CircleShape)
@@ -1486,6 +1490,13 @@ private fun ProgressivePlayer(
                         .glass(CircleShape)
                         .alpha(0.9f)
                         .chromeClickable(onClick = { onRatingShadeOpenChanged(!ratingShadeOpen) })
+                        // The handle owns the pull as well as the tap. Without this the clickable
+                        // consumes the pointer and the handle can only ever be tapped.
+                        .pointerInput(ratingShadeOpen) {
+                            detectVerticalDragGestures { _, delta ->
+                                ratingShadePull(delta)?.let(onRatingShadeOpenChanged)
+                            }
+                        }
                         .semantics {
                             contentDescription =
                                 if (ratingShadeOpen) "Hide star rating" else "Show star rating"
@@ -1511,6 +1522,7 @@ private fun ProgressivePlayer(
                         modifier = Modifier.size(13.dp),
                     )
                 }
+            }
             }
 
             Column(

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaStillViewer.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaStillViewer.kt
@@ -51,7 +51,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.ui.layout.ContentScale
+import com.opencapture.openzcine.settings.LocalFramingAssistConfiguration
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.CustomAccessibilityAction
@@ -120,6 +122,12 @@ internal fun MediaStillViewer(
     /** Records a closed rating-write breadcrumb (attempted / confirmed / refused). */
     onRatingDiagnostic: (AndroidDiagnosticEvent) -> Unit = {},
     onResolvedObjectSize: (MediaClipRecord, Long) -> Unit = { _, _ -> },
+    /**
+     * De-squeeze configuration; only this screen knows the decoded size, so the ratio is derived
+     * here. A display transform — the camera original is never touched, and share/export are
+     * unaffected.
+     */
+    desqueeze: LocalFramingAssistConfiguration? = null,
     onClose: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -295,6 +303,9 @@ internal fun MediaStillViewer(
                 bitmap = displayedImage,
                 filename = displayClip.filename,
                 modifier = Modifier.fillMaxSize(),
+                desqueezeAspectRatio =
+                    desqueeze?.desqueezedAspectRatio(
+                        displayedImage.width, displayedImage.height),
             )
         } else {
             StillPreviewPlaceholder(previewState)
@@ -576,6 +587,7 @@ private fun ZoomableStillPreview(
     bitmap: Bitmap,
     filename: String,
     modifier: Modifier = Modifier,
+    desqueezeAspectRatio: Float? = null,
 ) {
     var scale by remember(bitmap) { mutableFloatStateOf(1f) }
     var panOffset by remember(bitmap) { mutableStateOf(Offset.Zero) }
@@ -649,13 +661,22 @@ private fun ZoomableStillPreview(
             bitmap = bitmap.asImageBitmap(),
             contentDescription = null,
             modifier =
-                Modifier.fillMaxSize().graphicsLayer {
+                (
+                    if (desqueezeAspectRatio != null) {
+                        Modifier.aspectRatio(desqueezeAspectRatio)
+                    } else {
+                        Modifier.fillMaxSize()
+                    }
+                ).graphicsLayer {
                     scaleX = scale
                     scaleY = scale
                     translationX = panOffset.x
                     translationY = panOffset.y
                 },
-            contentScale = ContentScale.Fit,
+            // The pinch zoom rides on top of the de-squeezed box, so focus inspection happens at
+            // the intended geometry rather than on squeezed pixels.
+            contentScale =
+                if (desqueezeAspectRatio != null) ContentScale.FillBounds else ContentScale.Fit,
         )
     }
 }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackAssistOptions.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackAssistOptions.kt
@@ -80,6 +80,7 @@ import com.opencapture.openzcine.settings.LocalDesqueezeRatio
 import com.opencapture.openzcine.settings.LocalFramingAspectRatio
 import com.opencapture.openzcine.settings.LocalFramingGuideFamily
 import com.opencapture.openzcine.settings.LocalLevelStyle
+import com.opencapture.openzcine.settings.LocalMagnificationFactor
 import com.opencapture.openzcine.settings.GlassPillSlider
 import com.opencapture.openzcine.settings.OperatorSettings
 import com.opencapture.openzcine.settings.PanelCloseButton
@@ -98,10 +99,16 @@ import kotlinx.coroutines.launch
 internal fun hasPlaybackAssistOptions(tool: AssistTool): Boolean =
     tool.hasConfiguration && tool != AssistTool.LEVEL
 
-/** Mirrors iOS by keeping the live-only camera horizon and EV meter out of playback's toolbar. */
+/**
+ * Mirrors iOS by keeping the live-only camera horizon and EV meter out of playback's toolbar.
+ *
+ * MAG joins them: the punch-in is a live-view focus check driven by an on-feed key that playback
+ * does not mount, so offering the tool there would be a switch with nothing behind it.
+ */
 internal fun playbackAssistToolbarTools(tools: List<AssistTool>): List<AssistTool> =
     tools.filterNot {
-        it == AssistTool.LEVEL || it == AssistTool.EV || it.isPhotographyOnly
+        it == AssistTool.LEVEL || it == AssistTool.EV || it == AssistTool.MAG ||
+            it.isPhotographyOnly
     }
 
 /** Returns whether a live quick-settings panel still belongs to the visible monitor lifecycle. */
@@ -403,6 +410,7 @@ private fun PlaybackAssistOptionsContent(
         AssistTool.PLAY ->
             OptionCopy("Shows the just-captured still full-screen after each release.")
         AssistTool.DESQ -> DesqueezeOptions(settings)
+        AssistTool.MAG -> MagnificationOptions(settings)
         AssistTool.AUDIO ->
             OptionCopy("Meters the playing clip's audio. Available during media playback.")
     }
@@ -1296,6 +1304,18 @@ private fun LevelOptions(actions: AssistOptionsActions, settings: OperatorSettin
         LocalLevelStyle::label,
         selected = { settings.levelStyle == it },
     ) { settings.levelStyle = it }
+}
+
+@Composable
+private fun MagnificationOptions(settings: OperatorSettings) {
+    // On/off is the assist-bar MAG chip, and the punch-in itself is the on-feed key; this panel
+    // only picks how far in that key goes.
+    SegmentedChoice(
+        LocalMagnificationFactor.entries.toList(),
+        LocalMagnificationFactor::label,
+        selected = { settings.magnificationFactor == it },
+    ) { settings.magnificationFactor = it }
+    OptionCopy("Tap the magnify key on the feed to punch in and out.")
 }
 
 @Composable

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackState.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackState.kt
@@ -116,6 +116,67 @@ internal fun playbackChromeVisibilityForSwipe(
     return verticalDeltaDp < 0f
 }
 
+/**
+ * Slow-motion conform preview, mirroring `ConformPreview` in shared core — see that file for why
+ * capture rate, target rate and playback clock are kept as three separate values, and why an
+ * untrustworthy source refuses rather than guesses.
+ */
+internal val CONFORM_TARGET_RATES = listOf(23.976, 24.0, 25.0, 29.97, 30.0)
+
+/**
+ * A target must be at least this much slower, RELATIVELY, to count as a conform: the 1000/1001
+ * pulldown pairs differ by 0.1% and are the same shooting rate, while 24 against 25 differs by 4%
+ * and is a real conform. An absolute tolerance cannot separate those.
+ */
+internal const val CONFORM_FLOOR = 0.99
+
+internal data class ConformAvailability(
+    val targets: List<Double>,
+    val unavailableReason: String?,
+) {
+    val isAvailable: Boolean
+        get() = targets.isNotEmpty()
+}
+
+internal fun conformPreviewAvailability(
+    captureRate: Double?,
+    variableFrameRate: Boolean,
+): ConformAvailability {
+    if (captureRate == null || !captureRate.isFinite() || captureRate <= 0.0) {
+        return ConformAvailability(emptyList(), "Frame rate unavailable for this clip")
+    }
+    if (variableFrameRate) {
+        return ConformAvailability(
+            emptyList(),
+            "Variable frame rate — conform preview unavailable",
+        )
+    }
+    val targets = CONFORM_TARGET_RATES.filter { it < captureRate * CONFORM_FLOOR }
+    return if (targets.isEmpty()) {
+        ConformAvailability(emptyList(), "Not a high-frame-rate clip")
+    } else {
+        ConformAvailability(targets, null)
+    }
+}
+
+/** Target rate over capture rate; 1.0 in real time, so the player runs untouched. */
+internal fun conformPreviewSpeed(captureRate: Double?, target: Double?): Double {
+    if (captureRate == null || target == null) return 1.0
+    if (!captureRate.isFinite() || captureRate <= 0.0 || target <= 0.0) return 1.0
+    return target / captureRate
+}
+
+/** Cycles Real time -> each offered target -> Real time. */
+internal fun nextConformTarget(current: Double?, targets: List<Double>): Double? {
+    if (targets.isEmpty()) return null
+    val index = targets.indexOfFirst { it == current }
+    return when {
+        current == null -> targets.first()
+        index < 0 || index == targets.lastIndex -> null
+        else -> targets[index + 1]
+    }
+}
+
 /** How long the clean-view hint stays up; iOS uses the same 1.8s. */
 internal const val PLAYBACK_CLEAN_VIEW_HINT_MILLIS = 1_800L
 

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackState.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackState.kt
@@ -177,19 +177,6 @@ internal fun nextConformTarget(current: Double?, targets: List<Double>): Double?
     }
 }
 
-/**
- * The rating shade's pull (iOS `RatingShadePull`).
- *
- * It has to coexist with the chrome swipe, which already owns vertical drags on the picture.
- * Re-mapping that would break muscle memory for a control operators use constantly, so the shade
- * is pulled from the TOP band instead — where the stars live, and a zone the chrome gesture never
- * claimed. Returns the new open state, or null when the drag is too small to mean anything.
- */
-internal fun ratingShadePull(verticalDeltaDp: Float): Boolean? {
-    if (abs(verticalDeltaDp) < 6f) return null
-    return verticalDeltaDp > 0f
-}
-
 /** What a tap on the playback frame means (iOS `PlaybackFrameTap`). */
 internal enum class PlaybackFrameTap {
     RESTART_PLAYBACK,

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackState.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackState.kt
@@ -177,6 +177,19 @@ internal fun nextConformTarget(current: Double?, targets: List<Double>): Double?
     }
 }
 
+/**
+ * The rating shade's pull (iOS `RatingShadePull`).
+ *
+ * It has to coexist with the chrome swipe, which already owns vertical drags on the picture.
+ * Re-mapping that would break muscle memory for a control operators use constantly, so the shade
+ * is pulled from the TOP band instead — where the stars live, and a zone the chrome gesture never
+ * claimed. Returns the new open state, or null when the drag is too small to mean anything.
+ */
+internal fun ratingShadePull(verticalDeltaDp: Float): Boolean? {
+    if (abs(verticalDeltaDp) < 6f) return null
+    return verticalDeltaDp > 0f
+}
+
 /** What a tap on the playback frame means (iOS `PlaybackFrameTap`). */
 internal enum class PlaybackFrameTap {
     RESTART_PLAYBACK,

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackState.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackState.kt
@@ -116,6 +116,35 @@ internal fun playbackChromeVisibilityForSwipe(
     return verticalDeltaDp < 0f
 }
 
+/** How long the clean-view hint stays up; iOS uses the same 1.8s. */
+internal const val PLAYBACK_CLEAN_VIEW_HINT_MILLIS = 1_800L
+
+/** What a tap on the playback frame means (iOS `PlaybackFrameTap`). */
+internal enum class PlaybackFrameTap {
+    RESTORE_CHROME,
+    RESTART_PLAYBACK,
+    TOGGLE_TRANSPORT,
+}
+
+/**
+ * A hidden chrome wins over everything else.
+ *
+ * The clean-view button hands the operator a screen with no visible controls, so the tap that
+ * brings them back cannot also be the tap that plays or pauses. Without this the button would
+ * create precisely the trap it exists to remove — and a worse one than the swipe gesture ever
+ * was, because a gesture nobody knows about is undiscoverable, while a button that strands you
+ * is inescapable.
+ */
+internal fun playbackFrameTapAction(
+    chromeVisible: Boolean,
+    reachedEnd: Boolean,
+): PlaybackFrameTap =
+    when {
+        !chromeVisible -> PlaybackFrameTap.RESTORE_CHROME
+        reachedEnd -> PlaybackFrameTap.RESTART_PLAYBACK
+        else -> PlaybackFrameTap.TOGGLE_TRANSPORT
+    }
+
 /** Screen-space pan used for playback zoom without leaking Compose geometry into tests. */
 internal data class PlaybackPan(
     val x: Float = 0f,

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackState.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackState.kt
@@ -177,34 +177,24 @@ internal fun nextConformTarget(current: Double?, targets: List<Double>): Double?
     }
 }
 
-/** How long the clean-view hint stays up; iOS uses the same 1.8s. */
-internal const val PLAYBACK_CLEAN_VIEW_HINT_MILLIS = 1_800L
-
 /** What a tap on the playback frame means (iOS `PlaybackFrameTap`). */
 internal enum class PlaybackFrameTap {
-    RESTORE_CHROME,
     RESTART_PLAYBACK,
     TOGGLE_TRANSPORT,
 }
 
 /**
- * A hidden chrome wins over everything else.
+ * The tap means the same thing whether the chrome is up or hidden — play, pause, or restart at the
+ * end of a clip. Hiding the controls must not take transport away from the picture.
  *
- * The clean-view button hands the operator a screen with no visible controls, so the tap that
- * brings them back cannot also be the tap that plays or pauses. Without this the button would
- * create precisely the trap it exists to remove — and a worse one than the swipe gesture ever
- * was, because a gesture nobody knows about is undiscoverable, while a button that strands you
- * is inescapable.
+ * The way back does not ride on this tap: a small restore control stays on screen in clean view,
+ * and the swipe still works. That is what frees the tap to keep its meaning.
  */
 internal fun playbackFrameTapAction(
     chromeVisible: Boolean,
     reachedEnd: Boolean,
 ): PlaybackFrameTap =
-    when {
-        !chromeVisible -> PlaybackFrameTap.RESTORE_CHROME
-        reachedEnd -> PlaybackFrameTap.RESTART_PLAYBACK
-        else -> PlaybackFrameTap.TOGGLE_TRANSPORT
-    }
+    if (reachedEnd) PlaybackFrameTap.RESTART_PLAYBACK else PlaybackFrameTap.TOGGLE_TRANSPORT
 
 /** Screen-space pan used for playback zoom without leaking Compose geometry into tests. */
 internal data class PlaybackPan(

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackVideoEffectPolicy.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackVideoEffectPolicy.kt
@@ -4,6 +4,7 @@ package com.opencapture.openzcine.media
 
 import androidx.media3.common.C
 import androidx.media3.common.ColorInfo
+import androidx.media3.common.Format
 import androidx.media3.common.Player
 import androidx.media3.common.Tracks
 
@@ -34,6 +35,24 @@ internal fun selectedPlaybackVideoColorMode(tracks: Tracks): PlaybackVideoColorM
         }
     }
     return if (selectedVideoFound) PlaybackVideoColorMode.SDR else PlaybackVideoColorMode.UNKNOWN
+}
+
+/**
+ * The selected video track's frame rate, or null when the demuxer never established one.
+ *
+ * Feeds the conform preview's capture rate. Null is meaningful: `ConformPreview` refuses rather
+ * than conforming against a guess, because a preview at the wrong speed is worse than none.
+ */
+internal fun selectedPlaybackVideoFrameRate(tracks: Tracks): Float? {
+    for (group in tracks.groups) {
+        if (group.type != C.TRACK_TYPE_VIDEO) continue
+        for (index in 0 until group.length) {
+            if (!group.isTrackSelected(index)) continue
+            val rate = group.getTrackFormat(index).frameRate
+            if (rate != Format.NO_VALUE.toFloat() && rate > 0f && !rate.isNaN()) return rate
+        }
+    }
+    return null
 }
 
 /** Image-effect capability for the API 33 AGSL path and the API 29–32 SDR GLES fallback. */

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/OperatorSettings.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/OperatorSettings.kt
@@ -555,6 +555,25 @@ public data class LocalFramingAssistConfiguration(
                 1f
             }
 
+    /**
+     * The aspect ratio a STILL should be presented at once de-squeezed, or null when de-squeeze
+     * is off (present at the image's own ratio).
+     *
+     * Stills cannot use the two presentation scales the way the live feed does. The feed is
+     * scaled inside a fixed rect, but a still is FITTED to its container first, so scaling
+     * afterwards would push the image outside the frame it was just fitted into. Handing Compose
+     * a ratio lets `Modifier.aspectRatio` do the fit, and everything anchored to the resulting
+     * box follows without knowing about anamorphic. iOS `desqueezedAspectRatio`.
+     */
+    public fun desqueezedAspectRatio(sourceWidth: Int, sourceHeight: Int): Float? {
+        if (!desqueezeEnabled || sourceWidth <= 0 || sourceHeight <= 0) return null
+        val width = sourceWidth * horizontalPresentationScale
+        val height = sourceHeight * verticalPresentationScale
+        if (width <= 0f || height <= 0f) return null
+        val ratio = width / height
+        return if (ratio == sourceWidth.toFloat() / sourceHeight) null else ratio
+    }
+
     /** Local vertical monitor scale after applying the selected de-squeeze. */
     public val verticalPresentationScale: Float
         get() =

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/OperatorSettings.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/OperatorSettings.kt
@@ -324,6 +324,30 @@ public enum class LocalDesqueezeRatio(
     }
 }
 
+/**
+ * Live-view punch-in factors, mirroring the shared core's
+ * `AssistConfiguration.Magnification.Factor`.
+ *
+ * A closed set on purpose: this is a focus check, and a continuous zoom invites fiddling with a
+ * number that has no right answer.
+ */
+public enum class LocalMagnificationFactor(
+    /** Operator-facing label, also the accessibility wording. */
+    public val label: String,
+    /** The scale applied to the settled feed rect. */
+    public val scale: Float,
+) {
+    X2("2x", 2f),
+    X3("3x", 3f),
+    X4("4x", 4f),
+    ;
+
+    internal companion object {
+        fun fromStoredName(value: String?): LocalMagnificationFactor? =
+            entries.firstOrNull { it.name == value }
+    }
+}
+
 /** The source axis compressed by an anamorphic capture. */
 public enum class LocalDesqueezeOrientation(
     /** Operator-facing source-axis label. */
@@ -537,6 +561,10 @@ public data class LocalFramingAssistConfiguration(
     public val desqueezeFactor: Float = desqueezeRatio.factor,
     /** The source axis compressed by the anamorphic capture. */
     public val desqueezeOrientation: LocalDesqueezeOrientation,
+    /** Whether the punch-in tool is on, i.e. whether its quick key is on the feed. */
+    public val magnificationEnabled: Boolean = false,
+    /** The punch-in factor the quick key applies. */
+    public val magnificationFactor: LocalMagnificationFactor = LocalMagnificationFactor.X2,
 ) {
     /** Whether at least one selected guide is currently visible. */
     public val drawsGuides: Boolean
@@ -572,6 +600,24 @@ public data class LocalFramingAssistConfiguration(
         if (width <= 0f || height <= 0f) return null
         val ratio = width / height
         return if (ratio == sourceWidth.toFloat() / sourceHeight) null else ratio
+    }
+
+    /**
+     * The punch-in scale to apply to the settled feed rect, about its centre. Mirrors the shared
+     * core's `Magnification.scale(factor:isActive:)`.
+     *
+     * Exactly 1 when inactive, so the feed can apply it unconditionally and punching out lands on a
+     * framing identical to never having punched in — not a re-derived one. That identity is what
+     * stops repeated toggling from accumulating drift.
+     *
+     * Ordering is forced, not chosen: de-squeeze changes the image's SHAPE, so it has to settle
+     * before anything decides how big to draw the result. Applying the punch-in earlier would make
+     * it interact with the fit and the image would jump sideways as it zoomed.
+     */
+    public fun magnificationScale(isActive: Boolean): Float {
+        if (!isActive || !magnificationEnabled) return 1f
+        val scale = magnificationFactor.scale
+        return if (scale.isFinite() && scale > 1f) scale else 1f
     }
 
     /** Local vertical monitor scale after applying the selected de-squeeze. */
@@ -856,6 +902,9 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
     public val evMeterAssistEnabled: Toggle = Toggle("assist.local.evMeter", default = false)
     public val desqueezeEnabled: Toggle =
         Toggle(DESQUEEZE_ENABLED_KEY, default = legacyDesqueezeWasEnabled())
+    /** Puts the punch-in quick key on the feed; the punch-in itself is session-only. */
+    public val magnificationEnabled: Toggle =
+        Toggle("assist.local.magnification.enabled.v1", default = false)
     /** Shows the shared Swift meter's RGB edge blocks on the histogram. */
     public val histogramTrafficLightsEnabled: Toggle =
         Toggle("assist.scopes.histogramTrafficLights.v1", default = true)
@@ -873,6 +922,7 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
     private val desqueezeRatioState = mutableStateOf(loadDesqueezeRatio())
     private val desqueezeFactorState = mutableStateOf(loadDesqueezeFactor())
     private val desqueezeOrientationState = mutableStateOf(loadDesqueezeOrientation())
+    private val magnificationFactorState = mutableStateOf(loadMagnificationFactor())
     private val splitComparisonOrientationState = mutableStateOf(loadSplitComparisonOrientation())
     private val levelStyleState = mutableStateOf(loadLevelStyle())
     private val scopeCrushClipCompensationState = mutableStateOf(loadScopeCrushClipCompensation())
@@ -1052,6 +1102,14 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
             preferences.edit().putString(LEVEL_STYLE_KEY, new.name).apply()
         }
 
+    /** The punch-in factor the feed's magnify key applies; persisted immediately on change. */
+    public var magnificationFactor: LocalMagnificationFactor
+        get() = magnificationFactorState.value
+        set(new) {
+            magnificationFactorState.value = new
+            preferences.edit().putString(MAGNIFICATION_FACTOR_KEY, new.name).apply()
+        }
+
     /** The source axis compressed by the selected local anamorphic factor. */
     public var desqueezeOrientation: LocalDesqueezeOrientation
         get() = desqueezeOrientationState.value
@@ -1109,6 +1167,7 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
             AssistTool.LEVEL -> levelAssistEnabled.toggle()
             AssistTool.EV -> evMeterAssistEnabled.toggle()
             AssistTool.DESQ -> desqueezeEnabled.toggle()
+            AssistTool.MAG -> magnificationEnabled.toggle()
             else -> Unit
         }
     }
@@ -1122,6 +1181,7 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
             AssistTool.LEVEL -> levelAssistEnabled.value
             AssistTool.EV -> evMeterAssistEnabled.value
             AssistTool.DESQ -> desqueezeEnabled.value
+            AssistTool.MAG -> magnificationEnabled.value
             else -> false
         }
 
@@ -1268,6 +1328,8 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
                 desqueezeRatio = desqueezeRatio,
                 desqueezeFactor = desqueezeFactor,
                 desqueezeOrientation = desqueezeOrientation,
+                magnificationEnabled = magnificationEnabled.value,
+                magnificationFactor = magnificationFactor,
             )
 
     private val assistToolbarOrderState = mutableStateOf(loadAssistToolbarOrder())
@@ -1405,6 +1467,7 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
             levelAssistEnabled,
             evMeterAssistEnabled,
             desqueezeEnabled,
+            magnificationEnabled,
         )
 
     private fun loadDisplayModeOrder(): List<MonitorDisplayMode> {
@@ -1507,6 +1570,14 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
             editor.putBoolean(EV_METER_VISIBILITY_MIGRATED_KEY, true)
             changed = true
         }
+        if (!preferences.getBoolean(MAGNIFICATION_VISIBILITY_MIGRATED_KEY, false)) {
+            // MAG joined the framing group after its migration marker shipped, same as LEVEL.
+            // Add it exactly once so an existing custom toolbar sees the punch-in, then retain
+            // every later manual hide.
+            migrated += AssistTool.MAG
+            editor.putBoolean(MAGNIFICATION_VISIBILITY_MIGRATED_KEY, true)
+            changed = true
+        }
         if (changed) {
             editor.putStringSet(VISIBLE_ASSIST_TOOLS_KEY, migrated.mapTo(linkedSetOf()) { it.name }).apply()
         }
@@ -1584,6 +1655,11 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
         LocalDesqueezeOrientation.fromStoredName(
             preferences.getString(DESQUEEZE_ORIENTATION_KEY, null),
         ) ?: LocalDesqueezeOrientation.HORIZONTAL
+
+    private fun loadMagnificationFactor(): LocalMagnificationFactor =
+        LocalMagnificationFactor.fromStoredName(
+            preferences.getString(MAGNIFICATION_FACTOR_KEY, null),
+        ) ?: LocalMagnificationFactor.X2
 
     private fun loadSplitComparisonOrientation(): FeedSplitOrientation =
         FeedSplitOrientation.fromStoredName(
@@ -1796,6 +1872,9 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
         const val DESQUEEZE_RATIO_KEY = "assist.local.desqueeze.ratio.v2"
         const val DESQUEEZE_FACTOR_KEY = "assist.local.desqueeze.factor.v1"
         const val DESQUEEZE_ORIENTATION_KEY = "assist.local.desqueeze.orientation.v2"
+        const val MAGNIFICATION_FACTOR_KEY = "assist.local.magnification.factor.v1"
+        const val MAGNIFICATION_VISIBILITY_MIGRATED_KEY =
+            "assist.toolbar.magnificationVisibility.migrated.v1"
         const val SPLIT_COMPARISON_ORIENTATION_KEY = "assist.lut.splitComparison.orientation.v1"
         const val LEGACY_FRAMING_GUIDE_KEY = "assist.local.framingGuide.v1"
         const val LEGACY_DESQUEEZE_PRESENTATION_KEY = "assist.local.desqueezePresentation.v1"

--- a/Apps/Android/app/src/main/res/values/strings.xml
+++ b/Apps/Android/app/src/main/res/values/strings.xml
@@ -213,6 +213,7 @@
     <string name="assist_label_level">LEVEL</string>
     <string name="assist_label_ev_meter">EV</string>
     <string name="assist_label_desqueeze">DE-SQ</string>
+    <string name="assist_label_magnification">MAG</string>
     <string name="assist_label_audio">AUDIO</string>
     <string name="assist_label_play">PLAY</string>
     <string name="assist_title_focus_peaking">Peaking</string>
@@ -229,6 +230,7 @@
     <string name="assist_title_horizon">Horizon</string>
     <string name="assist_title_ev_meter">EV Meter</string>
     <string name="assist_title_desqueeze">Desqueeze</string>
+    <string name="assist_title_magnification">Magnification</string>
     <string name="assist_title_audio_levels">Audio Levels</string>
     <string name="assist_title_instant_playback">Instant Playback</string>
     <string name="assist_view">VIEW</string>
@@ -517,6 +519,8 @@
     <string name="focus_reset_moving">Reset focus point unavailable while moving focus</string>
     <string name="focus_reset">Reset focus point to center</string>
     <string name="split_comparison_key">Show or hide the 50/50 Log and LUT comparison</string>
+    <string name="magnification_key_enter">Magnify %1$s</string>
+    <string name="magnification_key_exit">Exit %1$s magnification</string>
     <string name="record_start_title">Start recording?</string>
     <string name="record_stop_title">Stop recording?</string>
     <string name="record_start_message">Send the record command to the camera.</string>

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/FramingAssistsTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/FramingAssistsTest.kt
@@ -5,6 +5,7 @@ import com.opencapture.openzcine.settings.LocalDesqueezeRatio
 import com.opencapture.openzcine.settings.LocalFramingAspectRatio
 import com.opencapture.openzcine.settings.LocalFramingAssistConfiguration
 import com.opencapture.openzcine.settings.LocalFramingGuideFamily
+import com.opencapture.openzcine.settings.LocalMagnificationFactor
 import com.opencapture.openzcine.settings.MonitorDisplayMode
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -187,6 +188,8 @@ class FramingAssistsTest {
         desqueezeEnabled: Boolean = false,
         desqueezeRatio: LocalDesqueezeRatio = LocalDesqueezeRatio.X100,
         desqueezeOrientation: LocalDesqueezeOrientation = LocalDesqueezeOrientation.HORIZONTAL,
+        magnificationEnabled: Boolean = false,
+        magnificationFactor: LocalMagnificationFactor = LocalMagnificationFactor.X2,
     ): LocalFramingAssistConfiguration =
         LocalFramingAssistConfiguration(
             guidesVisible = guidesVisible,
@@ -201,5 +204,67 @@ class FramingAssistsTest {
             desqueezeEnabled = desqueezeEnabled,
             desqueezeRatio = desqueezeRatio,
             desqueezeOrientation = desqueezeOrientation,
+            magnificationEnabled = magnificationEnabled,
+            magnificationFactor = magnificationFactor,
         )
+
+    /**
+     * The punch-in is exactly 1 unless the tool is on AND the key is pressed, which is what makes
+     * punching out land on the identical framing rather than a re-derived one. Every guard here is
+     * a way the feed could otherwise be left magnified with no visible control explaining it.
+     */
+    @Test
+    fun `punch-in only scales when the tool is on and the key is pressed`() {
+        val off = framingConfiguration()
+        assertEquals(1f, off.magnificationScale(isActive = true))
+        assertEquals(1f, off.magnificationScale(isActive = false))
+
+        val armed =
+            framingConfiguration(
+                magnificationEnabled = true,
+                magnificationFactor = LocalMagnificationFactor.X3,
+            )
+        assertEquals(1f, armed.magnificationScale(isActive = false))
+        assertEquals(3f, armed.magnificationScale(isActive = true))
+
+        // Every offered factor is a real punch-in; none quietly resolves to 1.
+        LocalMagnificationFactor.entries.forEach { factor ->
+            val scale =
+                framingConfiguration(magnificationEnabled = true, magnificationFactor = factor)
+                    .magnificationScale(isActive = true)
+            assertEquals(factor.scale, scale)
+            assertTrue(scale > 1f)
+        }
+    }
+
+    /**
+     * De-squeeze settles the image's SHAPE, so it has to compose with the punch-in rather than be
+     * replaced by it. Applying the punch-in first would re-fit to a different rectangle and the
+     * image would jump sideways as it zoomed.
+     */
+    @Test
+    fun `punch-in composes with desqueeze instead of replacing it`() {
+        val both =
+            framingConfiguration(
+                desqueezeEnabled = true,
+                desqueezeRatio = LocalDesqueezeRatio.X200,
+                desqueezeOrientation = LocalDesqueezeOrientation.HORIZONTAL,
+                magnificationEnabled = true,
+                magnificationFactor = LocalMagnificationFactor.X2,
+            )
+        val punchIn = both.magnificationScale(isActive = true)
+        // 2x squeeze halves the horizontal scale; a 2x punch-in brings it back to 1 while the
+        // vertical axis doubles — the anamorphic shape is preserved, not undone.
+        assertEquals(1f, both.horizontalPresentationScale * punchIn)
+        assertEquals(2f, both.verticalPresentationScale * punchIn)
+        // The de-squeezed still ratio is untouched: punch-in is a presentation scale, not a shape.
+        assertEquals(
+            both.desqueezedAspectRatio(4_000, 2_000),
+            framingConfiguration(
+                desqueezeEnabled = true,
+                desqueezeRatio = LocalDesqueezeRatio.X200,
+                desqueezeOrientation = LocalDesqueezeOrientation.HORIZONTAL,
+            ).desqueezedAspectRatio(4_000, 2_000),
+        )
+    }
 }

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/MonitorAnalysisPanelPlacementTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/MonitorAnalysisPanelPlacementTest.kt
@@ -632,6 +632,46 @@ class MonitorAnalysisPanelPlacementTest {
         )
     }
 
+    /**
+     * The punch-in key shares the recenter lane's row but takes the opposite edge, so it never
+     * lifts or shifts as the recenter and 50/50 keys come and go — the point of putting it there.
+     */
+    @Test
+    fun `magnification key mirrors the focus reset lane to the far edge without sharing its stack`() {
+        val landscapeFeed = landscapeZones().feed
+        val landscapeLane =
+            focusResetButtonBaseFrame(landscapeFeed, isPortrait = false, bottomChromeInset = 72f)
+        val landscapeKey =
+            magnificationKeyFrame(landscapeFeed, isPortrait = false, bottomChromeInset = 72f)
+        assertEquals(landscapeLane.y, landscapeKey.y)
+        assertEquals(40f, landscapeKey.width)
+        // Landscape recenter hugs the leading edge, so the key takes the trailing one.
+        assertTrue(landscapeKey.x > landscapeLane.x + landscapeLane.width)
+        assertEquals(landscapeFeed.x + landscapeFeed.width - 10f, landscapeKey.x + landscapeKey.width)
+
+        val portraitFeed = portraitZones().feed
+        val portraitLane =
+            focusResetButtonBaseFrame(portraitFeed, isPortrait = true, bottomChromeInset = 64f)
+        val portraitKey =
+            magnificationKeyFrame(portraitFeed, isPortrait = true, bottomChromeInset = 64f)
+        assertEquals(portraitLane.y, portraitKey.y)
+        // Portrait recenter hugs the trailing edge, so the mirror flips with it.
+        assertTrue(portraitKey.x + portraitKey.width < portraitLane.x)
+        assertEquals(portraitFeed.x + 10f, portraitKey.x)
+
+        // Whichever way the 50/50 key stacks, the magnify key stays put.
+        val stacked =
+            splitComparisonKeyFrame(
+                feed = landscapeFeed,
+                isPortrait = false,
+                bottomChromeInset = 72f,
+                focusResetMounted = true,
+                widthDp = 44f,
+                heightDp = 30f,
+            )
+        assertTrue(stacked.x + stacked.width < landscapeKey.x)
+    }
+
     @Test
     fun `focus reset climbs overlapping panels from lowest to highest`() {
         val bounds = ZoneFrame(0f, 0f, 400f, 320f)

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/media/PlaybackAssistStateTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/media/PlaybackAssistStateTest.kt
@@ -101,10 +101,18 @@ class PlaybackAssistStateTest {
         // has no live camera indicator) never lists it.
         assertFalse(hasPlaybackAssistOptions(AssistTool.EV))
         assertTrue(hasPlaybackAssistOptions(AssistTool.CROSS))
+        // MAG is driven by an on-feed key playback never mounts, so listing the tool there would
+        // be a switch with nothing behind it.
         assertEquals(
             listOf(AssistTool.LUT, AssistTool.AUDIO),
             playbackAssistToolbarTools(
-                listOf(AssistTool.LUT, AssistTool.LEVEL, AssistTool.EV, AssistTool.AUDIO),
+                listOf(
+                    AssistTool.LUT,
+                    AssistTool.LEVEL,
+                    AssistTool.EV,
+                    AssistTool.MAG,
+                    AssistTool.AUDIO,
+                ),
             ),
         )
     }

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/media/PlaybackStateTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/media/PlaybackStateTest.kt
@@ -186,26 +186,23 @@ class PlaybackStateTest {
                 },
         )
 
+    /**
+     * Hiding the controls must not take transport away from the picture: tap-to-pause works
+     * identically in clean view. The way back rides on the restore control that stays on screen
+     * and on the swipe, not on this tap (iOS `testCleanViewKeepsTapToPause`).
+     */
     @Test
-    fun `tapping a hidden chrome always restores it rather than toggling transport`() {
-        // Hidden chrome wins even at end-of-clip, where the tap would otherwise restart playback.
-        assertEquals(
-            PlaybackFrameTap.RESTORE_CHROME,
-            playbackFrameTapAction(chromeVisible = false, reachedEnd = false),
-        )
-        assertEquals(
-            PlaybackFrameTap.RESTORE_CHROME,
-            playbackFrameTapAction(chromeVisible = false, reachedEnd = true),
-        )
-        // With the chrome up, the tap keeps its old meaning.
-        assertEquals(
-            PlaybackFrameTap.TOGGLE_TRANSPORT,
-            playbackFrameTapAction(chromeVisible = true, reachedEnd = false),
-        )
-        assertEquals(
-            PlaybackFrameTap.RESTART_PLAYBACK,
-            playbackFrameTapAction(chromeVisible = true, reachedEnd = true),
-        )
+    fun `clean view keeps tap to pause`() {
+        for (chromeVisible in listOf(true, false)) {
+            assertEquals(
+                PlaybackFrameTap.TOGGLE_TRANSPORT,
+                playbackFrameTapAction(chromeVisible = chromeVisible, reachedEnd = false),
+            )
+            assertEquals(
+                PlaybackFrameTap.RESTART_PLAYBACK,
+                playbackFrameTapAction(chromeVisible = chromeVisible, reachedEnd = true),
+            )
+        }
     }
 
     /** Mirrors `ConformPreviewTests` in shared core, so the two platforms cannot drift apart. */

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/media/PlaybackStateTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/media/PlaybackStateTest.kt
@@ -184,4 +184,26 @@ class PlaybackStateTest {
                     null
                 },
         )
+
+    @Test
+    fun `tapping a hidden chrome always restores it rather than toggling transport`() {
+        // Hidden chrome wins even at end-of-clip, where the tap would otherwise restart playback.
+        assertEquals(
+            PlaybackFrameTap.RESTORE_CHROME,
+            playbackFrameTapAction(chromeVisible = false, reachedEnd = false),
+        )
+        assertEquals(
+            PlaybackFrameTap.RESTORE_CHROME,
+            playbackFrameTapAction(chromeVisible = false, reachedEnd = true),
+        )
+        // With the chrome up, the tap keeps its old meaning.
+        assertEquals(
+            PlaybackFrameTap.TOGGLE_TRANSPORT,
+            playbackFrameTapAction(chromeVisible = true, reachedEnd = false),
+        )
+        assertEquals(
+            PlaybackFrameTap.RESTART_PLAYBACK,
+            playbackFrameTapAction(chromeVisible = true, reachedEnd = true),
+        )
+    }
 }

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/media/PlaybackStateTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/media/PlaybackStateTest.kt
@@ -3,6 +3,7 @@ package com.opencapture.openzcine.media
 import androidx.media3.common.Player
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 
 /** Pure playback policy coverage; Media3 and camera I/O remain outside JVM tests. */
@@ -205,5 +206,45 @@ class PlaybackStateTest {
             PlaybackFrameTap.RESTART_PLAYBACK,
             playbackFrameTapAction(chromeVisible = true, reachedEnd = true),
         )
+    }
+
+    /** Mirrors `ConformPreviewTests` in shared core, so the two platforms cannot drift apart. */
+    @Test
+    fun `conform preview offers only meaningfully slower targets and refuses untrustworthy sources`() {
+        // The worked example: 60 to 24 is 40%.
+        assertEquals(0.4, conformPreviewSpeed(60.0, 24.0), 1e-9)
+        assertEquals(0.2, conformPreviewSpeed(120.0, 24.0), 1e-9)
+        // Real time leaves the player untouched.
+        assertEquals(1.0, conformPreviewSpeed(60.0, null), 1e-9)
+        assertEquals(1.0, conformPreviewSpeed(null, 24.0), 1e-9)
+
+        // A 30 fps clip is not offered 29.97 (pulldown, not slow motion) nor 30 (a no-op).
+        assertEquals(
+            listOf(23.976, 24.0, 25.0),
+            conformPreviewAvailability(30.0, variableFrameRate = false).targets,
+        )
+        // 24 fps has nothing meaningfully slower, so the control is inert and says why.
+        val twentyFour = conformPreviewAvailability(24.0, variableFrameRate = false)
+        assertFalse(twentyFour.isAvailable)
+        assertEquals("Not a high-frame-rate clip", twentyFour.unavailableReason)
+
+        // Untrustworthy sources refuse rather than conform against a guess.
+        assertFalse(conformPreviewAvailability(null, variableFrameRate = false).isAvailable)
+        assertFalse(conformPreviewAvailability(120.0, variableFrameRate = true).isAvailable)
+    }
+
+    @Test
+    fun `conform target cycles through every offer and back to real time`() {
+        val targets = conformPreviewAvailability(60.0, variableFrameRate = false).targets
+        var current: Double? = null
+        val visited = mutableListOf<Double?>()
+        repeat(targets.size + 1) {
+            current = nextConformTarget(current, targets)
+            visited.add(current)
+        }
+        // Every target once, then back to real time — no state the operator cannot leave.
+        assertEquals(targets + listOf<Double?>(null), visited)
+        // With nothing on offer the control cannot select anything.
+        assertNull(nextConformTarget(null, emptyList()))
     }
 }

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,5 +1,5 @@
-- Fixed: a USB-C camera error or unplug could crash the app.
-- Fixed: the Wi-Fi detail scanner no longer gives up after one bad frame, and you can always type the network and key by hand.
-- Fixed: aperture, ISO and shutter changes made on the camera now reach the app promptly.
-- Fixed: HEIF photos were missing from the media browser; connecting a second body no longer alters its settings.
+- Fixed: a USB-C error or unplug could crash the app; the Wi-Fi scanner survives a bad frame.
+- Fixed: aperture, ISO and shutter changes on the camera now reach the app promptly.
+- Fixed: HEIF photos were missing from the media browser; a second body keeps its settings.
 - New: per-DISP display settings, an Edit view that hides any monitor element, split video/photo layouts.
+- New: clean-view playback button, conform preview for high-frame-rate clips, de-squeeze in photo mode.

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,5 +1,5 @@
-- Fixed: a USB-C error or unplug could crash the app; the Wi-Fi scanner survives a bad frame.
-- Fixed: aperture, ISO and shutter changes on the camera now reach the app promptly.
-- Fixed: HEIF photos were missing from the media browser; a second body keeps its settings.
-- New: per-DISP display settings, an Edit view that hides any monitor element, split video/photo layouts.
-- New: clean-view playback button, conform preview for high-frame-rate clips, de-squeeze in photo mode.
+- Fixed: a USB-C error or unplug could crash the app; the Wi-Fi scanner survives bad frames.
+- Fixed: aperture, ISO and shutter changes on the camera reach the app promptly.
+- Fixed: HEIF photos missing from the media browser; a second body keeps its settings.
+- New: per-DISP display settings, an Edit view that hides any monitor element, split layouts.
+- New: live-view magnifier (2x/3x/4x), clean-view playback, conform preview, photo de-squeeze, tap-to-show star rating.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,11 @@ All notable changes to this project are documented here. The format is based on
 
 ### Changed
 
+- The **star rating in playback** moved from a permanent band above the transport to a shade at the
+  top of the picture: tap the star handle to reveal the stars, tap it again to put them away. They
+  stay put until you do. The handle only appears when a camera is connected, since the rating is
+  written to the card. Both platforms.
+
 - The **Focus dial** is available in video mode as well as photo mode, and is now **off by default**
   on a new install. An operator who already switched it on (or off) keeps that choice.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this project are documented here. The format is based on
 
 ### Added
 
+- **Slow-motion conform preview** for high-frame-rate clips: pick the rate the edit will conform
+  to and watch the clip at that speed, stated in full (`60 → 24 fps · 40%`). Real time stays the
+  default, audio is muted while a conform runs, and the clip itself is never touched. Where the
+  source cannot be trusted — unknown rate, variable frame rate — the control says why instead of
+  showing a plausible wrong speed.
+- **A visible clean-view button in playback**, hiding every non-essential control. The swipe-down
+  gesture still works; the button makes it discoverable. A tap on the picture always brings the
+  controls back.
+- **Anamorphic de-squeeze in photo mode** — live view, instant playback and the media-page still
+  viewer, with the same presets and custom 1.00–2.00× ratio the cinema path uses. Display only:
+  the camera original and any export are unchanged.
+
 - **Photography (stills) mode** (iOS + Android): dedicated stills chrome with a real shutter
   (hold-to-burst in continuous drives, tap-to-AF, bulb/time), built-in and app self-timers, and
   capture-bar pickers for mode (incl. U1–U3), ISO Auto, focus mode/area/subject, drive, white

--- a/Sources/OpenZCineCore/ConformPreview.swift
+++ b/Sources/OpenZCineCore/ConformPreview.swift
@@ -179,6 +179,25 @@ public enum ConformPreview {
         return "\(rateLabel(captureRate)) → \(rateLabel(targetRate)) fps · \(formatted)%"
     }
 
+    /// One menu row: the target rate and the speed it produces, without repeating the source rate
+    /// on every line — `24 fps · 48%`.
+    ///
+    /// The full `label` form belongs where the conform is stated once (a header, a badge); repeated
+    /// down a list it is the same eight characters five times over, which is what pushed the rows
+    /// to two lines and made the menu unreadable.
+    public static func targetLabel(captureRate: Double, targetRate: Double) -> String {
+        let percent = speed(captureRate: captureRate, targetRate: targetRate) * 100
+        let formatted =
+            abs(percent - percent.rounded()) < 0.05
+            ? String(Int(percent.rounded())) : String(format: "%.1f", percent)
+        return "\(rateLabel(targetRate)) fps · \(formatted)%"
+    }
+
+    /// Header for the list of targets, naming the source rate once: `Conform 50 fps to`.
+    public static func menuHeader(captureRate: Double) -> String {
+        "Conform \(rateLabel(captureRate)) fps to"
+    }
+
     /// Audio during a conform preview.
     ///
     /// Muted, and labelled as muted. Playing a track at 40% without pitch correction is misleading

--- a/Sources/OpenZCineCore/ConformPreview.swift
+++ b/Sources/OpenZCineCore/ConformPreview.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+/// Slow-motion conform preview: play a high-frame-rate clip at the rate it will be conformed to in
+/// the edit, so motion, performance, stabilisation and focus can be judged before the setup changes.
+///
+/// Real-time playback confirms a clip was captured; it does not show how 60 or 120 fps will FEEL
+/// once conformed. The rule is one line — the preview speed is the target timeline rate over the
+/// source capture rate, so 60 → 24 plays at 40% — and everything below exists to keep that line
+/// honest.
+///
+/// ## Three values, kept apart
+///
+/// The failure mode this design is built against is collapsing three different numbers into one:
+///
+/// 1. the **capture rate** the sensor actually ran at,
+/// 2. the **target rate** the operator is conforming to,
+/// 3. the **playback clock** and the duration it produces.
+///
+/// They diverge exactly where it matters. Footage recorded with an in-camera slow-motion playback
+/// rate is already conformed — its container plays at 24 while the sensor ran at 120 — so treating
+/// the container's nominal rate as the capture rate would conform it a second time and show 40% of
+/// 40%. Hence ``Source/captureRate`` is a separate input the shell must resolve from the most
+/// authoritative metadata it has, and ``Source/isAlreadyConformed`` exists to say "do not touch
+/// this one" rather than guessing.
+///
+/// ## Refusing rather than guessing
+///
+/// Where the source cannot be trusted — variable frame rate, or metadata that never arrived —
+/// ``availability(for:)`` returns a refusal instead of a plausible number. A conform preview that
+/// is quietly wrong is worse than one that is unavailable: the operator would be judging a
+/// performance at a speed the edit will never reproduce, and nothing on screen would say so.
+///
+/// This is a PREVIEW TRANSFORM. It never modifies the source clip and never implies a conformed
+/// export exists.
+public enum ConformPreview {
+
+    /// Timeline rates offered as conform targets: the broadcast and cinema standards an operator
+    /// would actually cut to. Ordered as presented.
+    public static let targetRates: [Double] = [23.976, 24, 25, 29.97, 30]
+
+    /// Frame rates within this many fps are the same rate for LABELLING — enough to absorb the
+    /// rounding a container's rational rate arrives with, small enough that 23.976 still prints
+    /// differently from 24.
+    public static let rateTolerance: Double = 0.01
+
+    /// A target must be at least this much slower, RELATIVELY, to count as a conform.
+    ///
+    /// An absolute tolerance cannot do this job. The 1000/1001 pulldown pairs sit 0.024–0.03 fps
+    /// apart (23.976 against 24, 29.97 against 30) and are the same shooting rate, not a slow-motion
+    /// conform — but 24 against 25 is only 1 fps apart and IS one. A 1% relative floor separates
+    /// them: the pulldown pairs differ by 0.1%, while 24/25 differs by 4%.
+    public static let conformFloor: Double = 0.99
+
+    /// What the shell managed to learn about the clip. Every field is something the player can only
+    /// answer after the asset loads, which is why this is an input rather than something derived
+    /// here.
+    public struct Source: Equatable, Sendable {
+        /// The rate the SENSOR ran at, from the most authoritative metadata available — not the
+        /// container's nominal playback rate unless that is genuinely all there is. `nil` when
+        /// nothing trustworthy arrived.
+        public var captureRate: Double?
+        /// True when the frame rate varies across the clip, so no single conform factor is correct.
+        public var isVariableFrameRate: Bool
+        /// True when the camera already applied a slow-motion playback rate, i.e. the file plays
+        /// conformed. Previewing a conform on top of that would apply the factor twice.
+        public var isAlreadyConformed: Bool
+
+        public init(
+            captureRate: Double? = nil,
+            isVariableFrameRate: Bool = false,
+            isAlreadyConformed: Bool = false
+        ) {
+            self.captureRate = captureRate
+            self.isVariableFrameRate = isVariableFrameRate
+            self.isAlreadyConformed = isAlreadyConformed
+        }
+    }
+
+    /// Whether a conform preview can be offered, and if not, why — the reason is shown to the
+    /// operator rather than the control simply being missing.
+    public enum Availability: Equatable, Sendable {
+        /// Offerable, with the target rates that are strictly slower than the capture rate.
+        case available([Double])
+        /// No trustworthy capture rate, so any factor would be a guess.
+        case unknownRate
+        /// The rate varies across the clip; one factor cannot be right for all of it.
+        case variableRate
+        /// The camera already conformed this clip; previewing again would double the factor.
+        case alreadyConformed
+        /// Nothing to conform to — the clip is not faster than the slowest target offered.
+        case notHighFrameRate
+
+        /// The offered targets, or empty when unavailable.
+        public var targets: [Double] {
+            if case .available(let rates) = self { return rates }
+            return []
+        }
+
+        public var isAvailable: Bool { !targets.isEmpty }
+
+        /// Operator-facing reason the control is inert. `nil` when it is available.
+        public var unavailableReason: String? {
+            switch self {
+            case .available: nil
+            case .unknownRate: "Frame rate unavailable for this clip"
+            case .variableRate: "Variable frame rate — conform preview unavailable"
+            case .alreadyConformed: "Already conformed in camera"
+            case .notHighFrameRate: "Not a high-frame-rate clip"
+            }
+        }
+    }
+
+    /// Whether a conform preview can be offered for `source`, and which targets.
+    ///
+    /// The refusals are ordered by how badly each would mislead: an unusable rate first, then a
+    /// rate that cannot be a single number, then a clip that is already conformed.
+    public static func availability(for source: Source) -> Availability {
+        guard let rate = source.captureRate, rate.isFinite, rate > 0 else { return .unknownRate }
+        if source.isVariableFrameRate { return .variableRate }
+        if source.isAlreadyConformed { return .alreadyConformed }
+        // Meaningfully slower, so a clip shot at 24 is offered neither "conform to 24" (a no-op)
+        // nor "conform to 23.976" (pulldown, not slow motion) — see `conformFloor`.
+        let targets = targetRates.filter { $0 < rate * conformFloor }
+        return targets.isEmpty ? .notHighFrameRate : .available(targets)
+    }
+
+    /// Playback speed for a conform: the target timeline rate over the source capture rate.
+    /// 60 → 24 is 0.4. Returns 1 for a degenerate source rather than a division by zero.
+    public static func speed(captureRate: Double, targetRate: Double) -> Double {
+        guard captureRate.isFinite, captureRate > 0, targetRate.isFinite, targetRate > 0 else {
+            return 1
+        }
+        return targetRate / captureRate
+    }
+
+    /// How long the clip runs once conformed: real time divided by the speed. A 6 s clip at 40%
+    /// runs 15 s.
+    public static func conformedDuration(sourceSeconds: Double, speed: Double) -> Double {
+        guard sourceSeconds.isFinite, sourceSeconds >= 0, speed.isFinite, speed > 0 else {
+            return 0
+        }
+        return sourceSeconds / speed
+    }
+
+    /// The source frame a conformed playhead is sitting on. Seeking stays anchored to SOURCE frame
+    /// indices — the conform is a clock change, not a re-timing of the media, so scrubbing must
+    /// still land on real frames.
+    public static func sourceFrameIndex(
+        conformedSeconds: Double, captureRate: Double, speed: Double
+    ) -> Int {
+        guard conformedSeconds.isFinite, conformedSeconds >= 0, captureRate > 0, speed > 0 else {
+            return 0
+        }
+        return Int((conformedSeconds * speed * captureRate).rounded(.down))
+    }
+
+    /// A frame rate as an operator writes it: whole rates plain, pulldown rates to two places.
+    /// 24 → "24", 23.976 → "23.98", 29.97 → "29.97", 59.94 → "59.94".
+    public static func rateLabel(_ rate: Double) -> String {
+        guard rate.isFinite, rate > 0 else { return "—" }
+        let whole = rate.rounded()
+        if abs(rate - whole) < rateTolerance { return String(Int(whole)) }
+        return String(format: "%.2f", rate)
+    }
+
+    /// The conform stated in full, so the operator can never be unsure what they are watching:
+    /// `60 → 24 fps · 40%`.
+    ///
+    /// The percentage is deliberately alongside the rates rather than instead of them. The rates
+    /// say what the edit will do; the percentage says what the eye is seeing, and an operator
+    /// judging a performance needs both.
+    public static func label(captureRate: Double, targetRate: Double) -> String {
+        let percent = speed(captureRate: captureRate, targetRate: targetRate) * 100
+        // Integer only when it genuinely is one: 40% prints "40", 20.83% prints "20.8". A 0.5
+        // threshold here would be met by every value, which is the bug this replaced.
+        let formatted =
+            abs(percent - percent.rounded()) < 0.05
+            ? String(Int(percent.rounded())) : String(format: "%.1f", percent)
+        return "\(rateLabel(captureRate)) → \(rateLabel(targetRate)) fps · \(formatted)%"
+    }
+
+    /// Audio during a conform preview.
+    ///
+    /// Muted, and labelled as muted. Playing a track at 40% without pitch correction is misleading
+    /// in a way that is easy to miss — it still sounds like audio, just wrong — and pitch-corrected
+    /// audio is a bigger piece of work that wants the playback clock settled first. Silence the
+    /// operator has been told about is the honest first version.
+    public static let audioLabel = "Audio muted during conform preview"
+}

--- a/Sources/OpenZCineCore/Magnification.swift
+++ b/Sources/OpenZCineCore/Magnification.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Live-view punch-in for checking critical focus.
+///
+/// The whole feature is one number applied at one point in the pipeline, and the reason it needs a
+/// file of its own is WHERE that point is.
+///
+/// ## It is the last transform, and that is not arbitrary
+///
+/// Magnification composes with de-squeeze, Fit/Fill, orientation and the LUT, and the ordering is
+/// forced rather than chosen. De-squeeze changes the image's SHAPE, so it has to settle before
+/// anything decides how big to draw it; Fit/Fill then decides the framing. Punch-in scales that
+/// settled result about its centre — so it magnifies exactly what the operator was looking at, and
+/// punching back out lands on the identical framing rather than a re-derived one.
+///
+/// Applying it earlier would make the punch-in interact with the fit: a 2× punch on a de-squeezed
+/// frame would re-fit to a different rectangle and the image would jump sideways as it zoomed.
+///
+/// ## Overlays come along for free, and that is the point
+///
+/// Peaking, guides, the grid and the AF boxes are all registered to the feed rect. Scaling that
+/// rect carries them with it, so a magnified view shows peaking on the magnified pixels rather
+/// than a stale overlay floating over a zoomed image — which is the only way a punch-in is useful
+/// for judging focus at all.
+///
+/// This is a MONITORING transform. It never changes the camera's crop mode, resolution, recorded
+/// image, or camera-side digital zoom.
+public enum Magnification {
+
+    /// The scale to apply to the settled feed rect, about its centre.
+    ///
+    /// Exactly 1 when inactive, so the shells can apply this unconditionally and punching out
+    /// lands on a framing that is identical to never having punched in — not a re-derived one.
+    /// That identity is what stops repeated toggling from accumulating drift.
+    ///
+    /// Scalars rather than a rect: this is shared with Android through Kotlin, which has no
+    /// CGRect, and each shell already owns its own geometry type.
+    public static func scale(factor: Double, isActive: Bool) -> Double {
+        guard isActive, factor.isFinite, factor > 1 else { return 1 }
+        return factor
+    }
+
+    /// Whether the quick-access button belongs on screen: the tool is on, and live view is the
+    /// thing being shown. Disabling the tool takes the button with it.
+    public static func showsButton(toolEnabled: Bool) -> Bool { toolEnabled }
+
+    /// The punched-in state after the tool is switched off.
+    ///
+    /// Always false. Leaving a punch-in armed behind a disabled tool is how the button and the
+    /// transform desynchronise — the operator would have a magnified feed and no visible control
+    /// that explains it.
+    public static func activeAfterDisabling() -> Bool { false }
+
+    /// Accessibility/label text for the quick-access button.
+    public static func buttonLabel(factor: AssistConfiguration.Magnification.Factor, isActive: Bool)
+        -> String
+    {
+        isActive ? "Exit \(factor.rawValue) magnification" : "Magnify \(factor.rawValue)"
+    }
+}

--- a/Sources/OpenZCineCore/OperatorPreferences.swift
+++ b/Sources/OpenZCineCore/OperatorPreferences.swift
@@ -26,6 +26,8 @@ public enum MonitorAssistTool: String, CaseIterable, Codable, Equatable, Identif
     case evMeter = "EV"
     case desqueeze = "DE-SQ"
     case instantReview = "PLAY"
+    /// Monitoring punch-in for critical focus (see `Magnification`).
+    case magnification = "MAG"
 
     public var id: String { rawValue }
 
@@ -37,7 +39,7 @@ public enum MonitorAssistTool: String, CaseIterable, Codable, Equatable, Identif
         case .lut, .peaking, .falseColor, .zebra, .waveform, .parade, .histogram, .vectorscope,
             .trafficLights,
             .guides, .grid,
-            .crosshair, .level, .desqueeze, .instantReview:
+            .crosshair, .level, .desqueeze, .instantReview, .magnification:
             true
         case .audioMeters, .evMeter:
             // Tap-only tools — the meters carry no operator-tunable options.
@@ -88,6 +90,7 @@ public enum MonitorAssistTool: String, CaseIterable, Codable, Equatable, Identif
         case .evMeter: "EV Meter"
         case .desqueeze: "Desqueeze"
         case .instantReview: "Instant Playback"
+        case .magnification: "Magnification"
         }
     }
 }
@@ -1135,6 +1138,41 @@ public struct AssistConfiguration: Codable, Equatable, Sendable {
         public var style: Style
     }
 
+    /// Live-view punch-in for checking critical focus, and nothing more.
+    ///
+    /// A MONITORING transform: it never touches the camera's crop mode, resolution, recorded
+    /// image or camera-side digital zoom. The operator punches in, confirms focus, and punches
+    /// back out to the identical framing they left.
+    ///
+    /// Only the factor is persisted. Whether the view is currently punched in is transient by
+    /// design — coming back to a session already magnified, with no memory of having done it,
+    /// would read as a broken feed rather than a restored preference.
+    public struct Magnification: Codable, Equatable, Sendable {
+        /// The punch-in factors offered. Deliberately a closed set: this is a focus check, and a
+        /// continuous zoom invites fiddling with a number that has no right answer.
+        public enum Factor: String, CaseIterable, Codable, Equatable, Sendable, Identifiable {
+            case x2 = "2x"
+            case x3 = "3x"
+            case x4 = "4x"
+
+            public var id: String { rawValue }
+
+            public var scale: Double {
+                switch self {
+                case .x2: 2
+                case .x3: 3
+                case .x4: 4
+                }
+            }
+        }
+
+        public init(factor: Factor = .x2) {
+            self.factor = factor
+        }
+
+        public var factor: Factor
+    }
+
     public struct Desqueeze: Codable, Equatable, Sendable {
         /// Common anamorphic squeeze chips (including 1.6×). Custom values use [factor].
         public enum Ratio: String, CaseIterable, Codable, Equatable, Sendable {
@@ -1710,6 +1748,8 @@ public struct AssistConfiguration: Codable, Equatable, Sendable {
     public var grid: Grid
     public var level: Level
     public var desqueeze: Desqueeze
+    /// Punch-in factor for the magnification assist; the punched-in state itself is not persisted.
+    public var magnification: Magnification = Magnification()
     public var falseColorReferenceEnabled: Bool
     /// Which false-colour ramp the overlay reads against (stop landmarks, monitor IRE, or limits).
     public var falseColorScale: FalseColorScale
@@ -1739,7 +1779,8 @@ public struct AssistConfiguration: Codable, Equatable, Sendable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case guides, grid, level, desqueeze, falseColorReferenceEnabled, falseColorScale,
+        case guides, grid, level, desqueeze, magnification, falseColorReferenceEnabled,
+            falseColorScale,
             zebra, trafficLights,
             zebraHighlightIRE, peakingColor, peakingSensitivity, scopes, selectedLUT,
             instantReviewSeconds, instantReviewShowsFocusPoint, instantReviewShowsCaptureInfo
@@ -1758,6 +1799,9 @@ public struct AssistConfiguration: Codable, Equatable, Sendable {
         grid = try c.decode(Grid.self, forKey: .grid)
         level = try c.decode(Level.self, forKey: .level)
         desqueeze = try c.decode(Desqueeze.self, forKey: .desqueeze)
+        // Added after the first persisted version, so an older saved config still loads.
+        magnification =
+            try c.decodeIfPresent(Magnification.self, forKey: .magnification) ?? Magnification()
         falseColorReferenceEnabled = try c.decode(Bool.self, forKey: .falseColorReferenceEnabled)
         selectedLUT = try c.decode(LUTSelection.self, forKey: .selectedLUT)
         let legacy = try decoder.container(keyedBy: LegacyCodingKeys.self)
@@ -1816,6 +1860,7 @@ public struct AssistConfiguration: Codable, Equatable, Sendable {
         try c.encode(grid, forKey: .grid)
         try c.encode(level, forKey: .level)
         try c.encode(desqueeze, forKey: .desqueeze)
+        try c.encode(magnification, forKey: .magnification)
         try c.encode(falseColorReferenceEnabled, forKey: .falseColorReferenceEnabled)
         try c.encode(falseColorScale, forKey: .falseColorScale)
         try c.encode(zebra, forKey: .zebra)

--- a/Sources/OpenZCineCore/StillCapture.swift
+++ b/Sources/OpenZCineCore/StillCapture.swift
@@ -218,7 +218,7 @@ extension MonitorAssistTool {
     public var appliesToPhotography: Bool {
         switch self {
         case .peaking, .falseColor, .zebra, .histogram, .grid, .level, .evMeter, .instantReview,
-            .desqueeze:
+            .desqueeze, .magnification:
             true
         case .lut, .waveform, .parade, .vectorscope, .trafficLights, .audioMeters,
             .guides, .crosshair:

--- a/Sources/OpenZCineCore/StillCapture.swift
+++ b/Sources/OpenZCineCore/StillCapture.swift
@@ -208,14 +208,20 @@ public enum StillCapturePolicy: Sendable {
 extension MonitorAssistTool {
     /// Assist tools that apply to still photography — the exposure aids (peaking, false
     /// color, zebra, histogram) plus the composition aids photographers actually use
-    /// (grid, level). Everything else is cinema-only, which keeps the photo toolbar
+    /// (grid, level, de-squeeze). Everything else is cinema-only, which keeps the photo toolbar
     /// deliberately shorter so the stills strip gets the bar width.
+    ///
+    /// De-squeeze is here because anamorphic lenses are used for stills too, and a squeezed
+    /// preview makes faces, framing and edge behaviour impossible to judge on a tethered shoot.
+    /// It is a display transform in every surface it reaches — the camera original is never
+    /// touched.
     public var appliesToPhotography: Bool {
         switch self {
-        case .peaking, .falseColor, .zebra, .histogram, .grid, .level, .evMeter, .instantReview:
+        case .peaking, .falseColor, .zebra, .histogram, .grid, .level, .evMeter, .instantReview,
+            .desqueeze:
             true
         case .lut, .waveform, .parade, .vectorscope, .trafficLights, .audioMeters,
-            .guides, .crosshair, .desqueeze:
+            .guides, .crosshair:
             false
         }
     }

--- a/Tests/OpenZCineCoreTests/ConformPreviewTests.swift
+++ b/Tests/OpenZCineCoreTests/ConformPreviewTests.swift
@@ -120,4 +120,20 @@ struct ConformPreviewTests {
         let odd = ConformPreview.label(captureRate: 120, targetRate: 25)
         #expect(odd == "120 → 25 fps · 20.8%")
     }
+
+    /// The per-row label drops the source rate, which is stated once in the header. Repeating it
+    /// on every row is what made the menu wrap to two lines a row.
+    @Test("Menu rows name the target and its speed, and the header names the source once")
+    func menuLabels() {
+        #expect(ConformPreview.targetLabel(captureRate: 50, targetRate: 24) == "24 fps · 48%")
+        #expect(ConformPreview.targetLabel(captureRate: 50, targetRate: 30) == "30 fps · 60%")
+        // The pulldown rates keep a decimal on both the rate and the percentage.
+        #expect(
+            ConformPreview.targetLabel(captureRate: 50, targetRate: 29.97) == "29.97 fps · 59.9%")
+        #expect(ConformPreview.menuHeader(captureRate: 50) == "Conform 50 fps to")
+        // Every row stays short enough not to wrap in a menu.
+        for target in ConformPreview.targetRates {
+            #expect(ConformPreview.targetLabel(captureRate: 120, targetRate: target).count <= 18)
+        }
+    }
 }

--- a/Tests/OpenZCineCoreTests/ConformPreviewTests.swift
+++ b/Tests/OpenZCineCoreTests/ConformPreviewTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+
+@testable import OpenZCineCore
+
+/// The test matrix the feature discussion asked for: 60→24, 120→24, already-conformed clips, VFR,
+/// and missing metadata. Each case is here because getting it wrong shows the operator a speed the
+/// edit will never reproduce, with nothing on screen saying so.
+@Suite("Slow-motion conform preview")
+struct ConformPreviewTests {
+
+    @Test("The worked example from the request: 60 to 24 is 40%")
+    func sixtyToTwentyFour() {
+        #expect(ConformPreview.speed(captureRate: 60, targetRate: 24) == 0.4)
+        #expect(ConformPreview.label(captureRate: 60, targetRate: 24) == "60 → 24 fps · 40%")
+    }
+
+    @Test("120 to 24 is 20%, and the offered targets are every rate slower than the source")
+    func oneTwentyToTwentyFour() {
+        #expect(ConformPreview.speed(captureRate: 120, targetRate: 24) == 0.2)
+        let availability = ConformPreview.availability(
+            for: ConformPreview.Source(captureRate: 120))
+        #expect(availability.targets == ConformPreview.targetRates)
+    }
+
+    /// A 30 fps clip must not be offered "conform to 30" — the control would do nothing — nor
+    /// "conform to 29.97", which is a pulldown pair rather than a slow-motion conform.
+    @Test("Only rates strictly slower than the source are offered")
+    func onlySlowerTargets() {
+        let thirty = ConformPreview.availability(for: ConformPreview.Source(captureRate: 30))
+        #expect(thirty.targets == [23.976, 24, 25])
+        // 24 fps has nothing meaningfully slower, so the feature is not offered at all.
+        let twentyFour = ConformPreview.availability(for: ConformPreview.Source(captureRate: 24))
+        #expect(twentyFour == .notHighFrameRate)
+        #expect(!twentyFour.isAvailable)
+    }
+
+    /// Each refusal exists because the alternative is a plausible, wrong number.
+    @Test("Untrustworthy sources refuse rather than guess, and say why")
+    func refusals() {
+        #expect(ConformPreview.availability(for: ConformPreview.Source()) == .unknownRate)
+        #expect(
+            ConformPreview.availability(for: ConformPreview.Source(captureRate: 0)) == .unknownRate)
+        #expect(
+            ConformPreview.availability(for: ConformPreview.Source(captureRate: .nan))
+                == .unknownRate)
+        #expect(
+            ConformPreview.availability(
+                for: ConformPreview.Source(captureRate: 120, isVariableFrameRate: true))
+                == .variableRate)
+        // Already conformed in camera: applying the factor again would show 40% of 40%.
+        #expect(
+            ConformPreview.availability(
+                for: ConformPreview.Source(captureRate: 120, isAlreadyConformed: true))
+                == .alreadyConformed)
+        // Every refusal is explained to the operator rather than silently disabling the control.
+        for source in [
+            ConformPreview.Source(),
+            ConformPreview.Source(captureRate: 120, isVariableFrameRate: true),
+            ConformPreview.Source(captureRate: 120, isAlreadyConformed: true),
+            ConformPreview.Source(captureRate: 24),
+        ] {
+            #expect(ConformPreview.availability(for: source).unavailableReason != nil)
+        }
+    }
+
+    /// A variable rate is refused even though a capture rate is present — one factor cannot be
+    /// right across the clip, so the ordering of the checks is itself the behaviour.
+    @Test("Variable frame rate outranks a usable-looking capture rate")
+    func variableRateWins() {
+        let source = ConformPreview.Source(
+            captureRate: 120, isVariableFrameRate: true, isAlreadyConformed: true)
+        #expect(ConformPreview.availability(for: source) == .variableRate)
+    }
+
+    @Test("Conformed duration stretches by the reciprocal of the speed")
+    func duration() {
+        // The 6 s, 60 fps fixture: at 24 it runs 15 s.
+        let speed = ConformPreview.speed(captureRate: 60, targetRate: 24)
+        #expect(ConformPreview.conformedDuration(sourceSeconds: 6, speed: speed) == 15)
+        // Degenerate inputs produce 0 rather than an infinity that would reach a time label.
+        #expect(ConformPreview.conformedDuration(sourceSeconds: 6, speed: 0) == 0)
+        #expect(ConformPreview.conformedDuration(sourceSeconds: .infinity, speed: 0.4) == 0)
+    }
+
+    /// Scrubbing has to stay anchored to real frames: the conform is a clock change, not a
+    /// re-timing of the media.
+    @Test("Seeking maps a conformed playhead back to a source frame index")
+    func sourceFrames() {
+        let speed = ConformPreview.speed(captureRate: 60, targetRate: 24)
+        // 15 s conformed is the whole 6 s clip: frame 360 of a 360-frame source.
+        #expect(
+            ConformPreview.sourceFrameIndex(
+                conformedSeconds: 15, captureRate: 60, speed: speed) == 360)
+        // Halfway through the conformed timeline is halfway through the frames.
+        #expect(
+            ConformPreview.sourceFrameIndex(
+                conformedSeconds: 7.5, captureRate: 60, speed: speed) == 180)
+        #expect(
+            ConformPreview.sourceFrameIndex(
+                conformedSeconds: 0, captureRate: 60, speed: speed) == 0)
+    }
+
+    @Test("Rates read the way an operator writes them")
+    func rateLabels() {
+        #expect(ConformPreview.rateLabel(24) == "24")
+        #expect(ConformPreview.rateLabel(60) == "60")
+        #expect(ConformPreview.rateLabel(23.976) == "23.98")
+        #expect(ConformPreview.rateLabel(29.97) == "29.97")
+        #expect(ConformPreview.rateLabel(0) == "—")
+    }
+
+    /// The pulldown rates do not divide evenly, so the percentage has to survive a non-integer.
+    @Test("A non-integer conform still states its speed")
+    func pulldownLabel() {
+        #expect(
+            ConformPreview.label(captureRate: 59.94, targetRate: 23.976)
+                == "59.94 → 23.98 fps · 40%"
+        )
+        let odd = ConformPreview.label(captureRate: 120, targetRate: 25)
+        #expect(odd == "120 → 25 fps · 20.8%")
+    }
+}

--- a/Tests/OpenZCineCoreTests/MagnificationTests.swift
+++ b/Tests/OpenZCineCoreTests/MagnificationTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+
+@testable import OpenZCineCore
+
+/// The acceptance criteria that can be checked without a screen: every factor, the round trip back
+/// to the original framing, and the states that must not desynchronise.
+@Suite("Live-view magnification")
+struct MagnificationTests {
+
+    @Test("Every offered factor punches in by exactly that much")
+    func factors() {
+        #expect(AssistConfiguration.Magnification.Factor.allCases.count == 3)
+        for factor in AssistConfiguration.Magnification.Factor.allCases {
+            #expect(Magnification.scale(factor: factor.scale, isActive: true) == factor.scale)
+        }
+        #expect(AssistConfiguration.Magnification.Factor.x2.scale == 2)
+        #expect(AssistConfiguration.Magnification.Factor.x3.scale == 3)
+        #expect(AssistConfiguration.Magnification.Factor.x4.scale == 4)
+    }
+
+    /// "One tap enters the selected magnification and the next tap returns to the IDENTICAL normal
+    /// framing" — so inactive has to be exactly 1, not approximately.
+    @Test("Punching out restores the original framing exactly")
+    func roundTrip() {
+        for factor in AssistConfiguration.Magnification.Factor.allCases {
+            #expect(Magnification.scale(factor: factor.scale, isActive: false) == 1)
+        }
+        // "Repeated toggling does not accumulate transforms": the scale is derived from the factor
+        // every time rather than compounded, so any number of round trips is still exactly 1.
+        var scale = 1.0
+        for _ in 0..<50 {
+            scale = Magnification.scale(factor: 4, isActive: true)
+            scale = Magnification.scale(factor: 4, isActive: false)
+        }
+        #expect(scale == 1)
+    }
+
+    @Test("A degenerate or absent factor cannot magnify")
+    func degenerate() {
+        #expect(Magnification.scale(factor: 1, isActive: true) == 1)
+        #expect(Magnification.scale(factor: 0, isActive: true) == 1)
+        #expect(Magnification.scale(factor: -2, isActive: true) == 1)
+        #expect(Magnification.scale(factor: .nan, isActive: true) == 1)
+        #expect(Magnification.scale(factor: .infinity, isActive: true) == 1)
+    }
+
+    /// "Disabling the tool while punched in restores the normal view and removes the button" — the
+    /// state the acceptance criteria single out as never allowed to desynchronise.
+    @Test("Disabling the tool cannot leave a punch-in armed behind a missing button")
+    func disablingClearsBoth() {
+        #expect(Magnification.showsButton(toolEnabled: true))
+        #expect(!Magnification.showsButton(toolEnabled: false))
+        #expect(!Magnification.activeAfterDisabling())
+        // The pair together: no button, and no transform.
+        let active = Magnification.activeAfterDisabling()
+        #expect(Magnification.scale(factor: 4, isActive: active) == 1)
+    }
+
+    @Test("The button says which factor it will apply, and how to leave")
+    func labels() {
+        #expect(Magnification.buttonLabel(factor: .x3, isActive: false) == "Magnify 3x")
+        #expect(Magnification.buttonLabel(factor: .x3, isActive: true) == "Exit 3x magnification")
+    }
+
+    /// It is a view-assist tool with a popup, and it has to reach photography — punching in to
+    /// confirm focus matters at least as much for stills as for cinema.
+    @Test("Magnification is a configurable tool and reaches photography")
+    func toolPolicy() {
+        #expect(MonitorAssistTool.magnification.hasConfiguration)
+        #expect(MonitorAssistTool.magnification.appliesToPhotography)
+        #expect(MonitorAssistTool.magnification.displaySettingsTitle == "Magnification")
+    }
+
+    @Test("The factor persists and an older saved config still loads")
+    func persistence() throws {
+        var preferences = AssistConfiguration()
+        preferences.magnification.factor = .x4
+        let data = try JSONEncoder().encode(preferences)
+        let restored = try JSONDecoder().decode(AssistConfiguration.self, from: data)
+        #expect(restored.magnification.factor == .x4)
+        // A config saved before this field existed decodes to the default rather than failing.
+        var json = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        json.removeValue(forKey: "magnification")
+        let legacy = try JSONSerialization.data(withJSONObject: json)
+        let decoded = try JSONDecoder().decode(AssistConfiguration.self, from: legacy)
+        #expect(decoded.magnification.factor == .x2)
+    }
+}

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		503189555B5DB867F6C29F0F /* FalseColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0205F75CD14D96A1E9B884E9 /* FalseColor.swift */; };
 		B0757000000000000000FE02 /* BurstSeriesGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0757000000000000000FE01 /* BurstSeriesGrouping.swift */; };
 		B0757000000000000000FE12 /* ConformPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0757000000000000000FE11 /* ConformPreview.swift */; };
+		B0757000000000000000FE22 /* Magnification.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0757000000000000000FE21 /* Magnification.swift */; };
 		65B3F5B581BF634D6C8247CD /* TrafficLightsMeter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBD5D243C94FA3B8F8BEE3C5 /* TrafficLightsMeter.swift */; };
 		6A455A5E5D850A48FD899BF4 /* AssistToolActivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A371B3334DBAAA71593727B /* AssistToolActivation.swift */; };
 		7182A6D4C55420DE0C30F08E /* CubeLUT.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08D59A4E8FE339FD74256B9 /* CubeLUT.swift */; };
@@ -193,6 +194,7 @@
 		0205F75CD14D96A1E9B884E9 /* FalseColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FalseColor.swift; path = ../Sources/OpenZCineCore/FalseColor.swift; sourceTree = SOURCE_ROOT; };
 		B0757000000000000000FE01 /* BurstSeriesGrouping.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BurstSeriesGrouping.swift; path = ../Sources/OpenZCineCore/BurstSeriesGrouping.swift; sourceTree = SOURCE_ROOT; };
 		B0757000000000000000FE11 /* ConformPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConformPreview.swift; path = ../Sources/OpenZCineCore/ConformPreview.swift; sourceTree = SOURCE_ROOT; };
+		B0757000000000000000FE21 /* Magnification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Magnification.swift; path = ../Sources/OpenZCineCore/Magnification.swift; sourceTree = SOURCE_ROOT; };
 		0E2135AF026E5ECA7A9DD631 /* InternetReachability.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InternetReachability.swift; sourceTree = "<group>"; };
 		1B2C3D4E5F60718293A4B5C6 /* PlaybackAssists.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlaybackAssists.swift; sourceTree = "<group>"; };
 		1E943CC20E05A8C345F7D2A9 /* MonitorLUT.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MonitorLUT.swift; path = ../Sources/OpenZCineCore/MonitorLUT.swift; sourceTree = SOURCE_ROOT; };
@@ -513,6 +515,7 @@
 				0205F75CD14D96A1E9B884E9 /* FalseColor.swift */,
 				B0757000000000000000FE01 /* BurstSeriesGrouping.swift */,
 				B0757000000000000000FE11 /* ConformPreview.swift */,
+				B0757000000000000000FE21 /* Magnification.swift */,
 				D329D509E000B93B59AE9A11 /* ScopeSampler.swift */,
 				D329D509E000B93B59AE9A12 /* AudioLevelMeter.swift */,
 				CF7929C792624D92E4643373 /* FocusAssist.swift */,
@@ -778,6 +781,7 @@
 				503189555B5DB867F6C29F0F /* FalseColor.swift in Sources */,
 				B0757000000000000000FE02 /* BurstSeriesGrouping.swift in Sources */,
 				B0757000000000000000FE12 /* ConformPreview.swift in Sources */,
+				B0757000000000000000FE22 /* Magnification.swift in Sources */,
 				3B2081943B1D2A36C4DA228C /* ScopeSampler.swift in Sources */,
 				3B2081943B1D2A36C4DA228D /* AudioLevelMeter.swift in Sources */,
 				B61762BD19CC1640C62FBF9E /* FocusAssist.swift in Sources */,

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		4D5E6F708192A3B4C5D6E7F8 /* ImageEffectsCompositor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E6F708192A3B4C5D6E7F809 /* ImageEffectsCompositor.swift */; };
 		503189555B5DB867F6C29F0F /* FalseColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0205F75CD14D96A1E9B884E9 /* FalseColor.swift */; };
 		B0757000000000000000FE02 /* BurstSeriesGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0757000000000000000FE01 /* BurstSeriesGrouping.swift */; };
+		B0757000000000000000FE12 /* ConformPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0757000000000000000FE11 /* ConformPreview.swift */; };
 		65B3F5B581BF634D6C8247CD /* TrafficLightsMeter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBD5D243C94FA3B8F8BEE3C5 /* TrafficLightsMeter.swift */; };
 		6A455A5E5D850A48FD899BF4 /* AssistToolActivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A371B3334DBAAA71593727B /* AssistToolActivation.swift */; };
 		7182A6D4C55420DE0C30F08E /* CubeLUT.swift in Sources */ = {isa = PBXBuildFile; fileRef = C08D59A4E8FE339FD74256B9 /* CubeLUT.swift */; };
@@ -191,6 +192,7 @@
 /* Begin PBXFileReference section */
 		0205F75CD14D96A1E9B884E9 /* FalseColor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FalseColor.swift; path = ../Sources/OpenZCineCore/FalseColor.swift; sourceTree = SOURCE_ROOT; };
 		B0757000000000000000FE01 /* BurstSeriesGrouping.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BurstSeriesGrouping.swift; path = ../Sources/OpenZCineCore/BurstSeriesGrouping.swift; sourceTree = SOURCE_ROOT; };
+		B0757000000000000000FE11 /* ConformPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConformPreview.swift; path = ../Sources/OpenZCineCore/ConformPreview.swift; sourceTree = SOURCE_ROOT; };
 		0E2135AF026E5ECA7A9DD631 /* InternetReachability.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InternetReachability.swift; sourceTree = "<group>"; };
 		1B2C3D4E5F60718293A4B5C6 /* PlaybackAssists.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlaybackAssists.swift; sourceTree = "<group>"; };
 		1E943CC20E05A8C345F7D2A9 /* MonitorLUT.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MonitorLUT.swift; path = ../Sources/OpenZCineCore/MonitorLUT.swift; sourceTree = SOURCE_ROOT; };
@@ -510,6 +512,7 @@
 				2B3C4D5E6F708192A3B4C5D6 /* ScopeDisplayScale.swift */,
 				0205F75CD14D96A1E9B884E9 /* FalseColor.swift */,
 				B0757000000000000000FE01 /* BurstSeriesGrouping.swift */,
+				B0757000000000000000FE11 /* ConformPreview.swift */,
 				D329D509E000B93B59AE9A11 /* ScopeSampler.swift */,
 				D329D509E000B93B59AE9A12 /* AudioLevelMeter.swift */,
 				CF7929C792624D92E4643373 /* FocusAssist.swift */,
@@ -774,6 +777,7 @@
 				3C4D5E6F708192A3B4C5D6E7 /* ScopeDisplayScale.swift in Sources */,
 				503189555B5DB867F6C29F0F /* FalseColor.swift in Sources */,
 				B0757000000000000000FE02 /* BurstSeriesGrouping.swift in Sources */,
+				B0757000000000000000FE12 /* ConformPreview.swift in Sources */,
 				3B2081943B1D2A36C4DA228C /* ScopeSampler.swift in Sources */,
 				3B2081943B1D2A36C4DA228D /* AudioLevelMeter.swift in Sources */,
 				B61762BD19CC1640C62FBF9E /* FocusAssist.swift in Sources */,

--- a/ios/Runner/DemoHarness.swift
+++ b/ios/Runner/DemoHarness.swift
@@ -40,6 +40,10 @@ enum DemoHarness {
     static let canvasScopes = flag("ZC_DEMO_CANVAS_SCOPES")
     /// `ZC_DEMO_WIFI_SCANNER=scan|manual` opens the Wi-Fi credential scanner for screenshots.
     static let cameraWiFiScannerMode = value("ZC_DEMO_WIFI_SCANNER")
+    /// `ZC_DEMO_PLAYBACK_CLEAN_VIEW=1` opens the clip player with its chrome already hidden, so
+    /// the clean view and its "tap to show controls" hint can be captured headlessly. Synthetic
+    /// taps do not reach this app, so the state is otherwise only reachable by hand.
+    static let playbackCleanView = flag("ZC_DEMO_PLAYBACK_CLEAN_VIEW")
     /// `ZC_DEMO_CAPTURE_FRAMES=N` dumps the next N live-view frames to disk — see
     /// ``captureLiveViewObject(_:)``.
     static let captureLiveViewFrameCount = value("ZC_DEMO_CAPTURE_FRAMES").flatMap(Int.init)

--- a/ios/Runner/DemoHarness.swift
+++ b/ios/Runner/DemoHarness.swift
@@ -44,10 +44,11 @@ enum DemoHarness {
     /// the clean view and its "tap to show controls" hint can be captured headlessly. Synthetic
     /// taps do not reach this app, so the state is otherwise only reachable by hand.
     static let playbackCleanView = flag("ZC_DEMO_PLAYBACK_CLEAN_VIEW")
-    /// `ZC_DEMO_RATING_SHADE=1` opens the star-rating shade in the clip player, so its OPEN state
-    /// can be captured headlessly. Synthetic taps do not reach this app, so it is otherwise only
-    /// reachable by hand — which is how an empty shade shipped unnoticed.
-    static let ratingShadeOpen = flag("ZC_DEMO_RATING_SHADE")
+    /// `ZC_DEMO_RATING_SHADE=handle|open` mounts the star-rating shade in the clip player without a
+    /// camera session, closed or already open. Both states need capturing: the rating is read from
+    /// the card, so neither is reachable headlessly, and synthetic taps do not reach this app —
+    /// which is how an empty shade shipped unnoticed.
+    static let ratingShade = value("ZC_DEMO_RATING_SHADE")
     /// `ZC_DEMO_CAPTURE_FRAMES=N` dumps the next N live-view frames to disk — see
     /// ``captureLiveViewObject(_:)``.
     static let captureLiveViewFrameCount = value("ZC_DEMO_CAPTURE_FRAMES").flatMap(Int.init)

--- a/ios/Runner/DemoHarness.swift
+++ b/ios/Runner/DemoHarness.swift
@@ -44,6 +44,10 @@ enum DemoHarness {
     /// the clean view and its "tap to show controls" hint can be captured headlessly. Synthetic
     /// taps do not reach this app, so the state is otherwise only reachable by hand.
     static let playbackCleanView = flag("ZC_DEMO_PLAYBACK_CLEAN_VIEW")
+    /// `ZC_DEMO_RATING_SHADE=1` opens the star-rating shade in the clip player, so its OPEN state
+    /// can be captured headlessly. Synthetic taps do not reach this app, so it is otherwise only
+    /// reachable by hand — which is how an empty shade shipped unnoticed.
+    static let ratingShadeOpen = flag("ZC_DEMO_RATING_SHADE")
     /// `ZC_DEMO_CAPTURE_FRAMES=N` dumps the next N live-view frames to disk — see
     /// ``captureLiveViewObject(_:)``.
     static let captureLiveViewFrameCount = value("ZC_DEMO_CAPTURE_FRAMES").flatMap(Int.init)

--- a/ios/Runner/MediaBrowser.swift
+++ b/ios/Runner/MediaBrowser.swift
@@ -3711,9 +3711,13 @@ struct MediaPlayerView: View {
         }
     }
 
+    /// Playback drops the live-only tools. The horizon needs a camera to read, and magnification is
+    /// driven by an on-feed key playback does not mount — offering it here would be a switch with
+    /// nothing behind it.
     private var visiblePlaybackToolbarTools: [MonitorAssistTool] {
         model.preferences.assistToolbarOrder.filter {
-            $0 != .level && model.preferences.isAssistToolbarButtonVisible($0)
+            $0 != .level && $0 != .magnification
+                && model.preferences.isAssistToolbarButtonVisible($0)
         }
     }
 

--- a/ios/Runner/MediaBrowser.swift
+++ b/ios/Runner/MediaBrowser.swift
@@ -2927,13 +2927,6 @@ struct MediaPlayerView: View {
     @State private var zoomContainerSize: CGSize = .zero
     /// Suppresses play/pause tap recognition after pinch, pan, or frame scrub so those gestures do not toggle transport.
     @State private var suppressNextPlaybackTap = false
-    /// Shown for a beat when the clean-view button hides the chrome, so the way back is never a
-    /// guess. Deliberately not the `toastMessage` toast — that one only renders while the chrome
-    /// is up, which is exactly when this is not needed.
-    /// Seeded by the demo hook so the hint is in the headless capture; in the app only
-    /// `enterCleanView()` raises it, and it dismisses itself.
-    @State private var cleanViewHintVisible = DemoHarness.playbackCleanView
-    @State private var cleanViewHintTask: Task<Void, Never>?
     /// Brief play/pause symbol shown centered on the video after a frame tap toggles transport.
     @State private var playbackFlashSymbol: String?
     @State private var playbackFlashVisible = false
@@ -3133,16 +3126,14 @@ struct MediaPlayerView: View {
                     .padding(.bottom, 2)
                 }
                 if chromeVisible { bottomBar }
-                if !chromeVisible && cleanViewHintVisible {
-                    Text("Tap to show controls")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(LiveDesign.text)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 7)
-                        .liquidGlass(in: Capsule(), interactive: false)
-                        .transition(.opacity)
-                        .allowsHitTesting(false)
-                        .accessibilityHidden(true)
+                if !chromeVisible {
+                    // The one control clean view keeps. Every other affordance is hidden, but the
+                    // way back cannot be: the swipe restores it for operators who know the
+                    // gesture, and this is here for everyone who does not.
+                    HStack {
+                        Spacer()
+                        restoreChromeButton
+                    }
                 }
             }
             .padding(.horizontal, 16)
@@ -3396,7 +3387,6 @@ struct MediaPlayerView: View {
                     restoreChrome()
                 } else {
                     // The gesture is for operators who already know it; no hint.
-                    cleanViewHintTask?.cancel()
                     withAnimation(.spring(duration: 0.32)) { chromeVisible = false }
                 }
             }
@@ -3802,6 +3792,28 @@ struct MediaPlayerView: View {
         .accessibilityLabel("Conform preview")
     }
 
+    /// The only control clean view keeps: it brings everything else back.
+    ///
+    /// Deliberately dimmed and small — it has to be findable without competing with the picture,
+    /// which is the whole reason the operator hid the rest.
+    private var restoreChromeButton: some View {
+        Button {
+            restoreChrome()
+        } label: {
+            Image(systemName: "arrow.down.right.and.arrow.up.left")
+                .font(.system(size: PlaybackChrome.actionIconSize, weight: .medium))
+                .foregroundStyle(LiveDesign.text.opacity(0.75))
+                .frame(
+                    width: PlaybackChrome.actionButtonSize.width,
+                    height: PlaybackChrome.actionButtonSize.height
+                )
+                .liquidGlass(in: Circle(), interactive: true)
+                .opacity(0.85)
+        }
+        .buttonStyle(.zcTapTarget)
+        .accessibilityLabel("Show playback controls")
+    }
+
     /// Hides every non-critical control, leaving the frame alone.
     ///
     /// The swipe-down gesture has always done this, but an undisclosed gesture is indistinguishable
@@ -3828,7 +3840,7 @@ struct MediaPlayerView: View {
         }
         .buttonStyle(.zcTapTarget)
         .accessibilityLabel("Hide playback controls")
-        .accessibilityHint("Tap the video to bring them back")
+        .accessibilityHint("A restore control stays in the corner")
     }
 
     private var viewAssistButton: some View {
@@ -4288,8 +4300,6 @@ struct MediaPlayerView: View {
             return
         }
         switch PlaybackFrameTap.action(chromeVisible: chromeVisible, reachedEnd: reachedEnd) {
-        case .restoreChrome:
-            restoreChrome()
         case .restartPlayback:
             restartPlayback()
             showPlaybackFlash(symbol: "play.fill")
@@ -4410,21 +4420,10 @@ struct MediaPlayerView: View {
     /// once-ever tutorial is forgotten long before the one time it is needed.
     private func enterCleanView() {
         withAnimation(.spring(duration: 0.32)) { chromeVisible = false }
-        cleanViewHintTask?.cancel()
-        withAnimation { cleanViewHintVisible = true }
-        cleanViewHintTask = Task {
-            try? await Task.sleep(for: .seconds(1.8))
-            guard !Task.isCancelled else { return }
-            withAnimation { cleanViewHintVisible = false }
-        }
     }
 
     private func restoreChrome() {
-        cleanViewHintTask?.cancel()
-        withAnimation(.spring(duration: 0.32)) {
-            chromeVisible = true
-            cleanViewHintVisible = false
-        }
+        withAnimation(.spring(duration: 0.32)) { chromeVisible = true }
     }
 
     private func showToast(_ message: String) {
@@ -4554,19 +4553,19 @@ private struct PlayerLayerView: UIViewRepresentable {
 /// the simulator — synthetic input does not reach this app — so the alternative to a test is
 /// reading the gesture code and hoping.
 enum PlaybackFrameTap: Equatable {
-    case restoreChrome
     case restartPlayback
     case toggleTransport
 
-    /// A hidden chrome wins over everything else.
+    /// The tap means the same thing whether the chrome is up or hidden — play, pause, or restart
+    /// at the end of a clip. Hiding the controls must not take transport away from the picture.
     ///
-    /// The clean-view button hands the operator a screen with no visible controls, so the tap that
-    /// brings them back cannot also be the tap that plays or pauses. Without this the button would
-    /// create precisely the trap it exists to remove — and it would be a worse trap than the swipe
-    /// gesture ever was, because a gesture nobody knows about is undiscoverable, while a button
-    /// that strands you is inescapable.
+    /// Two earlier attempts got this wrong. The first spent the tap on restoring the chrome, to
+    /// guarantee the clean-view button could not strand anyone — built on a false premise, since
+    /// swipe-up already restored it. The second kept the tap but flashed a hint teaching the
+    /// gesture, which is still a transient answer to a question the operator may ask at any time.
+    /// A small restore control that stays on screen answers it permanently and costs one glyph, so
+    /// the tap is free to mean what it always meant.
     static func action(chromeVisible: Bool, reachedEnd: Bool) -> PlaybackFrameTap {
-        guard chromeVisible else { return .restoreChrome }
-        return reachedEnd ? .restartPlayback : .toggleTransport
+        reachedEnd ? .restartPlayback : .toggleTransport
     }
 }

--- a/ios/Runner/MediaBrowser.swift
+++ b/ios/Runner/MediaBrowser.swift
@@ -2883,7 +2883,7 @@ struct MediaPlayerView: View {
     @State private var conformTarget: Double?
     /// Whether the star-rating shade is pulled down. Deliberately NOT reset per clip: the operator
     /// pulled it open to rate a run of shots, so it stays open across them until pushed back up.
-    @State private var ratingShadeOpen = false
+    @State private var ratingShadeOpen = DemoHarness.ratingShadeOpen
     @State private var timeObserver: Any?
     @State private var endObserver: NSObjectProtocol?
     @State private var reachedEnd = false
@@ -3747,30 +3747,24 @@ struct MediaPlayerView: View {
     /// vanishing, because a missing control reads as a missing feature.
     private var conformButton: some View {
         let availability = ConformPreview.availability(for: conformSource)
+        let rate = conformSource.captureRate ?? 0
         return Menu {
-            Button {
-                conformTarget = nil
-                applyMute()
-                if isPlaying { startPlayback() }
-            } label: {
-                Label("Real time", systemImage: conformTarget == nil ? "checkmark" : "")
-            }
-            ForEach(availability.targets, id: \.self) { target in
-                Button {
-                    conformTarget = target
-                    applyMute()
-                    if isPlaying { startPlayback() }
-                } label: {
-                    Label(
-                        ConformPreview.label(
-                            captureRate: conformSource.captureRate ?? 0, targetRate: target),
-                        systemImage: conformTarget == target ? "checkmark" : "")
+            // A Picker, not hand-rolled rows. The previous version passed an EMPTY SF Symbol name
+            // for unselected items, which is the ragged gap down the left of the menu; a Picker
+            // gets the platform's own selection treatment for free and stays legible.
+            Picker(ConformPreview.menuHeader(captureRate: rate), selection: $conformTarget) {
+                Text("Real time").tag(Double?.none)
+                ForEach(availability.targets, id: \.self) { target in
+                    // Target and speed only — the source rate is in the section header rather than
+                    // repeated on every row, which is what wrapped each row onto two lines.
+                    Text(ConformPreview.targetLabel(captureRate: rate, targetRate: target))
+                        .tag(Double?.some(target))
                 }
             }
+            .pickerStyle(.inline)
             if let reason = availability.unavailableReason {
                 Section { Text(reason) }
-            }
-            if conformTarget != nil {
+            } else if conformTarget != nil {
                 Section { Text(ConformPreview.audioLabel) }
             }
         } label: {
@@ -3797,6 +3791,10 @@ struct MediaPlayerView: View {
         }
         .disabled(!availability.isAvailable)
         .accessibilityLabel("Conform preview")
+        .onChange(of: conformTarget) { _, _ in
+            applyMute()
+            if isPlaying { startPlayback() }
+        }
     }
 
     /// Star rating, pulled down from the top edge and left there until pushed back up.
@@ -3810,12 +3808,16 @@ struct MediaPlayerView: View {
     /// handle is a tap target too, since a tap is easier than a drag on a moving picture.
     @ViewBuilder
     private var ratingShade: some View {
-        VStack(spacing: 6) {
-            if ratingShadeOpen, let stars = playerRatingStars {
+        VStack(spacing: 4) {
+            if ratingShadeOpen {
                 // Written to the card — the camera stays source of truth (the model confirms by
                 // readback). A refusal surfaces the body's response code in a toast rather than
                 // rolling back silently.
-                StarRatingRow(stars: stars) { target in
+                //
+                // Zero when the rating is unknown: `mediaStarRating` returns nil for a clip with no
+                // camera handle or no session, and binding that away rendered an EMPTY shade — the
+                // arrow toggled, nothing appeared, and nothing said why.
+                StarRatingRow(stars: playerRatingStars ?? 0) { target in
                     let previous = playerRatingStars
                     playerRatingStars = target
                     let clip = activeClip
@@ -3828,6 +3830,7 @@ struct MediaPlayerView: View {
                             showToast(message)
                         case .offline:
                             playerRatingStars = previous
+                            showToast("Connect the camera to rate this clip")
                         }
                     }
                 }
@@ -3835,27 +3838,33 @@ struct MediaPlayerView: View {
                 .padding(.vertical, 8)
                 .liquidGlass(in: Capsule(), interactive: false)
             }
+            // A bare chevron says "something is under here" without saying what. The star makes
+            // the handle self-describing, so the pull is discoverable without being used first.
             Button {
                 withAnimation(.spring(duration: 0.32)) { ratingShadeOpen.toggle() }
             } label: {
-                Image(systemName: ratingShadeOpen ? "chevron.up" : "chevron.down")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(LiveDesign.muted)
-                    .frame(width: 44, height: 20)
-                    .contentShape(Rectangle())
-                    .liquidGlass(in: Capsule(), interactive: true)
-                    .opacity(0.9)
+                HStack(spacing: 3) {
+                    Image(systemName: "star.fill")
+                        .font(.system(size: 10, weight: .semibold))
+                    Image(systemName: ratingShadeOpen ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                }
+                .foregroundStyle(LiveDesign.muted)
+                .frame(width: 52, height: 20)
+                .contentShape(Rectangle())
+                .liquidGlass(in: Capsule(), interactive: true)
+                .opacity(0.9)
             }
             .buttonStyle(.zcTapTarget)
             .accessibilityLabel(ratingShadeOpen ? "Hide star rating" : "Show star rating")
         }
-        // Full-width so the pull is a band under the top bar rather than a hunt for the handle.
-        // NOT a separate greedy ZStack child: an earlier attempt at that took the chrome's
-        // horizontal padding with it and clipped the back and favourite buttons off the edges.
         .frame(maxWidth: .infinity)
-        .padding(.top, 6)
+        .padding(.top, -6)
         .contentShape(Rectangle())
-        .gesture(ratingShadePullGesture)
+        // `simultaneousGesture`, not `gesture`: a plain drag recogniser on the container competes
+        // with the handle's Button and can eat the tap, which is the other half of "tapping the
+        // arrow did nothing".
+        .simultaneousGesture(ratingShadePullGesture)
     }
 
     private var ratingShadePullGesture: some Gesture {

--- a/ios/Runner/MediaBrowser.swift
+++ b/ios/Runner/MediaBrowser.swift
@@ -2411,7 +2411,13 @@ struct MediaPhotoViewer: View {
                 GeometryReader { geo in
                     Image(uiImage: image)
                         .resizable()
-                        .aspectRatio(contentMode: .fit)
+                        // Anamorphic stills are judged at their intended geometry; the file is
+                        // never touched. `nil` (de-squeeze off) means the image's own ratio.
+                        .aspectRatio(
+                            desqueezedAspectRatio(
+                                image.size, model.assistConfiguration.desqueeze),
+                            contentMode: .fit
+                        )
                         .frame(width: geo.size.width, height: geo.size.height)
                         .scaleEffect(zoom.scale)
                         .offset(zoom.offset)

--- a/ios/Runner/MediaBrowser.swift
+++ b/ios/Runner/MediaBrowser.swift
@@ -2884,7 +2884,7 @@ struct MediaPlayerView: View {
 
     @State private var isClipReady = false
     @State private var streamPollTask: Task<Void, Never>?
-    @State private var chromeVisible = true
+    @State private var chromeVisible = !DemoHarness.playbackCleanView
     @State private var assistMode = false
     @State private var assistOptionsTool: MonitorAssistTool?
     @State private var playbackBarFrame: CGRect = .zero
@@ -2917,6 +2917,13 @@ struct MediaPlayerView: View {
     @State private var zoomContainerSize: CGSize = .zero
     /// Suppresses play/pause tap recognition after pinch, pan, or frame scrub so those gestures do not toggle transport.
     @State private var suppressNextPlaybackTap = false
+    /// Shown for a beat when the clean-view button hides the chrome, so the way back is never a
+    /// guess. Deliberately not the `toastMessage` toast — that one only renders while the chrome
+    /// is up, which is exactly when this is not needed.
+    /// Seeded by the demo hook so the hint is in the headless capture; in the app only
+    /// `enterCleanView()` raises it, and it dismisses itself.
+    @State private var cleanViewHintVisible = DemoHarness.playbackCleanView
+    @State private var cleanViewHintTask: Task<Void, Never>?
     /// Brief play/pause symbol shown centered on the video after a frame tap toggles transport.
     @State private var playbackFlashSymbol: String?
     @State private var playbackFlashVisible = false
@@ -3116,6 +3123,17 @@ struct MediaPlayerView: View {
                     .padding(.bottom, 2)
                 }
                 if chromeVisible { bottomBar }
+                if !chromeVisible && cleanViewHintVisible {
+                    Text("Tap to show controls")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(LiveDesign.text)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 7)
+                        .liquidGlass(in: Capsule(), interactive: false)
+                        .transition(.opacity)
+                        .allowsHitTesting(false)
+                        .accessibilityHidden(true)
+                }
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 14)
@@ -3364,8 +3382,12 @@ struct MediaPlayerView: View {
                 guard !isFrameScrubbing else { return }
                 let dy = value.translation.height
                 guard abs(dy) > abs(value.translation.width) + 8, abs(dy) > 44 else { return }
-                withAnimation(.spring(duration: 0.32)) {
-                    chromeVisible = dy < 0
+                if dy < 0 {
+                    restoreChrome()
+                } else {
+                    // The gesture is for operators who already know it; no hint.
+                    cleanViewHintTask?.cancel()
+                    withAnimation(.spring(duration: 0.32)) { chromeVisible = false }
                 }
             }
     }
@@ -3653,6 +3675,7 @@ struct MediaPlayerView: View {
                 actionToggle("speaker.slash.fill", "speaker.wave.2.fill", on: isMuted) {
                     toggleMute()
                 }
+                cleanViewButton
                 viewAssistButton
                 shareButton
             }
@@ -3706,6 +3729,35 @@ struct MediaPlayerView: View {
                     }
             }
         }
+    }
+
+    /// Hides every non-critical control, leaving the frame alone.
+    ///
+    /// The swipe-down gesture has always done this, but an undisclosed gesture is indistinguishable
+    /// from a missing feature — so the capability gets a control you can see. The gesture stays for
+    /// operators who already know it.
+    private var cleanViewButton: some View {
+        Button {
+            enterCleanView()
+        } label: {
+            Image(systemName: "arrow.up.left.and.arrow.down.right")
+                .font(.system(size: PlaybackChrome.actionIconSize, weight: .medium))
+                .foregroundStyle(LiveDesign.text)
+                .frame(
+                    width: PlaybackChrome.actionButtonSize.width,
+                    height: PlaybackChrome.actionButtonSize.height
+                )
+                .contentShape(
+                    RoundedRectangle(cornerRadius: DesignTokens.cornerRadius, style: .continuous)
+                )
+                .liquidGlass(
+                    in: RoundedRectangle(
+                        cornerRadius: DesignTokens.cornerRadius, style: .continuous),
+                    interactive: true)
+        }
+        .buttonStyle(.zcTapTarget)
+        .accessibilityLabel("Hide playback controls")
+        .accessibilityHint("Tap the video to bring them back")
     }
 
     private var viewAssistButton: some View {
@@ -4099,6 +4151,7 @@ struct MediaPlayerView: View {
 
     /// Tap on the video frame toggles transport; at end-of-clip restarts from the beginning.
     private func handlePlaybackFrameTap() {
+        // Decision in `PlaybackFrameTap` so it can be tested; the view only performs it.
         guard isClipReady else { return }
         guard deliveryPresentation == nil, assistOptionsTool == nil else { return }
         guard !isFrameScrubbing else { return }
@@ -4106,10 +4159,13 @@ struct MediaPlayerView: View {
             suppressNextPlaybackTap = false
             return
         }
-        if reachedEnd {
+        switch PlaybackFrameTap.action(chromeVisible: chromeVisible, reachedEnd: reachedEnd) {
+        case .restoreChrome:
+            restoreChrome()
+        case .restartPlayback:
             restartPlayback()
             showPlaybackFlash(symbol: "play.fill")
-        } else {
+        case .toggleTransport:
             let willPlay = !isPlaying
             togglePlay()
             showPlaybackFlash(symbol: willPlay ? "play.fill" : "pause.fill")
@@ -4212,6 +4268,29 @@ struct MediaPlayerView: View {
             item.videoComposition != nil
         else { return }
         item.videoComposition = playbackEffectsBox.makeVideoComposition(for: item.asset)
+    }
+
+    /// Hides the chrome and says how to get it back. The hint is shown every time the BUTTON is
+    /// used rather than once ever: it costs nothing to re-read, it is self-limiting (only the
+    /// button raises it, and only the operator who wanted clean view presses that), and a
+    /// once-ever tutorial is forgotten long before the one time it is needed.
+    private func enterCleanView() {
+        withAnimation(.spring(duration: 0.32)) { chromeVisible = false }
+        cleanViewHintTask?.cancel()
+        withAnimation { cleanViewHintVisible = true }
+        cleanViewHintTask = Task {
+            try? await Task.sleep(for: .seconds(1.8))
+            guard !Task.isCancelled else { return }
+            withAnimation { cleanViewHintVisible = false }
+        }
+    }
+
+    private func restoreChrome() {
+        cleanViewHintTask?.cancel()
+        withAnimation(.spring(duration: 0.32)) {
+            chromeVisible = true
+            cleanViewHintVisible = false
+        }
     }
 
     private func showToast(_ message: String) {
@@ -4334,3 +4413,26 @@ private struct PlayerLayerView: UIViewRepresentable {
 }
 
 // MARK: - Supporting views
+
+/// What a tap on the playback frame means.
+///
+/// Lifted out of the view so the rule below is covered by a test. It cannot be checked by driving
+/// the simulator — synthetic input does not reach this app — so the alternative to a test is
+/// reading the gesture code and hoping.
+enum PlaybackFrameTap: Equatable {
+    case restoreChrome
+    case restartPlayback
+    case toggleTransport
+
+    /// A hidden chrome wins over everything else.
+    ///
+    /// The clean-view button hands the operator a screen with no visible controls, so the tap that
+    /// brings them back cannot also be the tap that plays or pauses. Without this the button would
+    /// create precisely the trap it exists to remove — and it would be a worse trap than the swipe
+    /// gesture ever was, because a gesture nobody knows about is undiscoverable, while a button
+    /// that strands you is inescapable.
+    static func action(chromeVisible: Bool, reachedEnd: Bool) -> PlaybackFrameTap {
+        guard chromeVisible else { return .restoreChrome }
+        return reachedEnd ? .restartPlayback : .toggleTransport
+    }
+}

--- a/ios/Runner/MediaBrowser.swift
+++ b/ios/Runner/MediaBrowser.swift
@@ -2881,6 +2881,9 @@ struct MediaPlayerView: View {
     @State private var conformSource = ConformPreview.Source()
     /// The selected conform target, or nil for real-time playback (the default, always).
     @State private var conformTarget: Double?
+    /// Whether the star-rating shade is pulled down. Deliberately NOT reset per clip: the operator
+    /// pulled it open to rate a run of shots, so it stays open across them until pushed back up.
+    @State private var ratingShadeOpen = false
     @State private var timeObserver: Any?
     @State private var endObserver: NSObjectProtocol?
     @State private var reachedEnd = false
@@ -3101,30 +3104,9 @@ struct MediaPlayerView: View {
 
             VStack {
                 if chromeVisible { topBar }
+                if chromeVisible { ratingShade }
                 Spacer()
                 if chromeVisible, let toastMessage { toastView(toastMessage) }
-                if chromeVisible, let stars = playerRatingStars {
-                    // Clip star rating, written to the card — the camera stays source of truth
-                    // (the model confirms by readback). A refusal surfaces the body's response
-                    // code in a toast instead of a silent rollback.
-                    StarRatingRow(stars: stars) { target in
-                        let previous = playerRatingStars
-                        playerRatingStars = target
-                        let clip = activeClip
-                        Task {
-                            switch await model.setMediaStarRating(target, for: clip) {
-                            case .confirmed(let confirmed):
-                                playerRatingStars = confirmed
-                            case .refused(_, let message):
-                                playerRatingStars = previous
-                                showToast(message)
-                            case .offline:
-                                playerRatingStars = previous
-                            }
-                        }
-                    }
-                    .padding(.bottom, 2)
-                }
                 if chromeVisible { bottomBar }
                 if !chromeVisible {
                     // The one control clean view keeps. Every other affordance is hidden, but the
@@ -3559,16 +3541,41 @@ struct MediaPlayerView: View {
     // MARK: Bottom bar (playback transport or inline view-assist)
 
     /// Compact playback chrome — primary controls use 44pt hit targets via `ZCTapTargetButtonStyle`.
-    private enum PlaybackChrome {
-        static let barPaddingH: CGFloat = 12
+    ///
+    /// Sized so the full transport row fits the narrowest supported width. It grew to eight
+    /// controls when the conform preview landed and silently overflowed: an HStack of fixed-size
+    /// children does not compress, so the row widened the whole chrome stack and pushed the TOP
+    /// bar's back and favourite buttons off both screen edges. Visual size only — `.zcTapTarget`
+    /// keeps every hit target at 44pt regardless.
+    enum PlaybackChrome {
+        static let barPaddingH: CGFloat = 10
         static let barPaddingV: CGFloat = 9
-        static let transportRowSpacing: CGFloat = 8
+        static let transportRowSpacing: CGFloat = 5
         static let scrubberRowSpacing: CGFloat = 5
-        static let transportButtonSize = CGSize(width: 40, height: 36)
-        static let actionButtonSize = CGSize(width: 38, height: 36)
+        static let transportButtonSize = CGSize(width: 38, height: 36)
+        static let actionButtonSize = CGSize(width: 32, height: 36)
         static let transportIconSize: CGFloat = 18
         static let primaryTransportIconSize: CGFloat = 22
         static let actionIconSize: CGFloat = 16
+
+        /// Narrowest screen the app ships on (iPhone SE class), in points. The row is checked
+        /// against this in `RunnerTests` so the next control added here fails a test rather than
+        /// silently shoving the top bar off the screen.
+        static let narrowestScreenWidth: CGFloat = 375
+        /// Horizontal padding the chrome stack applies outside the bar.
+        static let chromeHorizontalPadding: CGFloat = 16
+
+        /// Width the transport row needs: three transport buttons, five actions, the gaps between
+        /// them, the bar's own padding, and the minimum spacer.
+        static func transportRowWidth(
+            transportCount: Int = 3, actionCount: Int = 5, minimumSpacer: CGFloat = 6
+        ) -> CGFloat {
+            let buttons =
+                transportButtonSize.width * CGFloat(transportCount)
+                + actionButtonSize.width * CGFloat(actionCount)
+            let gaps = transportRowSpacing * CGFloat(transportCount + actionCount - 1)
+            return buttons + gaps + barPaddingH * 2 + minimumSpacer
+        }
     }
 
     private var bottomBar: some View {
@@ -3670,7 +3677,7 @@ struct MediaPlayerView: View {
                 }
                 transportButton("goforward.15") { seek(by: 15) }
 
-                Spacer(minLength: 12)
+                Spacer(minLength: 6)
 
                 actionToggle("speaker.slash.fill", "speaker.wave.2.fill", on: isMuted) {
                     toggleMute()
@@ -3790,6 +3797,77 @@ struct MediaPlayerView: View {
         }
         .disabled(!availability.isAvailable)
         .accessibilityLabel("Conform preview")
+    }
+
+    /// Star rating, pulled down from the top edge and left there until pushed back up.
+    ///
+    /// It used to sit above the transport, where it cost a permanent band of picture for a control
+    /// that is only wanted while actually rating. Up here it is out of the frame's way, and closed
+    /// it costs a handle.
+    ///
+    /// The handle is not decoration. A pull-down nobody knows about is the same mistake the
+    /// clean-view button exists to correct, so the shade always shows where to grab it — and the
+    /// handle is a tap target too, since a tap is easier than a drag on a moving picture.
+    @ViewBuilder
+    private var ratingShade: some View {
+        VStack(spacing: 6) {
+            if ratingShadeOpen, let stars = playerRatingStars {
+                // Written to the card — the camera stays source of truth (the model confirms by
+                // readback). A refusal surfaces the body's response code in a toast rather than
+                // rolling back silently.
+                StarRatingRow(stars: stars) { target in
+                    let previous = playerRatingStars
+                    playerRatingStars = target
+                    let clip = activeClip
+                    Task {
+                        switch await model.setMediaStarRating(target, for: clip) {
+                        case .confirmed(let confirmed):
+                            playerRatingStars = confirmed
+                        case .refused(_, let message):
+                            playerRatingStars = previous
+                            showToast(message)
+                        case .offline:
+                            playerRatingStars = previous
+                        }
+                    }
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .liquidGlass(in: Capsule(), interactive: false)
+            }
+            Button {
+                withAnimation(.spring(duration: 0.32)) { ratingShadeOpen.toggle() }
+            } label: {
+                Image(systemName: ratingShadeOpen ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(LiveDesign.muted)
+                    .frame(width: 44, height: 20)
+                    .contentShape(Rectangle())
+                    .liquidGlass(in: Capsule(), interactive: true)
+                    .opacity(0.9)
+            }
+            .buttonStyle(.zcTapTarget)
+            .accessibilityLabel(ratingShadeOpen ? "Hide star rating" : "Show star rating")
+        }
+        // Full-width so the pull is a band under the top bar rather than a hunt for the handle.
+        // NOT a separate greedy ZStack child: an earlier attempt at that took the chrome's
+        // horizontal padding with it and clipped the back and favourite buttons off the edges.
+        .frame(maxWidth: .infinity)
+        .padding(.top, 6)
+        .contentShape(Rectangle())
+        .gesture(ratingShadePullGesture)
+    }
+
+    private var ratingShadePullGesture: some Gesture {
+        DragGesture(minimumDistance: 20)
+            .onEnded { value in
+                guard
+                    let open = RatingShadePull.resolve(
+                        verticalDelta: value.translation.height,
+                        horizontalDelta: value.translation.width)
+                else { return }
+                withAnimation(.spring(duration: 0.32)) { ratingShadeOpen = open }
+            }
     }
 
     /// The only control clean view keeps: it brings everything else back.
@@ -4552,6 +4630,29 @@ private struct PlayerLayerView: UIViewRepresentable {
 /// Lifted out of the view so the rule below is covered by a test. It cannot be checked by driving
 /// the simulator — synthetic input does not reach this app — so the alternative to a test is
 /// reading the gesture code and hoping.
+/// The rating shade's pull, as a decision rather than a condition inside a gesture handler.
+///
+/// It has to coexist with the chrome swipe, which already owns vertical drags on the picture
+/// (down hides, up reveals). Resolving that by re-mapping the chrome gesture would break muscle
+/// memory for a control most operators use constantly, so the shade is pulled from the TOP EDGE
+/// instead — the notification-shade idiom, physically where the stars live, and a zone the chrome
+/// gesture never claimed.
+enum RatingShadePull {
+    /// Same thresholds as the chrome swipe, so one hand learns one movement.
+    static let minimumTravel: Double = 44
+    /// A drag must be this much more vertical than horizontal to count, so a scrub does not open it.
+    static let verticalBias: Double = 8
+
+    /// The shade's new state, or `nil` when the drag was too small or too horizontal to mean
+    /// anything — in which case whatever else wanted the gesture keeps it.
+    static func resolve(verticalDelta: Double, horizontalDelta: Double) -> Bool? {
+        guard abs(verticalDelta) > abs(horizontalDelta) + verticalBias,
+            abs(verticalDelta) > minimumTravel
+        else { return nil }
+        return verticalDelta > 0
+    }
+}
+
 enum PlaybackFrameTap: Equatable {
     case restartPlayback
     case toggleTransport

--- a/ios/Runner/MediaBrowser.swift
+++ b/ios/Runner/MediaBrowser.swift
@@ -2877,6 +2877,10 @@ struct MediaPlayerView: View {
     @State private var isMuted = false
     @State private var currentTime: Double = 0
     @State private var duration: Double = 0
+    /// What we managed to learn about the clip's capture rate; drives whether conform is offered.
+    @State private var conformSource = ConformPreview.Source()
+    /// The selected conform target, or nil for real-time playback (the default, always).
+    @State private var conformTarget: Double?
     @State private var timeObserver: Any?
     @State private var endObserver: NSObjectProtocol?
     @State private var reachedEnd = false
@@ -3263,7 +3267,7 @@ struct MediaPlayerView: View {
 
     private func resumePlaybackIfNeeded() {
         if wasPlayingBeforeDelivery {
-            player.play()
+            startPlayback()
             isPlaying = true
             wasPlayingBeforeDelivery = false
         }
@@ -3606,7 +3610,7 @@ struct MediaPlayerView: View {
     private var playbackTransportBar: some View {
         VStack(spacing: 6) {
             HStack(spacing: PlaybackChrome.scrubberRowSpacing) {
-                Text(timeLabel(isScrubbing ? scrubTime : currentTime))
+                Text(conformedLabel(isScrubbing ? scrubTime : currentTime))
                     .font(.system(size: 10, weight: .medium, design: .monospaced))
                     .foregroundStyle(LiveDesign.muted)
                     .frame(width: 40, alignment: .leading)
@@ -3647,12 +3651,12 @@ struct MediaPlayerView: View {
                         isScrubbing = false
                         clearEndStateIfSeeking(to: time)
                         if wasPlayingBeforeScrub {
-                            player.play()
+                            startPlayback()
                             isPlaying = true
                         }
                     }
                 )
-                Text(timeLabel(duration))
+                Text(conformedLabel(duration))
                     .font(.system(size: 10, weight: .medium, design: .monospaced))
                     .foregroundStyle(LiveDesign.muted)
                     .frame(width: 40, alignment: .trailing)
@@ -3681,6 +3685,7 @@ struct MediaPlayerView: View {
                 actionToggle("speaker.slash.fill", "speaker.wave.2.fill", on: isMuted) {
                     toggleMute()
                 }
+                conformButton
                 cleanViewButton
                 viewAssistButton
                 shareButton
@@ -3735,6 +3740,66 @@ struct MediaPlayerView: View {
                     }
             }
         }
+    }
+
+    /// Conform preview: play a high-frame-rate clip at the rate the edit will conform it to.
+    ///
+    /// Real time is the default and always the first item — this is a preview transform, and the
+    /// menu should never leave an operator unsure whether they are looking at the clip or at an
+    /// interpretation of it. When the clip cannot be conformed the control states WHY rather than
+    /// vanishing, because a missing control reads as a missing feature.
+    private var conformButton: some View {
+        let availability = ConformPreview.availability(for: conformSource)
+        return Menu {
+            Button {
+                conformTarget = nil
+                applyMute()
+                if isPlaying { startPlayback() }
+            } label: {
+                Label("Real time", systemImage: conformTarget == nil ? "checkmark" : "")
+            }
+            ForEach(availability.targets, id: \.self) { target in
+                Button {
+                    conformTarget = target
+                    applyMute()
+                    if isPlaying { startPlayback() }
+                } label: {
+                    Label(
+                        ConformPreview.label(
+                            captureRate: conformSource.captureRate ?? 0, targetRate: target),
+                        systemImage: conformTarget == target ? "checkmark" : "")
+                }
+            }
+            if let reason = availability.unavailableReason {
+                Section { Text(reason) }
+            }
+            if conformTarget != nil {
+                Section { Text(ConformPreview.audioLabel) }
+            }
+        } label: {
+            Image(systemName: "timelapse")
+                .font(.system(size: PlaybackChrome.actionIconSize, weight: .medium))
+                .foregroundStyle(
+                    conformTarget != nil
+                        ? LiveDesign.accent
+                        : (availability.isAvailable ? LiveDesign.text : LiveDesign.faint)
+                )
+                .frame(
+                    width: PlaybackChrome.actionButtonSize.width,
+                    height: PlaybackChrome.actionButtonSize.height
+                )
+                .background(
+                    conformTarget != nil ? LiveDesign.accentDim : Color.clear,
+                    in: RoundedRectangle(
+                        cornerRadius: DesignTokens.cornerRadius, style: .continuous)
+                )
+                .liquidGlass(
+                    in: RoundedRectangle(
+                        cornerRadius: DesignTokens.cornerRadius, style: .continuous),
+                    interactive: true)
+        }
+        .disabled(!availability.isAvailable)
+        .accessibilityLabel("Conform preview")
     }
 
     /// Hides every non-critical control, leaving the frame alone.
@@ -4012,7 +4077,7 @@ struct MediaPlayerView: View {
         player.replaceCurrentItem(with: item)
         observePlaybackEnd(for: item)
         player.automaticallyWaitsToMinimizeStalling = false
-        player.isMuted = isMuted
+        player.isMuted = isMuted || conformTarget != nil
         playbackScopeController.stop()
         syncPlaybackScopeSampling()
         Task {
@@ -4020,6 +4085,13 @@ struct MediaPlayerView: View {
                 guard generation == playerLoadGeneration else { return }
                 videoDisplaySize = size
             }
+        }
+        conformTarget = nil
+        conformSource = ConformPreview.Source()
+        Task {
+            let probed = await loadConformSource(from: asset)
+            guard generation == playerLoadGeneration else { return }
+            conformSource = probed
         }
         let interval = CMTime(seconds: isScrubbing ? 0.05 : 0.2, preferredTimescale: 600)
         timeObserver = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { time in
@@ -4037,8 +4109,40 @@ struct MediaPlayerView: View {
         // audio, negligible cost); polling below follows the toggle.
         audioMeterController.attach(to: item)
         syncPlaybackAudioMetering()
-        player.play()
+        startPlayback()
         isPlaying = true
+    }
+
+    /// What the asset can tell us about how it was shot.
+    ///
+    /// The container's nominal rate is all a proxy MP4 carries, so that is the capture rate here —
+    /// with one guard. If the track's own minimum frame duration disagrees with that nominal rate,
+    /// the file is not constant-rate and no single conform factor is correct, so it is marked
+    /// variable and the feature refuses rather than showing a plausible wrong speed.
+    ///
+    /// `isAlreadyConformed` stays false: a file the camera already conformed reports its PLAYBACK
+    /// rate here with nothing generic to distinguish it, so detecting it needs vendor metadata off
+    /// a real high-frame-rate recording. Until that is confirmed on hardware the honest position is
+    /// that we cannot tell, which means an in-camera slow-motion clip would be offered a conform it
+    /// should not be. [verify-on-HW]
+    private func loadConformSource(from asset: AVURLAsset) async -> ConformPreview.Source {
+        guard let track = try? await asset.loadTracks(withMediaType: .video).first else {
+            return ConformPreview.Source()
+        }
+        guard let nominal = try? await track.load(.nominalFrameRate), nominal.isFinite, nominal > 0
+        else { return ConformPreview.Source() }
+        let rate = Double(nominal)
+        guard let minimum = try? await track.load(.minFrameDuration), minimum.isValid,
+            minimum.seconds > 0
+        else {
+            // No per-frame timing to cross-check against; take the nominal rate at face value.
+            return ConformPreview.Source(captureRate: rate)
+        }
+        // A constant-rate track's shortest frame is 1/rate. Anything materially shorter means the
+        // clip runs faster somewhere than its nominal rate claims.
+        let impliedPeak = 1 / minimum.seconds
+        let varies = impliedPeak > rate * 1.05
+        return ConformPreview.Source(captureRate: rate, isVariableFrameRate: varies)
     }
 
     private func teardownPlayer() {
@@ -4152,7 +4256,25 @@ struct MediaPlayerView: View {
 
     private func togglePlay() {
         isPlaying.toggle()
-        isPlaying ? player.play() : player.pause()
+        isPlaying ? startPlayback() : player.pause()
+    }
+
+    /// Real seconds shown on the conformed timeline: a 6 s clip at 40% reads 15 s.
+    private func conformedLabel(_ seconds: Double) -> String {
+        timeLabel(ConformPreview.conformedDuration(sourceSeconds: seconds, speed: conformSpeed))
+    }
+
+    /// Playback rate for the active conform, or 1 in real time.
+    private var conformSpeed: Double {
+        guard let target = conformTarget, let rate = conformSource.captureRate else { return 1 }
+        return ConformPreview.speed(captureRate: rate, targetRate: target)
+    }
+
+    /// Starts playback at the conform rate. Setting a non-zero `rate` IS play, so this replaces
+    /// `player.play()` everywhere — calling `play()` would snap back to 1x and silently drop the
+    /// conform the operator selected.
+    private func startPlayback() {
+        player.rate = Float(conformSpeed)
     }
 
     /// Tap on the video frame toggles transport; at end-of-clip restarts from the beginning.
@@ -4234,7 +4356,7 @@ struct MediaPlayerView: View {
         isFrameScrubbing = false
         clearEndStateIfSeeking(to: scrubTime)
         if wasPlayingBeforeScrub {
-            player.play()
+            startPlayback()
             isPlaying = true
         }
         suppressNextPlaybackTap = true
@@ -4244,7 +4366,7 @@ struct MediaPlayerView: View {
         reachedEnd = false
         currentTime = 0
         player.seek(to: .zero, toleranceBefore: .zero, toleranceAfter: .zero)
-        player.play()
+        startPlayback()
         isPlaying = true
     }
 
@@ -4256,7 +4378,13 @@ struct MediaPlayerView: View {
 
     private func toggleMute() {
         isMuted.toggle()
-        player.isMuted = isMuted
+        applyMute()
+    }
+
+    /// A conform preview forces silence regardless of the mute toggle, so unmuting during one
+    /// cannot produce audio at the wrong speed.
+    private func applyMute() {
+        player.isMuted = isMuted || conformTarget != nil
     }
 
     /// Installs one `AVVideoComposition` per clip; assist toggles only mutate `playbackEffectsBox`.

--- a/ios/Runner/MediaBrowser.swift
+++ b/ios/Runner/MediaBrowser.swift
@@ -3103,8 +3103,19 @@ struct MediaPlayerView: View {
             }
 
             VStack {
-                if chromeVisible { topBar }
-                if chromeVisible { ratingShade }
+                if chromeVisible {
+                    // Handle sits on the top bar's own row, centred between the title and the
+                    // favourite button — the row's middle was dead space.
+                    ZStack {
+                        topBar
+                        if playerRatingStars != nil || DemoHarness.ratingShadeOpen {
+                            ratingShadeHandle
+                        }
+                    }
+                    if ratingShadeOpen, playerRatingStars != nil || DemoHarness.ratingShadeOpen {
+                        ratingStarRow
+                    }
+                }
                 Spacer()
                 if chromeVisible, let toastMessage { toastView(toastMessage) }
                 if chromeVisible { bottomBar }
@@ -3806,87 +3817,65 @@ struct MediaPlayerView: View {
     /// The handle is not decoration. A pull-down nobody knows about is the same mistake the
     /// clean-view button exists to correct, so the shade always shows where to grab it — and the
     /// handle is a tap target too, since a tap is easier than a drag on a moving picture.
+    /// The star row itself, revealed by dragging the handle down.
     @ViewBuilder
-    private var ratingShade: some View {
-        // Nothing at all without a camera-read rating. `mediaStarRating` returns nil when the clip
-        // has no handle or there is no session, i.e. the rating cannot be written either — so the
-        // handle would be advertising a control that could not work. Offering nothing is clearer
-        // than offering zero stars that refuse to stick.
-        // The demo hook stages the shade for headless capture; without it the state is
-        // unreachable, which is how an empty shade shipped once already.
-        if playerRatingStars != nil || DemoHarness.ratingShadeOpen {
-            ratingShadeContent
-        }
-    }
-
-    @ViewBuilder
-    private var ratingShadeContent: some View {
-        VStack(spacing: 4) {
-            if ratingShadeOpen {
-                // Written to the card — the camera stays source of truth (the model confirms by
-                // readback). A refusal surfaces the body's response code in a toast rather than
-                // rolling back silently.
-                //
-                // Zero when the rating is unknown: `mediaStarRating` returns nil for a clip with no
-                // camera handle or no session, and binding that away rendered an EMPTY shade — the
-                // arrow toggled, nothing appeared, and nothing said why.
-                StarRatingRow(stars: playerRatingStars ?? 0) { target in
-                    let previous = playerRatingStars
-                    playerRatingStars = target
-                    let clip = activeClip
-                    Task {
-                        switch await model.setMediaStarRating(target, for: clip) {
-                        case .confirmed(let confirmed):
-                            playerRatingStars = confirmed
-                        case .refused(_, let message):
-                            playerRatingStars = previous
-                            showToast(message)
-                        case .offline:
-                            playerRatingStars = previous
-                            showToast("Connect the camera to rate this clip")
-                        }
-                    }
+    private var ratingStarRow: some View {
+        // Written to the card — the camera stays source of truth (the model confirms by readback).
+        // A refusal surfaces the body's response code rather than rolling back silently.
+        StarRatingRow(stars: playerRatingStars ?? 0) { target in
+            let previous = playerRatingStars
+            playerRatingStars = target
+            let clip = activeClip
+            Task {
+                switch await model.setMediaStarRating(target, for: clip) {
+                case .confirmed(let confirmed):
+                    playerRatingStars = confirmed
+                case .refused(_, let message):
+                    playerRatingStars = previous
+                    showToast(message)
+                case .offline:
+                    playerRatingStars = previous
+                    showToast("Connect the camera to rate this clip")
                 }
-                .padding(.horizontal, 14)
-                .padding(.vertical, 8)
-                .liquidGlass(in: Capsule(), interactive: false)
             }
-            // A bare chevron says "something is under here" without saying what. The star makes
-            // the handle self-describing, so the pull is discoverable without being used first.
-            //
-            // NOT a Button. A Button claims drags that begin inside it, so the handle could only
-            // ever be tapped — a `simultaneousGesture` on the container never saw the drag start.
-            // A plain view with both recognisers lets tap and pull coexist, which is what a handle
-            // is supposed to do.
-            HStack(spacing: 3) {
-                Image(systemName: "star.fill")
-                    .font(.system(size: 10, weight: .semibold))
-                Image(systemName: ratingShadeOpen ? "chevron.up" : "chevron.down")
-                    .font(.system(size: 9, weight: .semibold))
-            }
-            .foregroundStyle(LiveDesign.muted)
-            .frame(width: 52, height: 20)
-            .liquidGlass(in: Capsule(), interactive: true)
-            .opacity(0.9)
-            // Visual height stays 20pt; the touch target is padded out to 44.
-            .padding(.vertical, 12)
-            .contentShape(Rectangle())
-            .onTapGesture {
-                withAnimation(.spring(duration: 0.32)) { ratingShadeOpen.toggle() }
-            }
-            .gesture(ratingShadePullGesture)
-            .accessibilityAddTraits(.isButton)
-            .accessibilityLabel(ratingShadeOpen ? "Hide star rating" : "Show star rating")
         }
-        .frame(maxWidth: .infinity)
-        .padding(.top, -6)
-        .contentShape(Rectangle())
-        // The handle owns the pull now; a second recogniser on the container would only race it.
-        .simultaneousGesture(ratingShadePullGesture)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .liquidGlass(in: Capsule(), interactive: false)
+        .padding(.top, 4)
+        .transition(.move(edge: .top).combined(with: .opacity))
     }
 
-    /// Settles on `onChanged`, not `onEnded`: a pull should follow the finger, and a shade that
-    /// only moves once you let go feels like a button with extra steps — which is what it was.
+    /// Drag-only handle. A bare chevron says "something is under here" without saying what; the
+    /// star makes it self-describing.
+    ///
+    /// Tapping does NOT toggle it. A handle that both taps and drags trains the tap, and the drag —
+    /// the gesture that actually makes this feel like a shade rather than a switch — never gets
+    /// discovered. A tap instead says what to do, which teaches it once at the moment of confusion.
+    private var ratingShadeHandle: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "star.fill")
+                .font(.system(size: 10, weight: .semibold))
+            Image(systemName: ratingShadeOpen ? "chevron.up" : "chevron.down")
+                .font(.system(size: 9, weight: .semibold))
+        }
+        .foregroundStyle(LiveDesign.muted)
+        .frame(width: 52, height: 20)
+        .liquidGlass(in: Capsule(), interactive: true)
+        .opacity(0.9)
+        // Visual height stays 20pt; the touch target is padded out to 44.
+        .padding(.vertical, 12)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            showToast(
+                ratingShadeOpen ? "Drag up to hide the rating" : "Drag down to rate this clip")
+        }
+        .gesture(ratingShadePullGesture)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(ratingShadeOpen ? "Hide star rating" : "Show star rating")
+        .accessibilityHint("Drag down to reveal, up to hide")
+    }
+
     private var ratingShadePullGesture: some Gesture {
         DragGesture(minimumDistance: 6)
             .onChanged { value in

--- a/ios/Runner/MediaBrowser.swift
+++ b/ios/Runner/MediaBrowser.swift
@@ -3808,6 +3808,19 @@ struct MediaPlayerView: View {
     /// handle is a tap target too, since a tap is easier than a drag on a moving picture.
     @ViewBuilder
     private var ratingShade: some View {
+        // Nothing at all without a camera-read rating. `mediaStarRating` returns nil when the clip
+        // has no handle or there is no session, i.e. the rating cannot be written either — so the
+        // handle would be advertising a control that could not work. Offering nothing is clearer
+        // than offering zero stars that refuse to stick.
+        // The demo hook stages the shade for headless capture; without it the state is
+        // unreachable, which is how an empty shade shipped once already.
+        if playerRatingStars != nil || DemoHarness.ratingShadeOpen {
+            ratingShadeContent
+        }
+    }
+
+    @ViewBuilder
+    private var ratingShadeContent: some View {
         VStack(spacing: 4) {
             if ratingShadeOpen {
                 // Written to the card — the camera stays source of truth (the model confirms by
@@ -3840,42 +3853,50 @@ struct MediaPlayerView: View {
             }
             // A bare chevron says "something is under here" without saying what. The star makes
             // the handle self-describing, so the pull is discoverable without being used first.
-            Button {
-                withAnimation(.spring(duration: 0.32)) { ratingShadeOpen.toggle() }
-            } label: {
-                HStack(spacing: 3) {
-                    Image(systemName: "star.fill")
-                        .font(.system(size: 10, weight: .semibold))
-                    Image(systemName: ratingShadeOpen ? "chevron.up" : "chevron.down")
-                        .font(.system(size: 9, weight: .semibold))
-                }
-                .foregroundStyle(LiveDesign.muted)
-                .frame(width: 52, height: 20)
-                .contentShape(Rectangle())
-                .liquidGlass(in: Capsule(), interactive: true)
-                .opacity(0.9)
+            //
+            // NOT a Button. A Button claims drags that begin inside it, so the handle could only
+            // ever be tapped — a `simultaneousGesture` on the container never saw the drag start.
+            // A plain view with both recognisers lets tap and pull coexist, which is what a handle
+            // is supposed to do.
+            HStack(spacing: 3) {
+                Image(systemName: "star.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                Image(systemName: ratingShadeOpen ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
             }
-            .buttonStyle(.zcTapTarget)
+            .foregroundStyle(LiveDesign.muted)
+            .frame(width: 52, height: 20)
+            .liquidGlass(in: Capsule(), interactive: true)
+            .opacity(0.9)
+            // Visual height stays 20pt; the touch target is padded out to 44.
+            .padding(.vertical, 12)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                withAnimation(.spring(duration: 0.32)) { ratingShadeOpen.toggle() }
+            }
+            .gesture(ratingShadePullGesture)
+            .accessibilityAddTraits(.isButton)
             .accessibilityLabel(ratingShadeOpen ? "Hide star rating" : "Show star rating")
         }
         .frame(maxWidth: .infinity)
         .padding(.top, -6)
         .contentShape(Rectangle())
-        // `simultaneousGesture`, not `gesture`: a plain drag recogniser on the container competes
-        // with the handle's Button and can eat the tap, which is the other half of "tapping the
-        // arrow did nothing".
+        // The handle owns the pull now; a second recogniser on the container would only race it.
         .simultaneousGesture(ratingShadePullGesture)
     }
 
+    /// Settles on `onChanged`, not `onEnded`: a pull should follow the finger, and a shade that
+    /// only moves once you let go feels like a button with extra steps — which is what it was.
     private var ratingShadePullGesture: some Gesture {
-        DragGesture(minimumDistance: 20)
-            .onEnded { value in
+        DragGesture(minimumDistance: 6)
+            .onChanged { value in
                 guard
                     let open = RatingShadePull.resolve(
                         verticalDelta: value.translation.height,
-                        horizontalDelta: value.translation.width)
+                        horizontalDelta: value.translation.width),
+                    open != ratingShadeOpen
                 else { return }
-                withAnimation(.spring(duration: 0.32)) { ratingShadeOpen = open }
+                withAnimation(.spring(duration: 0.28)) { ratingShadeOpen = open }
             }
     }
 
@@ -4647,8 +4668,11 @@ private struct PlayerLayerView: UIViewRepresentable {
 /// instead — the notification-shade idiom, physically where the stars live, and a zone the chrome
 /// gesture never claimed.
 enum RatingShadePull {
-    /// Same thresholds as the chrome swipe, so one hand learns one movement.
-    static let minimumTravel: Double = 44
+    /// Shorter than the chrome swipe's 44. That threshold is for a swipe anywhere on the
+    /// picture, where a low bar would fire by accident; this one starts on a 52pt handle the
+    /// operator has deliberately grabbed, so it should give way almost at once — a pull that
+    /// needs 44pt of travel reads as a stuck control.
+    static let minimumTravel: Double = 16
     /// A drag must be this much more vertical than horizontal to count, so a scrub does not open it.
     static let verticalBias: Double = 8
 

--- a/ios/Runner/MediaBrowser.swift
+++ b/ios/Runner/MediaBrowser.swift
@@ -2881,9 +2881,9 @@ struct MediaPlayerView: View {
     @State private var conformSource = ConformPreview.Source()
     /// The selected conform target, or nil for real-time playback (the default, always).
     @State private var conformTarget: Double?
-    /// Whether the star-rating shade is pulled down. Deliberately NOT reset per clip: the operator
-    /// pulled it open to rate a run of shots, so it stays open across them until pushed back up.
-    @State private var ratingShadeOpen = DemoHarness.ratingShadeOpen
+    /// Whether the star-rating shade is open. Deliberately NOT reset per clip: the operator opened
+    /// it to rate a run of shots, so it stays open across them until it is closed again.
+    @State private var ratingShadeOpen = DemoHarness.ratingShade == "open"
     @State private var timeObserver: Any?
     @State private var endObserver: NSObjectProtocol?
     @State private var reachedEnd = false
@@ -3108,11 +3108,11 @@ struct MediaPlayerView: View {
                     // favourite button — the row's middle was dead space.
                     ZStack {
                         topBar
-                        if playerRatingStars != nil || DemoHarness.ratingShadeOpen {
+                        if ratingShadeMounts {
                             ratingShadeHandle
                         }
                     }
-                    if ratingShadeOpen, playerRatingStars != nil || DemoHarness.ratingShadeOpen {
+                    if ratingShadeOpen, ratingShadeMounts {
                         ratingStarRow
                     }
                 }
@@ -3850,47 +3850,35 @@ struct MediaPlayerView: View {
         .transition(.move(edge: .top).combined(with: .opacity))
     }
 
-    /// Drag-only handle. A bare chevron says "something is under here" without saying what; the
-    /// star makes it self-describing.
-    ///
-    /// Tapping does NOT toggle it. A handle that both taps and drags trains the tap, and the drag —
-    /// the gesture that actually makes this feel like a shade rather than a switch — never gets
-    /// discovered. A tap instead says what to do, which teaches it once at the moment of confusion.
-    private var ratingShadeHandle: some View {
-        HStack(spacing: 3) {
-            Image(systemName: "star.fill")
-                .font(.system(size: 10, weight: .semibold))
-            Image(systemName: ratingShadeOpen ? "chevron.up" : "chevron.down")
-                .font(.system(size: 9, weight: .semibold))
-        }
-        .foregroundStyle(LiveDesign.muted)
-        .frame(width: 52, height: 20)
-        .liquidGlass(in: Capsule(), interactive: true)
-        .opacity(0.9)
-        // Visual height stays 20pt; the touch target is padded out to 44.
-        .padding(.vertical, 12)
-        .contentShape(Rectangle())
-        .onTapGesture {
-            showToast(
-                ratingShadeOpen ? "Drag up to hide the rating" : "Drag down to rate this clip")
-        }
-        .gesture(ratingShadePullGesture)
-        .accessibilityAddTraits(.isButton)
-        .accessibilityLabel(ratingShadeOpen ? "Hide star rating" : "Show star rating")
-        .accessibilityHint("Drag down to reveal, up to hide")
+    /// Nothing at all without a camera-read rating: nil means the clip has no handle or there is no
+    /// session, so the rating could not be written either and the handle would advertise a control
+    /// that cannot work.
+    private var ratingShadeMounts: Bool {
+        playerRatingStars != nil || DemoHarness.ratingShade != nil
     }
 
-    private var ratingShadePullGesture: some Gesture {
-        DragGesture(minimumDistance: 6)
-            .onChanged { value in
-                guard
-                    let open = RatingShadePull.resolve(
-                        verticalDelta: value.translation.height,
-                        horizontalDelta: value.translation.width),
-                    open != ratingShadeOpen
-                else { return }
-                withAnimation(.spring(duration: 0.28)) { ratingShadeOpen = open }
+    /// Tap toggles it. A bare chevron says "something is under here" without saying what; the
+    /// star makes it self-describing.
+    ///
+    /// The drag it used to want is gone: pulling a shade down over a moving picture is fussy on a
+    /// handheld rig, and the one gesture that has to stay reliable here is the scrub.
+    private var ratingShadeHandle: some View {
+        Button {
+            withAnimation(.spring(duration: 0.28)) { ratingShadeOpen.toggle() }
+        } label: {
+            HStack(spacing: 3) {
+                Image(systemName: "star.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                Image(systemName: ratingShadeOpen ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
             }
+            .foregroundStyle(LiveDesign.muted)
+            .frame(width: 52, height: 20)
+            .liquidGlass(in: Capsule(), interactive: true)
+            .opacity(0.9)
+        }
+        .buttonStyle(.zcTapTarget)
+        .accessibilityLabel(ratingShadeOpen ? "Hide star rating" : "Show star rating")
     }
 
     /// The only control clean view keeps: it brings everything else back.
@@ -4653,32 +4641,6 @@ private struct PlayerLayerView: UIViewRepresentable {
 /// Lifted out of the view so the rule below is covered by a test. It cannot be checked by driving
 /// the simulator — synthetic input does not reach this app — so the alternative to a test is
 /// reading the gesture code and hoping.
-/// The rating shade's pull, as a decision rather than a condition inside a gesture handler.
-///
-/// It has to coexist with the chrome swipe, which already owns vertical drags on the picture
-/// (down hides, up reveals). Resolving that by re-mapping the chrome gesture would break muscle
-/// memory for a control most operators use constantly, so the shade is pulled from the TOP EDGE
-/// instead — the notification-shade idiom, physically where the stars live, and a zone the chrome
-/// gesture never claimed.
-enum RatingShadePull {
-    /// Shorter than the chrome swipe's 44. That threshold is for a swipe anywhere on the
-    /// picture, where a low bar would fire by accident; this one starts on a 52pt handle the
-    /// operator has deliberately grabbed, so it should give way almost at once — a pull that
-    /// needs 44pt of travel reads as a stuck control.
-    static let minimumTravel: Double = 16
-    /// A drag must be this much more vertical than horizontal to count, so a scrub does not open it.
-    static let verticalBias: Double = 8
-
-    /// The shade's new state, or `nil` when the drag was too small or too horizontal to mean
-    /// anything — in which case whatever else wanted the gesture keeps it.
-    static func resolve(verticalDelta: Double, horizontalDelta: Double) -> Bool? {
-        guard abs(verticalDelta) > abs(horizontalDelta) + verticalBias,
-            abs(verticalDelta) > minimumTravel
-        else { return nil }
-        return verticalDelta > 0
-    }
-}
-
 enum PlaybackFrameTap: Equatable {
     case restartPlayback
     case toggleTransport

--- a/ios/Runner/MonitorExperience.swift
+++ b/ios/Runner/MonitorExperience.swift
@@ -671,8 +671,13 @@ struct InstantReviewOverlay: View {
             ZStack(alignment: .topTrailing) {
                 Color.black
                 GeometryReader { proxy in
+                    // Fit the de-squeezed size rather than scaling after the fit: the AF boxes
+                    // below derive their scale from `fitted`, so de-squeezing here carries them
+                    // with the image instead of leaving them on the squeezed geometry.
                     let fitted = Self.fittedRect(
-                        image: review.image.size, container: proxy.size)
+                        image: desqueezedSize(
+                            review.image.size, model.assistConfiguration.desqueeze),
+                        container: proxy.size)
                     // The stand-in thumb shows blurred; the upgrade animates the blur away
                     // as the full image swaps underneath, reading as one continuous sharpen.
                     Image(uiImage: review.image)

--- a/ios/Runner/MonitorExperience.swift
+++ b/ios/Runner/MonitorExperience.swift
@@ -395,7 +395,18 @@ private struct LiveFrameRaster: View {
             height: height
         )
         .scaleEffect(
-            desqueezeScale(model.assistConfiguration.desqueeze), anchor: .center)
+            desqueezeScale(model.assistConfiguration.desqueeze), anchor: .center
+        )
+        // Punch-in goes LAST, on the settled and framed image — see `Magnification`. Applied here
+        // it scales exactly what the operator is looking at, so punching out lands on the identical
+        // framing and the overlays registered to this layer come along magnified.
+        .scaleEffect(
+            Magnification.scale(
+                factor: model.assistConfiguration.magnification.factor.scale,
+                isActive: model.magnificationActive),
+            anchor: .center
+        )
+        .clipped()
     }
 }
 

--- a/ios/Runner/MonitorOverlays.swift
+++ b/ios/Runner/MonitorOverlays.swift
@@ -719,6 +719,38 @@ func desqueezeScale(_ desqueeze: AssistConfiguration.Desqueeze) -> CGSize {
         : CGSize(width: 1, height: 1 / factor)
 }
 
+/// A still's presented size once de-squeezed: the source with the chosen axis divided out.
+///
+/// Stills cannot use ``desqueezeScale`` the way the live feed does. The feed layer is scaled inside
+/// a fixed rect, but a still is FITTED to its container first, so scaling afterwards would push the
+/// image outside the frame it was just fitted into. De-squeezing the size before the fit keeps the
+/// whole picture on screen and lets everything anchored to the fitted rect — the AF box on instant
+/// review, the zoom transform in the viewer — follow without knowing about anamorphic at all.
+///
+/// Note `orientation` names the axis that is SCALED DOWN (matching ``desqueezeScale``), not the
+/// lens's squeeze axis: vertical letterboxes, horizontal pillarboxes.
+func desqueezedSize(_ size: CGSize, _ desqueeze: AssistConfiguration.Desqueeze) -> CGSize {
+    guard desqueeze.enabled, desqueeze.factor > 1, size.width > 0, size.height > 0 else {
+        return size
+    }
+    let factor = CGFloat(desqueeze.factor)
+    return desqueeze.orientation == .horizontal
+        ? CGSize(width: size.width / factor, height: size.height)
+        : CGSize(width: size.width, height: size.height / factor)
+}
+
+/// ``desqueezedSize`` as an aspect ratio, for the SwiftUI fits that take one. `nil` when
+/// de-squeeze is off, which `aspectRatio(_:contentMode:)` reads as "use the image's own".
+func desqueezedAspectRatio(
+    _ size: CGSize, _ desqueeze: AssistConfiguration.Desqueeze
+) -> CGFloat? {
+    guard desqueeze.enabled, desqueeze.factor > 1, size.width > 0, size.height > 0 else {
+        return nil
+    }
+    let presented = desqueezedSize(size, desqueeze)
+    return presented.width / presented.height
+}
+
 /// The visible (de-squeezed) image rectangle inside the full feed rect — the same centred sub-rect
 /// the scale above produces, so framing overlays land on the de-squeezed image.
 func desqueezedRect(_ full: CGRect, _ desqueeze: AssistConfiguration.Desqueeze) -> CGRect {

--- a/ios/Runner/MonitorPanels.swift
+++ b/ios/Runner/MonitorPanels.swift
@@ -2411,6 +2411,18 @@ struct AssistPanel: View {
                 }
 
                 switch tool {
+                case .magnification:
+                    // Punch-in factor only. The punched-in state itself is driven by the button on
+                    // the feed, not from here — a popup you must reopen to leave a magnified view
+                    // would be worse than no shortcut at all.
+                    SegmentedButtons(
+                        items: AssistConfiguration.Magnification.Factor.allCases.map(\.rawValue),
+                        selected: model.assistConfiguration.magnification.factor.rawValue
+                    ) { value in
+                        if let factor = AssistConfiguration.Magnification.Factor(rawValue: value) {
+                            model.assistConfiguration.magnification.factor = factor
+                        }
+                    }
                 case .guides:
                     SegmentedButtons(
                         items: AssistConfiguration.Guides.Family.allCases.map(\.rawValue),

--- a/ios/Runner/MonitorUnified.swift
+++ b/ios/Runner/MonitorUnified.swift
@@ -1637,6 +1637,42 @@ struct MonitorShell: View {
                         .animation(.easeOut(duration: 0.2), value: y)
                         .transition(.scale(scale: 0.6).combined(with: .opacity))
                 }
+
+                // Punch-in quick key, on the TRAILING side of the same lane so it clears the
+                // recenter/50-50 stack and the camera-settings bar below. One tap in, one tap out —
+                // reopening a popup to leave a magnified view would defeat the point of a focus
+                // check. The filled icon is the active state, which is read off the same flag that
+                // drives the transform, so the two cannot disagree.
+                if Magnification.showsButton(
+                    toolEnabled: model.renderedLiveAssistTools.contains(.magnification))
+                {
+                    let factor = model.assistConfiguration.magnification.factor
+                    Button {
+                        model.magnificationActive.toggle()
+                    } label: {
+                        Image(
+                            systemName: model.magnificationActive
+                                ? "minus.magnifyingglass" : "plus.magnifyingglass"
+                        )
+                        .font(.system(size: 17, weight: .semibold))
+                        .foregroundStyle(
+                            model.magnificationActive ? LiveDesign.accent : LiveDesign.text
+                        )
+                        .frame(width: size, height: size)
+                        .background(.black.opacity(0.55), in: Circle())
+                        .overlay(
+                            Circle().strokeBorder(
+                                model.magnificationActive
+                                    ? LiveDesign.accent : LiveDesign.hairline, lineWidth: 1))
+                    }
+                    .buttonStyle(.zcTapTarget)
+                    .position(x: CGFloat(context.viewportWidth) - 24 - size / 2, y: baseY)
+                    .animation(.easeOut(duration: 0.2), value: baseY)
+                    .transition(.scale(scale: 0.6).combined(with: .opacity))
+                    .accessibilityLabel(
+                        Magnification.buttonLabel(
+                            factor: factor, isActive: model.magnificationActive))
+                }
             }
 
             // MF focus-by-wire scrub: beside the right system rail whenever the operator has

--- a/ios/Runner/MonitorUnified.swift
+++ b/ios/Runner/MonitorUnified.swift
@@ -1435,6 +1435,45 @@ struct MonitorShell: View {
             && !model.interfaceLocked && model.chromeEditorMode == nil
     }
 
+    /// Whether the punch-in quick key mounts. Deliberately independent of the recenter/50-50
+    /// lane: the punch-in has to be reachable even when neither of those keys is up. The two
+    /// trailing clauses are the ones every on-feed key carries.
+    private var magnificationKeyMounts: Bool {
+        Magnification.showsButton(
+            toolEnabled: model.renderedLiveAssistTools.contains(.magnification))
+            && !model.interfaceLocked && model.chromeEditorMode == nil
+    }
+
+    /// The punch-in quick key itself, shared by both orientations so only the seat differs.
+    ///
+    /// One tap in, one tap out — reopening a popup to leave a magnified view would defeat the
+    /// point of a focus check. The icon's active state reads off the same flag that drives the
+    /// transform, so the two cannot disagree.
+    @ViewBuilder private func magnificationKey(size: CGFloat) -> some View {
+        Button {
+            model.magnificationActive.toggle()
+        } label: {
+            Image(
+                systemName: model.magnificationActive
+                    ? "minus.magnifyingglass" : "plus.magnifyingglass"
+            )
+            .font(.system(size: 17, weight: .semibold))
+            .foregroundStyle(model.magnificationActive ? LiveDesign.accent : LiveDesign.text)
+            .frame(width: size, height: size)
+            .background(.black.opacity(0.55), in: Circle())
+            .overlay(
+                Circle().strokeBorder(
+                    model.magnificationActive ? LiveDesign.accent : LiveDesign.hairline,
+                    lineWidth: 1))
+        }
+        .buttonStyle(.zcTapTarget)
+        .transition(.scale(scale: 0.6).combined(with: .opacity))
+        .accessibilityLabel(
+            Magnification.buttonLabel(
+                factor: model.assistConfiguration.magnification.factor,
+                isActive: model.magnificationActive))
+    }
+
     /// The live/clean chrome: full-width info deck and the bottom assist/capture strips. Every
     /// region is per-DISP-mode configuration now — no mode branches here.
     @ViewBuilder private func landscapeChrome(
@@ -1637,42 +1676,20 @@ struct MonitorShell: View {
                         .animation(.easeOut(duration: 0.2), value: y)
                         .transition(.scale(scale: 0.6).combined(with: .opacity))
                 }
+            }
 
-                // Punch-in quick key, on the TRAILING side of the same lane so it clears the
-                // recenter/50-50 stack and the camera-settings bar below. One tap in, one tap out —
-                // reopening a popup to leave a magnified view would defeat the point of a focus
-                // check. The filled icon is the active state, which is read off the same flag that
-                // drives the transform, so the two cannot disagree.
-                if Magnification.showsButton(
-                    toolEnabled: model.renderedLiveAssistTools.contains(.magnification))
-                {
-                    let factor = model.assistConfiguration.magnification.factor
-                    Button {
-                        model.magnificationActive.toggle()
-                    } label: {
-                        Image(
-                            systemName: model.magnificationActive
-                                ? "minus.magnifyingglass" : "plus.magnifyingglass"
-                        )
-                        .font(.system(size: 17, weight: .semibold))
-                        .foregroundStyle(
-                            model.magnificationActive ? LiveDesign.accent : LiveDesign.text
-                        )
-                        .frame(width: size, height: size)
-                        .background(.black.opacity(0.55), in: Circle())
-                        .overlay(
-                            Circle().strokeBorder(
-                                model.magnificationActive
-                                    ? LiveDesign.accent : LiveDesign.hairline, lineWidth: 1))
-                    }
-                    .buttonStyle(.zcTapTarget)
-                    .position(x: CGFloat(context.viewportWidth) - 24 - size / 2, y: baseY)
-                    .animation(.easeOut(duration: 0.2), value: baseY)
-                    .transition(.scale(scale: 0.6).combined(with: .opacity))
-                    .accessibilityLabel(
-                        Magnification.buttonLabel(
-                            factor: factor, isActive: model.magnificationActive))
-                }
+            // Punch-in quick key, on the feed's far edge OPPOSITE the recenter/50-50 lane, level
+            // with it. Landscape stacks those two bottom-left, so the punch-in takes bottom-right.
+            if magnificationKeyMounts {
+                let size: CGFloat = 40
+                let laneY =
+                    map.assistStrip.map { CGFloat($0.frame.y) - 30 }
+                    ?? CGFloat(context.viewportHeight) - 40
+                magnificationKey(size: size)
+                    .position(
+                        x: CGFloat(map.feed.x + map.feed.width) - 10 - size / 2,
+                        y: min(laneY, CGFloat(map.feed.y + map.feed.height) - 10 - size / 2)
+                    )
             }
 
             // MF focus-by-wire scrub: beside the right system rail whenever the operator has
@@ -1999,6 +2016,20 @@ struct MonitorShell: View {
                             - (recenterMounted ? size + 10 : 0)
                     )
                     .transition(.scale(scale: 0.6).combined(with: .opacity))
+            }
+
+            // Punch-in quick key — the portrait counterpart. Portrait's recenter/50-50 lane is
+            // bottom-RIGHT and the collapsed assist rail owns bottom-LEFT, so the punch-in stacks
+            // directly above that rail: still one thumb-reach from the corner, and clear of both.
+            if model.displayMode != .command, magnificationKeyMounts {
+                let size: CGFloat = 40
+                let controlsHeight = map.captureStrip?.frame.height ?? 0
+                let bottomClearance = isFill ? controlsHeight + 10 : 10
+                magnificationKey(size: size)
+                    .offset(
+                        x: feed.x + 10 + size / 2,
+                        y: feed.y + feed.height - bottomClearance - 44 - 10 - size / 2
+                    )
             }
 
             // Bottom system band. The opaque glass draws only when the band still carries a

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -9448,6 +9448,7 @@ extension MonitorAssistTool {
         case .level: "gyroscope"
         case .evMeter: "plusminus"
         case .desqueeze: "arrow.left.and.right"
+        case .magnification: "plus.magnifyingglass"
         case .instantReview: "photo.badge.checkmark"
         }
     }
@@ -9470,6 +9471,7 @@ extension MonitorAssistTool {
         case .level: "Horizon"
         case .evMeter: "EV Meter"
         case .desqueeze: "Desqueeze"
+        case .magnification: "Magnify"
         case .instantReview: "Instant Playback"
         }
     }

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -691,6 +691,9 @@ final class NativeAppModel {
     /// moving it; the camera remains the source of truth, this just suppresses our ChangeAfArea
     /// sends. Session-only.
     var focusPointLocked = false
+    /// Whether the live view is punched in. Transient by design — see `Magnification`; a session
+    /// that restored itself already magnified would read as a broken feed.
+    var magnificationActive = false
     var cameraState = CameraDisplayState.preview
     // Per-frame telemetry (timecode, FPS) is held separately from `cameraState` so updating it
     // never invalidates every view observing the heavy HUD struct — only the readouts re-render.
@@ -8728,6 +8731,12 @@ final class NativeAppModel {
         AssistToolActivation.set(
             tool, visible: visible, context: context, preferences: &preferences,
             configuration: &assistConfiguration)
+        // Switching the tool off cannot leave the feed punched in: the button goes with the tool,
+        // so an armed transform would have no visible control explaining it. `Magnification`
+        // states the rule; this is the only place the tool can be turned off.
+        if tool == .magnification, !visible {
+            magnificationActive = Magnification.activeAfterDisabling()
+        }
         if tool == .instantReview, visible {
             // Arm the post-capture diff with the card's current handles right away.
             seedInstantReviewBaseline()

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,27 +1,27 @@
 New and changed
 
-- Display settings are rebuilt around the three DISP modes, and video and photo keep separate layouts (one switch at the top of the tab). DISP 1 and DISP 2 have an "Edit view" that opens the monitor itself: tap the eye on any element to show or hide it, down to individual readouts and buttons. Anything you hide stays on screen at 30% while you edit, so you can always turn it back on.
-- DISP 2 now offers exactly the same elements as DISP 1, with different defaults: the picture, the side rail, the focus box and the batteries, everything else off. Switch on whatever else you want. The recording tally, the record control while rolling and camera warnings always stay.
-- The focus dial works in video as well as photo. Off by default, in the FOCUS popup; if you already switched it on, it stays on.
-- H.265 8-bit and 10-bit are separate choices: the codec popup shows one H.265 row with 8-bit and 10-bit either side, so you pick the depth directly. Stream Preset and Quality Bias now both read Fast, Balanced, Quality - Quality Bias had only two positions, so the middle grade was unreachable. New installs start on Quality.
-- Playback gains a clean-view button that hides every control, leaving one small button in the corner to bring them back. Swipe and tap-to-pause both still work. High-frame-rate clips can be watched at their edit speed - pick a rate and it shows what you get, e.g. 60 to 24 fps at 40%, audio muted. De-squeeze now works in photo mode: live view, instant playback and the media viewer.
+- Display settings are rebuilt around the three DISP modes, and video and photo keep separate layouts (one switch at the top of the tab). DISP 1 and DISP 2 have an "Edit view" that opens the monitor itself: tap the eye on any element to show or hide it, down to individual readouts and buttons. What you hide stays on screen at 30% while you edit.
+- DISP 2 offers the same elements as DISP 1 with different defaults: picture, side rail, focus box and batteries, everything else off. The recording tally, the record control while rolling and camera warnings always stay.
+- The focus dial works in video as well as photo. Off by default, in the FOCUS popup; if you already switched it on, it stays on. Live view also gains a magnifier: switch it on in the view-assist tools, pick 2x, 3x or 4x, and a key on the picture punches in and back out.
+- H.265 8-bit and 10-bit are separate choices: the codec popup shows one H.265 row with 8-bit and 10-bit either side. Stream Preset and Quality Bias now both read Fast, Balanced, Quality - Quality Bias had only two positions before. New installs start on Quality.
+- Playback gains a clean-view button that hides every control, leaving one small button in the corner to bring them back. Swipe and tap-to-pause both still work. High-frame-rate clips can be watched at their edit speed - pick a rate and it shows what you get, e.g. 60 to 24 fps at 40%, audio muted. De-squeeze now works in photo mode: live view, instant playback and the media viewer. The star rating no longer takes a permanent band of picture: tap the star handle at the top to show the stars, tap again to put them away.
 - Media filters match the tab you are on: Photos offers JPEG, HEIF and NEF, an L/M/S size row, and Today / 7 days / 30 days.
 
 Fixes
 
-- Changes you make on the camera reach the app quickly again. Turning the aperture ring, ISO or shutter on the body used to take up to twenty seconds to show - or in video, never. This was the most-reported problem and the one worth hammering.
+- Changes you make on the camera reach the app quickly again. Turning the aperture ring, ISO or shutter on the body used to take up to twenty seconds to show - or in video, never.
 - Photos shot as HEIF now appear in the media browser at all. The app did not recognise the file type Nikon writes, so every one of them was silently missing from the list.
-- Connecting a second camera no longer changes its settings. Moving between bodies could flip shutter angle back to shutter speed and disturb other settings; connecting is now read-only.
-- Pickers show what your camera actually supports, in the order it uses. Bodies without U1-U3 are no longer offered them, drive modes read Single, CL, CH, CH+, and 3D tracking and subject detection are named apart instead of both reading "Subject".
-- Unplugging the cable or power-cycling the camera used to wedge the app until you force-quit it. Both now recover on their own, or offer you Retry connection and Operator menu on the last frame.
+- Connecting a second camera no longer changes its settings. Moving between bodies could flip shutter angle back to shutter speed; connecting is now read-only.
+- Pickers show what your camera actually supports, in the order it uses. Bodies without U1-U3 are no longer offered them, drive modes read Single, CL, CH, CH+, and 3D tracking and subject detection are named apart.
+- Unplugging the cable or power-cycling the camera used to wedge the app until you force-quit it. Both now recover on their own, or offer Retry connection and Operator menu on the last frame.
 - The first connection attempt no longer needs cancelling and retrying.
 - Command view keeps the timecode running. It used to freeze at whatever the clock read when you switched - convincing, and wrong while rolling.
-- The focus dial no longer stalls and take tap-to-focus down with it, and the media filter popup fits on smaller phones instead of sliding off the edge.
+- The focus dial no longer stalls and takes tap-to-focus down with it, and the media filter popup fits on smaller phones.
 
 What to test
 
-- Open Settings, Display, DISP 2, then Edit view. Hide a few things - a rail key, the focus box, a readout - tap Done (which brings you back to Display), and confirm the live monitor matches. Then check DISP 1 kept its own layout, and that switching Layout For to Photo shows a separate set.
-- On the Photos tab, open Filter: you should see JPEG/HEIF/NEF and L/M/S, not MOV and 6K. If you shoot HEIF, check those frames are actually listed.
+- Open Settings, Display, DISP 2, then Edit view. Hide a few things - a rail key, the focus box, a readout - tap Done and confirm the live monitor matches. Check DISP 1 kept its own layout, and that Layout For > Photo shows a separate set.
+- Switch the magnifier on, set it to 3x, and punch in while pulling focus by hand. Check the picture goes back exactly where it was when you punch out.
+- On the Photos tab, open Filter: you should see JPEG/HEIF/NEF and L/M/S, not MOV and 6K. If you shoot HEIF, check those frames are listed.
 - Turn the aperture ring on the camera while watching IRIS, in video and in photo. It should track you as you turn, close to real time.
-- Connect one body, disconnect, then connect a differently configured one. Nothing on the second camera should change just because you connected.
-- Pull the cable mid-shot and separately switch the camera off and on: both should hold the last frame and offer Retry, and Operator menu should leave straight away.
+- Connect one body, disconnect, then connect a differently configured one: nothing on the second camera should change. Then pull the cable mid-shot, and separately switch the camera off and on - both should hold the last frame and offer Retry.

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -1,11 +1,11 @@
 New and changed
 
-- Display settings are rebuilt around the three DISP modes, and video and photo keep separate layouts (one switch at the top of the tab). DISP 1 and DISP 2 have an "Edit view" that opens the monitor itself: tap the eye on any element - top bar and each of its readouts, focus box, batteries, lock, tool bar, camera values, and record / Media / Settings / DISP individually - to show or hide it. Anything you hide stays on screen at 30% while you edit, so you can always turn it back on.
+- Display settings are rebuilt around the three DISP modes, and video and photo keep separate layouts (one switch at the top of the tab). DISP 1 and DISP 2 have an "Edit view" that opens the monitor itself: tap the eye on any element to show or hide it, down to individual readouts and buttons. Anything you hide stays on screen at 30% while you edit, so you can always turn it back on.
 - DISP 2 now offers exactly the same elements as DISP 1, with different defaults: the picture, the side rail, the focus box and the batteries, everything else off. Switch on whatever else you want. The recording tally, the record control while rolling and camera warnings always stay.
-- The focus dial works in video as well as photo. It is off by default and lives in the FOCUS popup; if you had already switched it on, it stays on.
-- H.265 8-bit and 10-bit are separate choices. When your camera offers both, the codec popup shows one H.265 row with 8-bit and 10-bit either side of it, so you pick the depth directly.
-- Stream Preset and Quality Bias now both read Fast, Balanced, Quality. Quality Bias had only two positions before, so the middle grade your camera offers was unreachable. New installs start on the Quality preset.
-- Media filters match the tab you are on. Photos offers JPEG, HEIF and NEF, an L/M/S size row, and Today, 7 days or 30 days - instead of the video formats and resolutions it used to show.
+- The focus dial works in video as well as photo. Off by default, in the FOCUS popup; if you already switched it on, it stays on.
+- H.265 8-bit and 10-bit are separate choices: the codec popup shows one H.265 row with 8-bit and 10-bit either side, so you pick the depth directly. Stream Preset and Quality Bias now both read Fast, Balanced, Quality - Quality Bias had only two positions, so the middle grade was unreachable. New installs start on Quality.
+- Playback gains a clean-view button that hides every control; tap the picture to bring them back. High-frame-rate clips can be watched at their edit speed - pick a rate and it shows what you get, e.g. 60 to 24 fps at 40%, with audio muted while it runs. De-squeeze now works in photo mode too: live view, instant playback and the media viewer.
+- Media filters match the tab you are on: Photos offers JPEG, HEIF and NEF, an L/M/S size row, and Today / 7 days / 30 days.
 
 Fixes
 

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -4,7 +4,7 @@ New and changed
 - DISP 2 now offers exactly the same elements as DISP 1, with different defaults: the picture, the side rail, the focus box and the batteries, everything else off. Switch on whatever else you want. The recording tally, the record control while rolling and camera warnings always stay.
 - The focus dial works in video as well as photo. Off by default, in the FOCUS popup; if you already switched it on, it stays on.
 - H.265 8-bit and 10-bit are separate choices: the codec popup shows one H.265 row with 8-bit and 10-bit either side, so you pick the depth directly. Stream Preset and Quality Bias now both read Fast, Balanced, Quality - Quality Bias had only two positions, so the middle grade was unreachable. New installs start on Quality.
-- Playback gains a clean-view button that hides every control; tap the picture to bring them back. High-frame-rate clips can be watched at their edit speed - pick a rate and it shows what you get, e.g. 60 to 24 fps at 40%, with audio muted while it runs. De-squeeze now works in photo mode too: live view, instant playback and the media viewer.
+- Playback gains a clean-view button that hides every control, leaving one small button in the corner to bring them back. Swipe and tap-to-pause both still work. High-frame-rate clips can be watched at their edit speed - pick a rate and it shows what you get, e.g. 60 to 24 fps at 40%, audio muted. De-squeeze now works in photo mode: live view, instant playback and the media viewer.
 - Media filters match the tab you are on: Photos offers JPEG, HEIF and NEF, an L/M/S size row, and Today / 7 days / 30 days.
 
 Fixes
@@ -14,8 +14,8 @@ Fixes
 - Connecting a second camera no longer changes its settings. Moving between bodies could flip shutter angle back to shutter speed and disturb other settings; connecting is now read-only.
 - Pickers show what your camera actually supports, in the order it uses. Bodies without U1-U3 are no longer offered them, drive modes read Single, CL, CH, CH+, and 3D tracking and subject detection are named apart instead of both reading "Subject".
 - Unplugging the cable or power-cycling the camera used to wedge the app until you force-quit it. Both now recover on their own, or offer you Retry connection and Operator menu on the last frame.
-- The first connection attempt no longer needs cancelling and retrying before it will work.
-- Command view keeps the timecode running. It used to freeze at whatever the clock read when you switched, which looked convincing and was wrong while rolling.
+- The first connection attempt no longer needs cancelling and retrying.
+- Command view keeps the timecode running. It used to freeze at whatever the clock read when you switched - convincing, and wrong while rolling.
 - The focus dial no longer stalls and take tap-to-focus down with it, and the media filter popup fits on smaller phones instead of sliding off the edge.
 
 What to test


### PR DESCRIPTION
Four operator-facing features, both platforms, plus the fixes that came out of using them.

Closes discussions #262, #260, #261; implements issue #288.

## Clean view in playback (#262)

Playback gets a button that hides every control, and one small dimmed button in the corner that brings them back. The swipe still works — the button is there for the operators who never discovered it. Tap-to-pause survives: hiding the chrome does not cost you the gesture you use most.

## De-squeeze in photo mode (#260)

Anamorphic de-squeeze now reaches every stills surface — live view, instant playback, and the media-page still viewer — with the same presets and 1.00–2.00× custom ratio the cinema path already had. Display only; the camera original and any export are untouched.

## Slow-motion conform preview (#261)

Pick the rate the edit will conform to and watch the clip at that speed, stated in full (`60 → 24 fps · 40%`). Real time stays the default, audio mutes while a conform runs, and the clip itself is never modified. Where the source cannot be trusted — unknown rate, variable frame rate — the control says why rather than showing a plausible wrong speed.

## Live-view magnification (#288)

A view-assist tool with a 2×/3×/4× factor and a key on the picture that punches in and back out.

The transform order is forced rather than chosen: de-squeeze changes the image's *shape* and has to settle first, Fit/Fill then frames it, and magnification scales that settled result about its centre. Applied any earlier, the image would re-fit to a different rectangle and slide sideways as it zoomed. `Magnification.scale` returns exactly `1` when inactive, so punching out lands on framing identical to never having punched in — that identity is what stops repeated toggling from accumulating drift.

Shared policy in `Sources/OpenZCineCore/Magnification.swift`, transcribed by both shells. Playback drops the tool on both platforms: it is driven by an on-feed key playback never mounts, so listing it there would be a switch with nothing behind it (iOS was listing it — fixed here).

## Star rating moves to a shade

The rating used to cost a permanent band of picture above the transport for a control only wanted while actually rating. It now sits at the top: tap the star handle to show the stars, tap again to put them away, and they stay until you do. The handle only appears when a camera is connected, since the rating is written to the card — advertising it otherwise would be a control that cannot work.

It shipped as a pull first and that was wrong: on a handheld rig the pull competes with the scrub, which is the one gesture that has to stay reliable. Tap only.

## Verification

`just check` (1116 tests), `just ios-test`, `just android-check`, `just swift-lint`, demo isolation, and both release-notes gates all green.

Deploy-and-look on the simulator in **both orientations** for every UI change. That is not ceremony here — it caught two real bugs in this branch that compiled and passed tests:

- the magnify key was seated on the *viewport's* trailing edge, which in landscape put it behind the record/settings rail: the tool was on and the transform armed with nothing on screen to press;
- it was also nested inside a battery-cluster branch portrait never takes, and gated on another key already being up.

Both are fixed by giving it its own mount rule and seating it on the *feed's* far edge from the recenter lane — bottom-right in landscape, bottom-left in portrait, where that lane is not.

The demo harness grew `ZC_DEMO_RATING_SHADE=handle|open` for the same reason: the rating is card-read, so with no camera the handle correctly hides entirely, which made its default state invisible to headless capture.

## Not verified

- **No hardware.** The punched-in image itself, and its composition with de-squeeze, Fit/Fill, LUT and peaking at each factor, is unit-tested but has never been seen on a live stream. Tagged `[verify-on-HW]`.
- **No Android device was attached**, so that side is compile- and test-verified only, not deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)