### PR TITLE
fix(relay): a watcher with control can record, and a screen recording stops walking the picture behind

### DIFF
--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/RelayBroadcastController.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/RelayBroadcastController.kt
@@ -305,32 +305,50 @@ class RelayBroadcastController(
         )
     }
 
-    /** Runs a watcher's command on this device's own session — same entry points as local UI. */
+    /**
+     * Runs a watcher's command on this device's own session — same entry points as local UI.
+     *
+     * Deliberately NOT the monitor's record control: the Record Confirmation preference belongs to
+     * whoever pressed the button, and the holder already answered it on their own screen. A prompt
+     * raised here would wait on an operator who is holding the other device, and the take would
+     * never start (iOS shipped exactly that).
+     */
     private fun execute(command: MonitorRelayWire.Command) {
         val session = session ?: return
         scope.launch {
-            when (command) {
-                is MonitorRelayWire.Command.ToggleRecording ->
-                    runCatching {
-                        session.setRecording(
-                            session.recordingState.value != CameraRecordingState.RECORDING
-                        )
+            runCatching {
+                    when (command) {
+                        is MonitorRelayWire.Command.ToggleRecording ->
+                            session.setRecording(
+                                session.recordingState.value != CameraRecordingState.RECORDING
+                            )
+                        is MonitorRelayWire.Command.FocusPoint ->
+                            session.changeAfArea(
+                                CameraFocusPoint(command.cameraX, command.cameraY)
+                            )
+                        is MonitorRelayWire.Command.PickerValue -> {
+                            // The holder's picker write, run on this device's own session through
+                            // the same typed entry point the local drums use — so it is subject to
+                            // every guard and queue a local write is. A word this side has no
+                            // control for is dropped rather than guessed at
+                            // (see [RelayPickerVocabulary]).
+                            val write =
+                                RelayPickerVocabulary.write(command.picker, command.value)
+                            if (write != null) {
+                                session.applyControl(write.control, write.label)
+                            }
+                        }
                     }
-                is MonitorRelayWire.Command.FocusPoint ->
-                    runCatching {
-                        session.changeAfArea(
-                            CameraFocusPoint(command.cameraX, command.cameraY)
-                        )
-                    }
-                is MonitorRelayWire.Command.PickerValue ->
-                    // The holder's picker write, run on this device's own session through the
-                    // same typed entry point the local drums use — so it is subject to every
-                    // guard and queue a local write is. A word this side has no control for is
-                    // dropped rather than guessed at (see [RelayPickerVocabulary]).
-                    RelayPickerVocabulary.write(command.picker, command.value)?.let { write ->
-                        runCatching { session.applyControl(write.control, write.label) }
-                    }
-            }
+                }
+                // A refusal here is invisible on BOTH devices otherwise — the holder sees its
+                // control do nothing and this screen says nothing at all. Closed command
+                // vocabulary only; the exception stays in local logcat, never in a report.
+                .onFailure {
+                    android.util.Log.w(
+                        "RelayHost",
+                        "watcher command refused: ${command.javaClass.simpleName}",
+                    )
+                }
         }
     }
 

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/relay/RelayWatchControllerTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/relay/RelayWatchControllerTest.kt
@@ -26,6 +26,10 @@ import org.json.JSONObject
  * the bounded deadline instead of the decoder-exhaustion path's tens of seconds. Off-device
  * `MediaCodec` construction throws, which the frame source swallows into "fed, decoded
  * nothing" — exactly the black-feed shape the deadline exists to bound.
+ *
+ * ...and the control-holder's record press, which reaches the host as a command over that same
+ * socket. Nothing on this path may ask for a camera session or an operator's confirmation: a
+ * watcher has neither, and the answer it does give was already given on its own screen.
  */
 class RelayWatchControllerTest {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -152,6 +156,57 @@ class RelayWatchControllerTest {
         }
     }
 
+    /**
+     * The watcher half of "the confirmation belongs to whoever pressed the button": a
+     * control-holding watcher's record press leaves the device as a plain command. Nothing on this
+     * path may consult a camera session or the Record Confirmation preference — a watcher has no
+     * session by design, and the prompt was already answered on this screen. iOS shipped exactly
+     * that mistake (field report: granted control, live record button, nothing recorded), so this
+     * is the parity guard, not a spare test.
+     */
+    @Test
+    fun `a control-holding watcher's record press reaches the host as a command`() {
+        LoopbackRelayHost().use { host ->
+            val controller = controller(host)
+            controller.start()
+            val (socket, _) = host.acceptHello()
+            host.send(
+                socket,
+                MonitorRelayWire.Kind.HELLO,
+                MonitorRelayWire.Hello(
+                        version = MonitorRelayWire.VERSION,
+                        hostName = "Host",
+                        cameraName = null,
+                    )
+                    .toJson()
+                    .toString()
+                    .toByteArray(Charsets.UTF_8),
+            )
+            host.send(
+                socket,
+                MonitorRelayWire.Kind.CONTROL_TOKEN,
+                MonitorRelayWire.ControlToken(
+                        holderName = "Test watcher",
+                        holderIsRecipient = true,
+                    )
+                    .toJson()
+                    .toString()
+                    .toByteArray(Charsets.UTF_8),
+            )
+            // Liveness bound only — the grant arrives over a loopback socket, and the controller's
+            // collector runs on a dispatcher shared with the rest of the suite.
+            val holding = runBlocking {
+                withTimeoutOrNull(30_000) { controller.ui.first { it.holdsControl } }
+            }
+            assertTrue(holding != null, "the control token never reached the watcher")
+
+            runBlocking { controller.session.setRecording(true) }
+
+            assertEquals(MonitorRelayWire.Command.ToggleRecording, host.readCommand(socket))
+            runBlocking { controller.stop() }
+        }
+    }
+
     private fun controller(
         host: LoopbackRelayHost,
         deadlineMillis: Long = 6_000L,
@@ -194,6 +249,14 @@ private class LoopbackRelayHost : AutoCloseable {
         return socket to
             MonitorRelayWire.Hello.fromJson(JSONObject(String(payload, Charsets.UTF_8)))
     }
+
+    /** Reads the next message the watcher sends, which must be a command. */
+    fun readCommand(socket: Socket): MonitorRelayWire.Command? =
+        MonitorRelayWire.Command.fromJson(
+            JSONObject(
+                String(readMessage(socket, MonitorRelayWire.Kind.COMMAND), Charsets.UTF_8)
+            )
+        )
 
     fun send(socket: Socket, kind: Int, payload: ByteArray) {
         socket.getOutputStream().apply {

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,5 +1,5 @@
-- New: Share This Feed — other devices watch what you see, and can ask for camera control.
-- New: one camera keeps a setup per way of connecting, including several Wi-Fi networks, each nameable with its own Stream Preset and Quality Bias.
+- Fixed: a watcher granted camera control can now start and stop recording.
+- Fixed: sharing your feed no longer falls behind while the screen is being recorded.
+- New: one camera keeps a setup per way of connecting, each nameable with its own picture settings.
 - New: vertical camera mode, and the mirror assist for a camera facing you.
-- Fixed: the camera is found on subnets it could not be found on before.
-- Fixed: a Wi-Fi connection no longer asks you to join the camera's own network.
+- Fixed: the camera is found on networks it could not be found on before.

--- a/Sources/OpenZCineCore/RelayBitrateAdaptation.swift
+++ b/Sources/OpenZCineCore/RelayBitrateAdaptation.swift
@@ -44,6 +44,53 @@ public enum RelayEncoderProfile: String, CaseIterable, Codable, Equatable, Senda
     }
 }
 
+/// The skip-don't-queue rule applied to a STAGE of the broadcaster's own pipeline rather than to
+/// a viewer's link: how many frames may be inside the stage before new ones are dropped.
+///
+/// The per-viewer window (`RelayEncoderProfile.maxInFlightFramesPerPeer`) bounds the network, and
+/// while the network is the slow part that is the only bound needed. But the broadcaster's encode
+/// is a stage too, and it can become the slow part on its own: an iOS screen recording takes its
+/// share of the same hardware encoder, so the encode drops below the source rate while every
+/// viewer link still reports clear. Handing that stage a frame it has no capacity for is the same
+/// mistake in a different place — the frames are kept, latency accumulates by seconds, and the
+/// picture snaps back to live only when the contention ends and the backlog drains at full speed.
+///
+/// A skipped ENCODE costs no keyframe. The reference chain runs over the frames the encoder
+/// actually saw, so a frame never handed to it leaves no gap: the next encoded frame still
+/// predicts from the last one every viewer already has. (A skipped SEND is the opposite — the
+/// viewer is missing a link it needs, which is why the link layer latches `needsKeyframe`.)
+public struct RelayEncodeLane: Equatable, Sendable {
+    /// Frames inside the stage before the next is dropped.
+    ///
+    /// Two, matching the link layer's low-latency window, for the same reason: one being worked
+    /// on and one behind it. A depth of one would idle the stage between arrivals, so any encode
+    /// running a hair longer than the frame interval would alias the stream to half the source
+    /// rate instead of the ~90% the hardware can still deliver. Two bounds the added latency at
+    /// one frame's work — tens of milliseconds — instead of the unbounded seconds this exists
+    /// to prevent.
+    public static let defaultDepth = 2
+
+    public let depth: Int
+    public private(set) var framesInFlight = 0
+
+    public init(depth: Int = RelayEncodeLane.defaultDepth) {
+        self.depth = max(1, depth)
+    }
+
+    /// Claims the lane for one frame. `false` means SKIP this frame: the stage has not drained,
+    /// and a monitor shows the newest frame or it is not a monitor.
+    public mutating func admit() -> Bool {
+        guard framesInFlight < depth else { return false }
+        framesInFlight += 1
+        return true
+    }
+
+    /// Gives the lane back when the stage finishes. Floored at zero so a stray completion — a
+    /// broadcast stopped mid-frame, an encoder swapped under a live session — cannot lend the
+    /// lane depth it does not have and quietly reopen the unbounded path.
+    public mutating func release() { framesInFlight = max(0, framesInFlight - 1) }
+}
+
 /// Where "the camera feed is starving" begins, given what this session's feed does when the
 /// relay is NOT competing with it.
 ///

--- a/Sources/OpenZCineCore/VideoSource.swift
+++ b/Sources/OpenZCineCore/VideoSource.swift
@@ -53,6 +53,16 @@ public enum VideoSourceKind: String, CaseIterable, Codable, Equatable, Identifia
     public var carriesCameraFrameHeader: Bool { self == .cameraLiveView }
 }
 
+/// What a record press should do on the device that received it.
+public enum RecordPressOutcome: Equatable, Sendable {
+    /// Ask this device's operator first; their answer resumes the press.
+    case confirm
+    /// Run it now.
+    case run
+    /// Refuse — this press would drive this device's own camera, and there is no live view.
+    case needsLiveView
+}
+
 /// What the monitor can truthfully display, given where the picture comes from and whether a
 /// camera control session exists.
 ///
@@ -128,6 +138,30 @@ public struct MonitorDataAvailability: Equatable, Sendable {
     /// round-robin are serviced. Reading a source as "just where the picture comes from" is what
     /// made that easy to miss.
     public var runsCameraFrameLoop: Bool { source == .cameraLiveView && ownsCameraSession }
+
+    /// Resolves a record press: confirm here, run it, or refuse for want of a live view.
+    ///
+    /// The Record Confirmation preference belongs to whoever pressed the button, and is answered
+    /// exactly once. A watcher answers on its own screen and sends an already-answered command, so
+    /// the host must never raise a second prompt — the operator who would answer it is holding the
+    /// other device, and the prompt sits there unseen while the take never starts.
+    ///
+    /// The live-view pre-flight is the owned path's gate alone. A watcher has no session by design
+    /// — it drives the camera by asking the host to — so refusing its press for a session it was
+    /// never meant to have is the same bug from the other end. Whether it may drive the camera at
+    /// all is the control token's question, and the send checks that for itself.
+    ///
+    /// - Parameters:
+    ///   - isRelayedCommand: Whether this press arrived from a watcher rather than from this
+    ///     device's own screen.
+    ///   - liveViewReady: Whether this device could run the record itself right now.
+    public func recordPress(
+        confirmationEnabled: Bool, isRelayedCommand: Bool, liveViewReady: Bool
+    ) -> RecordPressOutcome {
+        if isRelayedCommand { return .run }
+        if source != .relay, !liveViewReady { return .needsLiveView }
+        return confirmationEnabled ? .confirm : .run
+    }
 
     /// Whether a standalone control pump has to run.
     ///

--- a/Tests/OpenZCineCoreTests/RelayBitrateAdaptationTests.swift
+++ b/Tests/OpenZCineCoreTests/RelayBitrateAdaptationTests.swift
@@ -110,3 +110,64 @@ import Testing
     #expect(RelayEncoderProfile.lowLatency.maxInFlightFramesPerPeer == 2)
     #expect(RelayEncoderProfile.quality.maxInFlightFramesPerPeer == 4)
 }
+
+// MARK: The encode lane
+
+/// The field report: an operator starts a screen recording on the broadcasting phone (ReplayKit
+/// takes its share of the same hardware encoder), the watcher's picture falls seconds behind, and
+/// it snaps back to live the instant the recording stops. That snap-back is a queue draining —
+/// frames were being handed to a stage that had not finished the previous one, and every one of
+/// them was kept. The lane is the rule that drops them instead.
+@Test func encodeLanePassesTheNewestFrameNotTheOldest() {
+    var lane = RelayEncodeLane(depth: 1)
+    var encoded: [Int] = []
+    // Frames 1–5 arrive while frame 1 is still inside the encoder.
+    for frame in 1...5 where lane.admit() { encoded.append(frame) }
+    #expect(encoded == [1])
+    lane.release()
+    // The stage drained. The next frame encoded must be the one arriving NOW — not frame 2,
+    // which is what a queue would have kept and what made the watcher run late.
+    for frame in 6...8 where lane.admit() { encoded.append(frame) }
+    #expect(encoded == [1, 6])
+}
+
+/// A source that permanently outruns the drain must not accumulate: the work admitted stays
+/// pinned to the drain's own rate, however long the run is.
+@Test func encodeLaneStaysBoundedWhenTheSourceOutrunsTheDrain() {
+    var lane = RelayEncodeLane(depth: 2)
+    var admitted = 0
+    var peakInFlight = 0
+    for frame in 0..<1_000 {
+        if lane.admit() { admitted += 1 }
+        peakInFlight = max(peakInFlight, lane.framesInFlight)
+        // The drain finishes one frame for every four the source offers.
+        if frame % 4 == 3 { lane.release() }
+    }
+    #expect(peakInFlight == 2)
+    // One admission per completion of the drain (250 of them) plus the depth the lane opened
+    // with, less the final release no frame follows — bounded by the drain, never by the 1000
+    // frames the source offered.
+    #expect(admitted == 251)
+}
+
+@Test func encodeLaneDepthIsTheOnlyThingBetweenFullAndReady() {
+    var lane = RelayEncodeLane(depth: 2)
+    // `#expect` cannot hold a mutating call, so each admission is bound first.
+    let first = lane.admit()
+    let second = lane.admit()
+    let third = lane.admit()
+    #expect(first)
+    #expect(second)
+    #expect(!third)
+    lane.release()
+    let afterDrain = lane.admit()
+    #expect(afterDrain)
+    // Releases with nothing in flight cannot lend the lane extra depth — a stray completion
+    // (a stopped broadcast, a swapped encoder) must not reopen the unbounded door.
+    lane.release()
+    lane.release()
+    lane.release()
+    #expect(lane.framesInFlight == 0)
+    let refilled = (lane.admit(), lane.admit(), lane.admit())
+    #expect(refilled == (true, true, false))
+}

--- a/Tests/OpenZCineCoreTests/VideoSourceTests.swift
+++ b/Tests/OpenZCineCoreTests/VideoSourceTests.swift
@@ -187,6 +187,63 @@ struct VideoSourceTests {
         #expect(watcher.cameraTimecode)
     }
 
+    /// The Record Confirmation preference belongs to whoever pressed the button, and it is answered
+    /// exactly once. The field report it comes from: a watcher was granted control, its record
+    /// button was live, and pressing it never started a take — the press was refused for a session
+    /// a watcher is never meant to have, and on the other side the host raised a second prompt on
+    /// a device nobody was holding.
+    @Test("The record confirmation follows the presser, and is asked once")
+    func recordConfirmationFollowsThePresser() {
+        let holder = MonitorDataAvailability(
+            source: .relay, ownsCameraSession: false, receivesCameraMetadata: true,
+            holdsRelayControl: true)
+        // A watcher has no live view of its own by design — it drives the camera by asking the
+        // host to — so the owned-session pre-flight must not stand between its tap and the send.
+        #expect(
+            holder.recordPress(
+                confirmationEnabled: true, isRelayedCommand: false, liveViewReady: false)
+                == .confirm)
+        #expect(
+            holder.recordPress(
+                confirmationEnabled: false, isRelayedCommand: false, liveViewReady: false)
+                == .run)
+
+        // The host running that watcher's command must not ask again: the operator who would
+        // answer is holding the other device, so the prompt sits unseen and the take never starts.
+        let host = MonitorDataAvailability(
+            source: .cameraLiveView, ownsCameraSession: true, receivesCameraMetadata: true)
+        #expect(
+            host.recordPress(
+                confirmationEnabled: true, isRelayedCommand: true, liveViewReady: true) == .run)
+    }
+
+    /// ...and the local path keeps every gate it had. A press that would drive this device's own
+    /// camera with no live view behind it is still refused, confirmation on or off.
+    @Test("A local record press still needs this device's own live view")
+    func localRecordPressStillNeedsLiveView() {
+        let local = MonitorDataAvailability(
+            source: .cameraLiveView, ownsCameraSession: false, receivesCameraMetadata: false)
+        #expect(
+            local.recordPress(
+                confirmationEnabled: true, isRelayedCommand: false, liveViewReady: false)
+                == .needsLiveView)
+        #expect(
+            local.recordPress(
+                confirmationEnabled: false, isRelayedCommand: false, liveViewReady: false)
+                == .needsLiveView)
+
+        let live = MonitorDataAvailability(
+            source: .cameraLiveView, ownsCameraSession: true, receivesCameraMetadata: true)
+        #expect(
+            live.recordPress(
+                confirmationEnabled: true, isRelayedCommand: false, liveViewReady: true)
+                == .confirm)
+        #expect(
+            live.recordPress(
+                confirmationEnabled: false, isRelayedCommand: false, liveViewReady: true)
+                == .run)
+    }
+
     @Test("The blank display state states nothing it cannot know")
     func blankDisplayState() {
         let blank = CameraDisplayState.blank

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		TEST00000000000000000002 /* ExternalBetaReadinessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00000000000000000001 /* ExternalBetaReadinessTests.swift */; };
 		TEST00000000000000000004 /* NativeCameraEstablishRetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00000000000000000003 /* NativeCameraEstablishRetryTests.swift */; };
 		TEST00000000000000000090 /* ConnectionLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00000000000000000091 /* ConnectionLifecycleTests.swift */; };
+		TEST00000000000000000092 /* RelayRecordControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00000000000000000093 /* RelayRecordControlTests.swift */; };
 		USBC00000000000000000002 /* PTPUSBContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = USBC00000000000000000001 /* PTPUSBContainer.swift */; };
 		USBT00000000000000000002 /* USBCameraTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = USBT00000000000000000001 /* USBCameraTransport.swift */; };
 		RLNK00000000000000000002 /* MonitorRelayLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = RLNK00000000000000000001 /* MonitorRelayLink.swift */; };
@@ -345,6 +346,7 @@
 		TEST00000000000000000001 /* ExternalBetaReadinessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalBetaReadinessTests.swift; sourceTree = "<group>"; };
 		TEST00000000000000000003 /* NativeCameraEstablishRetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeCameraEstablishRetryTests.swift; sourceTree = "<group>"; };
 		TEST00000000000000000091 /* ConnectionLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionLifecycleTests.swift; sourceTree = "<group>"; };
+		TEST00000000000000000093 /* RelayRecordControlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayRecordControlTests.swift; sourceTree = "<group>"; };
 		USBC00000000000000000001 /* PTPUSBContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PTPUSBContainer.swift; path = ../Sources/OpenZCineCore/PTPUSBContainer.swift; sourceTree = SOURCE_ROOT; };
 		USBT00000000000000000001 /* USBCameraTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = USBCameraTransport.swift; sourceTree = "<group>"; };
 		RLNK00000000000000000001 /* MonitorRelayLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorRelayLink.swift; sourceTree = "<group>"; };
@@ -402,6 +404,7 @@
 				TEST00000000000000000001 /* ExternalBetaReadinessTests.swift */,
 				TEST00000000000000000003 /* NativeCameraEstablishRetryTests.swift */,
 				TEST00000000000000000091 /* ConnectionLifecycleTests.swift */,
+				TEST00000000000000000093 /* RelayRecordControlTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -747,6 +750,7 @@
 				TEST00000000000000000002 /* ExternalBetaReadinessTests.swift in Sources */,
 				TEST00000000000000000004 /* NativeCameraEstablishRetryTests.swift in Sources */,
 				TEST00000000000000000090 /* ConnectionLifecycleTests.swift in Sources */,
+				TEST00000000000000000092 /* RelayRecordControlTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/MonitorRelayVideo.swift
+++ b/ios/Runner/MonitorRelayVideo.swift
@@ -119,6 +119,12 @@ final class MonitorRelayVideoEncoder: @unchecked Sendable {
 
     /// Encodes one frame. `completion` receives nil when the encoder is unavailable — the caller
     /// falls back to JPEG rather than dropping the picture.
+    ///
+    /// This queue is a plain FIFO and holds EVERYTHING it is given: it applies no backpressure of
+    /// its own, and it cannot, because only the caller knows which frame is the newest. Callers
+    /// gate on `RelayEncodeLane` — an encoder slowed by anything else on the hardware block (a
+    /// screen recording, most visibly) otherwise banks every frame it is offered and hands the
+    /// watcher a picture that runs later by the second.
     func encode(_ image: CGImage, completion: @escaping @Sendable (EncodedFrame?) -> Void) {
         queue.async { completion(self.encodeSync(image)) }
     }

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -1367,7 +1367,12 @@ final class NativeAppModel {
     ///
     /// Routed through the same entry points the local UI uses rather than a parallel path, so a
     /// relayed record or focus point is subject to every guard, queue and safe point a local one
-    /// is — including the confirmation setting and the interface lock.
+    /// is — including the interface lock.
+    ///
+    /// The one thing that does NOT apply is the operator's confirmation prompt: it belongs to
+    /// whoever pressed the button, the viewer already answered it on its own screen, and a second
+    /// prompt would sit unanswered on a device nobody is holding while the take never starts.
+    /// `applyingRelayCommand` is what tells the shared entry points which press this is.
     private func executeRelayCommand(_ command: MonitorRelayCommand) {
         applyingRelayCommand = true
         defer { applyingRelayCommand = false }
@@ -9591,17 +9596,22 @@ final class NativeAppModel {
 
     func toggleRecording() {
         guard !relayControlSurrendered else { return }
-        if preferences.recordConfirmationEnabled {
-            if !isDemoSession {
-                guard cameraSession != nil, isMonitorPresented else {
-                    connectionMessage = "Start live view before recording."
-                    return
-                }
-            }
+        // Who confirms, and whether the owned-session pre-flight applies at all, is one shared
+        // rule — see `MonitorDataAvailability.recordPress`. Both answers turn on facts this
+        // method used to ignore: that a watcher has no session of its own, and that a relayed
+        // command was already confirmed by the operator who pressed the button.
+        switch monitorAvailability.recordPress(
+            confirmationEnabled: preferences.recordConfirmationEnabled,
+            isRelayedCommand: applyingRelayCommand,
+            liveViewReady: isDemoSession || (cameraSession != nil && isMonitorPresented))
+        {
+        case .confirm:
             pendingRecordConfirmation = !isRecording
-            return
+        case .run:
+            executeRecordToggle()
+        case .needsLiveView:
+            showMonitorNotice("Start live view before recording.")
         }
-        executeRecordToggle()
     }
 
     // MARK: - Still capture (photography mode)
@@ -10885,7 +10895,10 @@ final class NativeAppModel {
             return
         }
         guard cameraSession != nil, isMonitorPresented else {
-            connectionMessage = "Start live view before recording."
+            // The refusal reaches the operator, not just the log — the monitor never renders
+            // `connectionMessage` (see `showMonitorNotice`), so the remote-shutter and watch
+            // presses that land here were refused in silence.
+            showMonitorNotice("Start live view before recording.")
             return
         }
         // Optimistically flip the button now (snappy), then queue the actual record op for the next

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -1032,6 +1032,13 @@ final class NativeAppModel {
     @ObservationIgnored private var latestRelayFrameMetadata: MonitorRelayFrameMetadata?
     /// Hardware HEVC for the outgoing stream; created with broadcasting, torn down with it.
     @ObservationIgnored private var relayVideoEncoder: MonitorRelayVideoEncoder?
+    /// Frames handed to the hardware encoder but not yet returned. The encoder's own queue is a
+    /// plain FIFO with no bound, so nothing below this stops a source that outruns it — see
+    /// `RelayEncodeLane`.
+    @ObservationIgnored private var relayEncodeLane = RelayEncodeLane()
+    /// The same bound for the JPEG degrade path, which compresses off the main actor and is
+    /// therefore just as capable of being handed more frames than it is finishing.
+    @ObservationIgnored private var relayJPEGLane = RelayEncodeLane()
     /// Steps the outgoing bitrate against viewer backpressure; reset with each broadcast.
     @ObservationIgnored private var relayBitrateAdaptation = RelayBitrateAdaptation()
     /// Whether the running advertisement includes peer-to-peer, so a session that later proves
@@ -1504,9 +1511,21 @@ final class NativeAppModel {
             broadcastRelayFrameAsJPEG(image: image, metadata: metadata, host: relayHost)
             return
         }
+        // The encoder is a STAGE, and it falls behind on its own: an iOS screen recording takes
+        // its share of the same hardware block, so the encode drops under the source rate while
+        // every viewer link still reports clear — the skip above never fires, and the encoder's
+        // queue (an unbounded FIFO) keeps every frame. That is the "watcher runs seconds late,
+        // then snaps to live when the recording stops" report: a backlog draining at full speed.
+        // Same rule as the link layer, one layer up — the newest frame wins, the rest are
+        // dropped. Nothing is encoded, so no viewer is missing a reference and no keyframe is
+        // owed. Deliberately NOT fed to the bitrate ladder above: this is contention for the
+        // encoder, not for the channel, and shrinking the stream is not the answer to it.
+        guard relayEncodeLane.admit() else { return }
         relayVideoEncoder.encode(cgImage) { [weak self] encoded in
             Task { @MainActor in
-                guard let self, let relayHost = self.relayHost, self.isRelayBroadcasting else {
+                guard let self else { return }
+                self.relayEncodeLane.release()
+                guard let relayHost = self.relayHost, self.isRelayBroadcasting else {
                     return
                 }
                 guard let encoded else {
@@ -1535,15 +1554,28 @@ final class NativeAppModel {
         image: UIImage, metadata: MonitorRelayFrameMetadata, host: MonitorRelayHost,
         onlyJPEGPeers: Bool = false
     ) {
+        // The same bound as the encoder's, for a differently-shaped version of the same fault:
+        // a detached task per frame does not queue, it RUNS, so a compress slower than the
+        // source multiplies live tasks — each holding a whole frame — until the memory or the
+        // CPU gives. One guard here covers all three callers (no encoder, encoder failed, and
+        // the twin for jpeg-only watchers). The two frames the lane does allow can still finish
+        // in either order, which costs a watcher one frame period; unbounded fan-out bounds that
+        // at nothing at all.
+        guard relayJPEGLane.admit() else { return }
         let handoff = UVCFrameHandoff(image: image)
-        Task.detached(priority: .utility) {
-            guard let jpeg = handoff.image.jpegData(compressionQuality: 0.6) else { return }
-            await MainActor.run {
-                if onlyJPEGPeers {
-                    host.broadcastJPEGFallback(frameMetadata: metadata, image: jpeg)
-                } else {
-                    host.broadcast(frameMetadata: metadata, image: jpeg)
-                }
+        // Awaited FROM the main actor rather than hopping back TO it: the lane is main-actor
+        // state, and a weak reference carried INTO a detached task is task-isolated, which
+        // cannot then be read by a main-actor closure. The compress still runs off the actor.
+        Task { [weak self] in
+            let jpeg = await Task.detached(priority: .utility) {
+                handoff.image.jpegData(compressionQuality: 0.6)
+            }.value
+            self?.relayJPEGLane.release()
+            guard let jpeg else { return }
+            if onlyJPEGPeers {
+                host.broadcastJPEGFallback(frameMetadata: metadata, image: jpeg)
+            } else {
+                host.broadcast(frameMetadata: metadata, image: jpeg)
             }
         }
     }

--- a/ios/RunnerTests/RelayRecordControlTests.swift
+++ b/ios/RunnerTests/RelayRecordControlTests.swift
@@ -1,0 +1,51 @@
+import Testing
+
+@testable import Runner
+
+/// Who answers the Record Confirmation prompt, when a second device is driving the camera.
+///
+/// The field report behind this: a watcher was granted control, its record button was live, and
+/// pressing it did nothing at all. The preference is on by default, so this is what every pair of
+/// devices hit on the first take.
+@Suite("Relayed record control")
+struct RelayRecordControlTests {
+
+    /// The watcher's own press must reach the relay send. It has no camera session by design — it
+    /// drives the camera by asking the host to — so the owned-session pre-flight is not its gate.
+    /// Refusing there swallowed the press before the send, with a message the watcher never shows.
+    @MainActor
+    @Test("A watcher holding control confirms its own record press instead of being refused")
+    func watcherRecordPressRaisesItsOwnConfirmation() {
+        let model = NativeAppModel()
+        // Set rather than trust: `NativeAppModel()` loads the persisted preferences, so a stored
+        // value from a previous run would decide the outcome instead of the default.
+        model.preferences = OperatorPreferences.defaults
+        #expect(model.preferences.recordConfirmationEnabled, "the default this bug rides on")
+        model.videoSource = .relay
+        model.relayHoldsControl = true
+        #expect(
+            model.monitorAvailability.recordControl, "a control holder mounts the record button")
+
+        model.toggleRecording()
+
+        // The prompt the watcher answers is the alert mounted on that record button.
+        #expect(model.pendingRecordConfirmation == true)
+
+        model.confirmRecordToggle()
+        #expect(model.pendingRecordConfirmation == nil, "the answer is consumed, not left pending")
+    }
+
+    /// The other half of the same rule, from the local side: a press on a device that would have to
+    /// drive its OWN camera is still refused without a session. Nothing here loosens that.
+    @MainActor
+    @Test("A local press with no camera session is still refused")
+    func localRecordPressWithoutASessionIsStillRefused() {
+        let model = NativeAppModel()
+        model.preferences = OperatorPreferences.defaults
+
+        model.toggleRecording()
+
+        #expect(model.pendingRecordConfirmation == nil)
+        #expect(!model.isRecording)
+    }
+}

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -12,8 +12,8 @@ Fixes
 - The camera is found on networks it could not be found on before, including one whose address sits on a different subnet from your phone's.
 - Scanned Wi-Fi details can be corrected. If OCR misreads a character in the network name or the key, tap either and fix it instead of starting over.
 - A Wi-Fi connection no longer asks you to join the camera's own network, and saved setups no longer read as offline while you are on that network.
-- A weak or busy link degrades the picture instead of dropping the session.
-- Arming the Bluetooth shutter no longer sets your phone to half volume.
+- A weak or busy link degrades the picture instead of dropping the session, and screen recording while you share your feed no longer walks the watcher's picture behind the action.
+- A watcher granted camera control can now start and stop the take. The record confirmation is asked once, on the device you pressed the button on.
 - The occasional single bright frame in live view should be gone. Please report it if you still see one.
 - Changes made on the camera reach the app quickly again - the aperture ring, ISO or shutter used to take twenty seconds, or in video never.
 - Unplugging the cable or power-cycling the camera used to wedge the app. Both recover on their own, or offer Retry connection.
@@ -22,6 +22,6 @@ What to test
 
 - Save the same body on two different Wi-Fi networks. Each should stay its own setup with its own Stream Preset and Quality Bias, and renaming one should not touch the other.
 - Turn the camera on its side, in video and in photo. The picture should stay upright and the controls should still be reachable.
-- Turn on Share This Feed on a connected device, open the app on a second one, and ask for control from the watcher.
+- Turn on Share This Feed, ask for control from the second device, and start a take from it. Then screen-record on the sharing device and check the watcher stays with the action.
 - Watch a dim high-ISO shot with Feed Noise Reduction on and off, then step the Feed Upscaler through Fast, Quality and AI on the same framing.
 - Pair a camera by scanning its screen, and deliberately correct a character in the key before connecting.


### PR DESCRIPTION
Two faults a watcher hits, found from one session of field reports. They are
independent, and both were verified on hardware before this PR.

## A watcher granted control could not start the take

The Record Confirmation preference (on by default) was being applied to
*relayed* commands, where it makes no sense — the operator who would answer the
prompt is not the one who pressed the button. It broke in two places:

- The iOS watcher's own tap died on an owned-session pre-flight
  (`guard cameraSession != nil`) before ever reaching the relay send. A watcher
  has no session by design; the host runs it.
- An iOS broadcaster re-confirmed the command, raising a "Start recording?"
  dialog on a device nobody is holding. This half is why an **Android** watcher
  hit the bug too.

The rule now lives once, in the shared core as
`MonitorDataAvailability.recordPress`: a relayed command runs, a local press
keeps its live-view gate, and the confirmation follows whoever pressed the
button and is asked exactly once. The refusal also stops writing to
`connectionMessage`, which the monitor never renders — a watcher that genuinely
cannot record now says so out loud, which matters more here than usual: a
silent failure to roll is worse than a refusal.

## The relay fell seconds behind under screen recording, then snapped back

The skip-don't-queue rule was applied to the sockets but not to the encoder
above them. iOS screen recording contends for the same hardware encoder, so the
encode drops below the source rate while every viewer link still reports clear
— the existing `peersFull` skip never fires, because it only counts frames that
already came *through* the encoder. The frames pile up in an unbounded dispatch
queue nothing was watching, then drain at full speed when the contention ends.

`RelayEncodeLane` caps that stage at two frames, so the newest wins. Two rather
than one: a depth of one idles the stage between arrivals, and any encode
running a hair longer than the frame interval would alias the stream to half the
source rate — an aliasing failure this repo has already eaten once on the pacing
gate. The JPEG degrade path had the same fault in a different shape, since
`Task.detached` per frame does not queue, it multiplies, and is capped too.

A skipped encode owes no keyframe: the reference chain runs over frames the
encoder actually saw, so one never handed to it leaves no gap. That is the
opposite of a skipped send, where the peer really is missing a link — which is
why only that path latches `needsKeyframe`.

## Android

Neither fix is needed there, and this was verified rather than assumed. The
watcher path was already correct end to end. The broadcaster has no encoder
stage at all: camera JPEG bytes pass through untouched, the frame pump is a
single sequential collect over `shareIn(replay: 1)` which conflates, and the
peer channel is already a bounded `DROP_OLDEST` — newest-wins, stricter than the
iOS skip. Kotlin twin tests pin the watcher rule regardless, and one was proven
load-bearing by breaking the gate it guards and watching it fail.

## Gates

`just check` (1317 tests) · `just native-check` · `just android-check` ·
`just secrets` · `just hygiene` — all green on the merged tree, not just on each
half.

## Known gaps

- The Android **host** half has no unit test: `RelayBroadcastController` needs a
  real `NsdManager` and the app module has no Robolectric. A doc note on
  `execute()` guards it.
- Its swallowed-exception fix is a logcat line rather than a diagnostics closed
  code, because the controller has no store handle and reaching one is real
  plumbing for a nice-to-have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
