### PR TITLE
fix(feed): the noise filter stops handing VideoToolbox a reference it never had

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		TEST00000000000000000004 /* NativeCameraEstablishRetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00000000000000000003 /* NativeCameraEstablishRetryTests.swift */; };
 		TEST00000000000000000090 /* ConnectionLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00000000000000000091 /* ConnectionLifecycleTests.swift */; };
 		TEST00000000000000000092 /* RelayRecordControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00000000000000000093 /* RelayRecordControlTests.swift */; };
+		TEST00000000000000000094 /* LiveFeedNoiseFilterWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00000000000000000095 /* LiveFeedNoiseFilterWindowTests.swift */; };
 		USBC00000000000000000002 /* PTPUSBContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = USBC00000000000000000001 /* PTPUSBContainer.swift */; };
 		USBT00000000000000000002 /* USBCameraTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = USBT00000000000000000001 /* USBCameraTransport.swift */; };
 		RLNK00000000000000000002 /* MonitorRelayLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = RLNK00000000000000000001 /* MonitorRelayLink.swift */; };
@@ -347,6 +348,7 @@
 		TEST00000000000000000003 /* NativeCameraEstablishRetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeCameraEstablishRetryTests.swift; sourceTree = "<group>"; };
 		TEST00000000000000000091 /* ConnectionLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionLifecycleTests.swift; sourceTree = "<group>"; };
 		TEST00000000000000000093 /* RelayRecordControlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayRecordControlTests.swift; sourceTree = "<group>"; };
+		TEST00000000000000000095 /* LiveFeedNoiseFilterWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveFeedNoiseFilterWindowTests.swift; sourceTree = "<group>"; };
 		USBC00000000000000000001 /* PTPUSBContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PTPUSBContainer.swift; path = ../Sources/OpenZCineCore/PTPUSBContainer.swift; sourceTree = SOURCE_ROOT; };
 		USBT00000000000000000001 /* USBCameraTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = USBCameraTransport.swift; sourceTree = "<group>"; };
 		RLNK00000000000000000001 /* MonitorRelayLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorRelayLink.swift; sourceTree = "<group>"; };
@@ -405,6 +407,7 @@
 				TEST00000000000000000003 /* NativeCameraEstablishRetryTests.swift */,
 				TEST00000000000000000091 /* ConnectionLifecycleTests.swift */,
 				TEST00000000000000000093 /* RelayRecordControlTests.swift */,
+				TEST00000000000000000095 /* LiveFeedNoiseFilterWindowTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -751,6 +754,7 @@
 				TEST00000000000000000004 /* NativeCameraEstablishRetryTests.swift in Sources */,
 				TEST00000000000000000090 /* ConnectionLifecycleTests.swift in Sources */,
 				TEST00000000000000000092 /* RelayRecordControlTests.swift in Sources */,
+				TEST00000000000000000094 /* LiveFeedNoiseFilterWindowTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/FrameDecoder.swift
+++ b/ios/Runner/FrameDecoder.swift
@@ -483,7 +483,17 @@ final class LiveFeedNoiseFilter {
     private var processorBox: AnyObject?
     private var destinationPool: CVPixelBufferPool?
     private var key: (width: Int, height: Int, format: OSType)?
-    private var previous: CVPixelBuffer?
+    /// Frames already denoised, kept as the filter's view of the PAST.
+    ///
+    /// A window, not a slot. This was one buffer and the processor was handed
+    /// `previous.map { [$0] } ?? []` — at most one reference — while the configuration's
+    /// `previousFrameCount` was never read at all. Hand a temporal filter fewer references than
+    /// it was configured for and it builds its internal frame list with a hole in it, and a hole
+    /// there is `-[__NSArrayM insertObject:atIndex:] object cannot be nil`: an ObjC exception
+    /// from inside VideoToolbox, which Swift cannot catch, so the app is gone.
+    private var past: [CVPixelBuffer] = []
+    /// How many past frames the processor says it needs (`previousFrameCount`).
+    private var previousFrameCount = 0
     private var frameCount: Int64 = 0
     private var unavailable = false
     private lazy var commandQueue = MTLCreateSystemDefaultDevice()?.makeCommandQueue()
@@ -539,10 +549,34 @@ final class LiveFeedNoiseFilter {
     /// Forgets a latched refusal and the frame history behind it.
     func reset() {
         unavailable = false
-        previous = nil
+        past.removeAll()
         pending.removeAll()
         key = nil
         report = "idle"
+    }
+
+    /// Whether the processor may be given this pair of reference windows.
+    ///
+    /// Pure so the invariant that killed a shipped build can be tested without a media engine:
+    /// a temporal processor configured for N past and M future frames must be handed exactly N
+    /// and exactly M. Given fewer it does not denoise less, it inserts nil into its own frame
+    /// list and throws from Objective-C, where Swift cannot catch it.
+    static func canRun(
+        past: Int, previousWanted: Int, futures: Int, futureWanted: Int
+    ) -> Bool {
+        past == previousWanted && futures == futureWanted
+    }
+
+    /// Keeps the past window at exactly the length the processor was configured for.
+    private func rememberPast(_ frame: CVPixelBuffer) {
+        guard previousFrameCount > 0 else {
+            past.removeAll()
+            return
+        }
+        past.append(frame)
+        if past.count > previousFrameCount {
+            past.removeFirst(past.count - previousFrameCount)
+        }
     }
 
     /// Denoises `frame`, or returns nil to leave the caller with what it already had.
@@ -591,10 +625,22 @@ final class LiveFeedNoiseFilter {
             // The oldest queued frame is the one being denoised; everything after it is future.
             let current = pending.removeFirst()
             let futures = Array(pending.prefix(futureWanted))
-            let pastFrames = previous.map { [$0] } ?? []
-            guard !pastFrames.isEmpty || !futures.isEmpty else {
-                previous = current
-                report = "seeding"
+            let pastFrames = past
+            // BOTH windows exactly as configured, or the filter does not run.
+            //
+            // It used to run on whatever it had, needing only one reference of either kind. That
+            // is not a weaker denoise, it is a contract violation: the processor was configured
+            // for `previousFrameCount` past frames and given fewer, and it fills the gap in its
+            // own frame list with nil. The first frame after any reconfigure or restart had an
+            // empty past window and went straight through this — which is why a session could run
+            // for a quarter of an hour and then die at the moment something restarted it.
+            guard
+                Self.canRun(
+                    past: pastFrames.count, previousWanted: previousFrameCount,
+                    futures: futures.count, futureWanted: futureWanted)
+            else {
+                rememberPast(current)
+                report = "seeding (\(pastFrames.count)/\(previousFrameCount) past)"
                 return nil
             }
 
@@ -654,7 +700,7 @@ final class LiveFeedNoiseFilter {
                 _ = disable("the model failed (\((error as NSError).code))")
                 return nil
             }
-            previous = current
+            rememberPast(current)
             report = "ran \(fourCCName(size.format)) ±\(pastFrames.count)/\(futures.count)"
             return destination
         #endif
@@ -723,6 +769,12 @@ final class LiveFeedNoiseFilter {
             // focus monitor, and the operator agreed to spend it, not to spend an unbounded
             // amount of it if a future OS raises the number.
             nextFrameCount = min(configuration.nextFrameCount ?? 0, 2)
+            // Read, not assumed. Future frames are clamped because each one is latency the
+            // operator agreed to spend; past frames cost only memory, so this takes the number
+            // the processor asks for. Different silicon asks for different numbers — which is how
+            // this arrived as a crash on one iPad model and nowhere else.
+            previousFrameCount = max(0, configuration.previousFrameCount ?? 0)
+            past.removeAll()
             pending.removeAll()
             guard
                 let pool = LiveFeedSuperResolution.pool(
@@ -752,7 +804,7 @@ final class LiveFeedNoiseFilter {
             destinationPool = pool
             // A new session owns a new history: references from the old one describe a stream
             // this processor never saw.
-            previous = nil
+            past.removeAll()
             pending.removeAll()
             key = size
             log.info(

--- a/ios/RunnerTests/LiveFeedNoiseFilterWindowTests.swift
+++ b/ios/RunnerTests/LiveFeedNoiseFilterWindowTests.swift
@@ -1,0 +1,52 @@
+import Testing
+
+@testable import Runner
+
+/// The crash this pins: TestFlight 0.2.5 (253) on an iPad16,5 died with
+/// `-[__NSArrayM insertObject:atIndex:]: object cannot be nil` thrown from inside
+/// `-[VTFrameProcessor processWithCommandBuffer:parameters:]`. The filter honoured the
+/// configuration's future-frame count and never read its PAST-frame count, so it handed the
+/// processor at most one previous reference however many it had been configured for — and passed
+/// ZERO on the first frame after any restart. A temporal processor fills a missing reference with
+/// nil, and that throw is Objective-C, so there is nothing Swift can catch.
+struct LiveFeedNoiseFilterWindowTests {
+    @Test("Both reference windows must be exactly full")
+    func bothWindowsMustBeFull() {
+        #expect(
+            LiveFeedNoiseFilter.canRun(
+                past: 2, previousWanted: 2, futures: 2, futureWanted: 2))
+
+        // The shipped bug, in both of its shapes.
+        #expect(
+            !LiveFeedNoiseFilter.canRun(
+                past: 1, previousWanted: 2, futures: 2, futureWanted: 2),
+            "one reference against a two-frame configuration is the iPad16,5 crash")
+        #expect(
+            !LiveFeedNoiseFilter.canRun(
+                past: 0, previousWanted: 1, futures: 2, futureWanted: 2),
+            "the first frame after a restart had an empty past window and ran anyway")
+    }
+
+    /// A processor that wants no references of a kind is satisfied by having none.
+    @Test("A zero-length window is full when it is empty")
+    func zeroLengthWindowIsSatisfied() {
+        #expect(
+            LiveFeedNoiseFilter.canRun(
+                past: 0, previousWanted: 0, futures: 0, futureWanted: 0))
+        #expect(
+            LiveFeedNoiseFilter.canRun(
+                past: 1, previousWanted: 1, futures: 0, futureWanted: 0))
+    }
+
+    /// Too MANY is refused as well. The count is a contract, not a floor — a processor handed an
+    /// unexpected extra reference is being told about a frame it never agreed to see.
+    @Test("An over-full window is refused too")
+    func overFullWindowIsRefused() {
+        #expect(
+            !LiveFeedNoiseFilter.canRun(
+                past: 3, previousWanted: 2, futures: 2, futureWanted: 2))
+        #expect(
+            !LiveFeedNoiseFilter.canRun(
+                past: 2, previousWanted: 2, futures: 3, futureWanted: 2))
+    }
+}

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -14,7 +14,7 @@ Fixes
 - A Wi-Fi connection no longer asks you to join the camera's own network, and saved setups no longer read as offline while you are on that network.
 - A weak or busy link degrades the picture instead of dropping the session, and screen recording while you share your feed no longer walks the watcher's picture behind the action.
 - A watcher granted camera control can now start and stop the take. The record confirmation is asked once, on the device you pressed the button on.
-- The occasional single bright frame in live view should be gone. Please report it if you still see one.
+- Fixed a crash that could end a live session on some iPads while Feed Noise Reduction was on. Thank you to whoever sent that report — the log had exactly what was needed.
 - Changes made on the camera reach the app quickly again - the aperture ring, ISO or shutter used to take twenty seconds, or in video never.
 - Unplugging the cable or power-cycling the camera used to wedge the app. Both recover on their own, or offer Retry connection.
 


### PR DESCRIPTION
Crash report from TestFlight 0.2.5 (253), iPad16,5, iOS 26.6 — fifteen minutes into a
live session, over Wi-Fi.

```
Exception Reason: *** -[__NSArrayM insertObject:atIndex:]: object cannot be nil
2  CoreFoundation    -[__NSArrayM insertObject:atIndex:]
3  VideoToolbox      -[VTFrameProcessor processWithCommandBuffer:parameters:]
4  Runner            LiveFeedNoiseFilter.filter(_:strength:)   FrameDecoder.swift:650
5  Runner            FrameDecoder.hardwareDecoded(_:)
6  Runner            NativeAppModel.streamUntilStall(session:)
```

## Cause

The temporal noise filter read the configuration's `nextFrameCount` and honoured it. It
**never read `previousFrameCount`** — the past was a single slot, and the processor was
handed `previous.map { [$0] } ?? []`: at most one reference, however many the
configuration had promised it.

Give a temporal processor fewer references than it was configured for and it does not
denoise more weakly. It builds its internal frame list with a hole in it and inserts nil,
and that throw is Objective-C — Swift cannot catch it, so the process aborts.

**Two ways in, and the second is why it took fifteen minutes.**

On silicon that asks for more than one past frame it was always short. Media engines
differ, which is why this arrived on an M4 iPad Pro and on nothing else in testing.

And the guard let a frame through with an **empty** past window as long as one future
frame existed — which is exactly the first frame after any reconfigure or restart, since
both clear the history. A session ran fine until something restarted the stream
underneath it.

## Fix

The past is a window, sized by the count the processor asks for, and the filter refuses to
run unless **both** windows are exactly full — not short, and not over-full. The count is a
contract, not a floor.

Future frames stay clamped at two because each one is latency the operator agreed to
spend. Past frames cost only memory, so they take the number given.

## Verification

The decision is a pure function, so the invariant that killed a shipped build is pinned
without needing a media engine — the filter itself is unreachable in the simulator.

It is load-bearing, not decorative: reverting `canRun` to the shipped rule fails all three
cases, restoring it passes. Both shapes of the bug are asserted by name.

`just native-check` · `just check` · `just secrets` · `just hygiene` — all green.

## What this does not do

It corrects the contract at one call site. It does not make the app survive a future
contract violation elsewhere, and the super-resolution path has the same shape — frame
counts taken from a configuration, an uncatchable throw if they disagree. Worth a separate
sweep of the other `VTFrameProcessor` call sites.

**Not verified on hardware** — the reporting device is an iPad16,5 and I have none. The
proof that matters is that model running with Feed Noise Reduction on through a stream
restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
