### PR TITLE
fix(relay): a watcher's control survives a blink on a congested set

### DIFF
--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
@@ -314,6 +314,9 @@ class MainActivity : ComponentActivity() {
                                     scope = connectionScope,
                                     deviceName = relayDeviceName,
                                     broadcast = direct,
+                                    watcherId =
+                                        com.opencapture.openzcine.relay.RelayWatcherIdentity
+                                            .current(applicationContext),
                                     onPasscodeRemembered = { code ->
                                         persistWatcherPasscode(direct.name, code)
                                     },
@@ -827,6 +830,10 @@ class MainActivity : ComponentActivity() {
                                                     scope = connectionScope,
                                                     deviceName = relayDeviceName,
                                                     broadcast = broadcast,
+                                                    watcherId =
+                                                        com.opencapture.openzcine.relay
+                                                            .RelayWatcherIdentity
+                                                            .current(applicationContext),
                                                     onJpegOnlyLatched = persistJpegOnly,
                                                     onPasscodeRemembered = { code ->
                                                         persistWatcherPasscode(

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/MonitorRelayClient.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/MonitorRelayClient.kt
@@ -53,6 +53,12 @@ class MonitorRelayClient(private val scope: CoroutineScope) {
         deviceName: String,
         passcode: String?,
         codecs: List<String>? = null,
+        /**
+         * This install's stable relay identity. Lets the host recognise this DEVICE across a
+         * reconnect and hand back the control it was holding (`RelayControlLease`). Null keeps the
+         * old behaviour: control is released the moment the socket dies.
+         */
+        watcherId: String? = null,
     ) {
         readerJob =
             scope.launch(Dispatchers.IO) {
@@ -80,6 +86,7 @@ class MonitorRelayClient(private val scope: CoroutineScope) {
                                 cameraName = null,
                                 passcode = passcode,
                                 codecs = codecs,
+                                watcherId = watcherId,
                             )
                             .toJson()
                             .toString()

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/MonitorRelayHost.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/MonitorRelayHost.kt
@@ -1,5 +1,6 @@
 package com.opencapture.openzcine.relay
 
+import com.opencapture.openzcine.core.RelayControlLease
 import com.opencapture.openzcine.core.RelayEncoderProfile
 import java.net.ServerSocket
 import java.net.Socket
@@ -53,6 +54,11 @@ class MonitorRelayHost(
     var onFailure: ((String) -> Unit)? = null
 
     private class Peer(val id: Long, val socket: Socket, laneDepth: Int) {
+        /**
+         * The stable install identity from this peer's hello, when it sent one. What lets a
+         * dropped holder be recognised on a NEW socket and resume its control.
+         */
+        var watcherId: String? = null
         var name: String = "A device"
         var authorized: Boolean = false
         val control = Channel<ByteArray>(Channel.UNLIMITED)
@@ -71,6 +77,13 @@ class MonitorRelayHost(
     private var acceptJob: Job? = null
     private var latestStateJson: String? = null
     private var controlHolderID: Long? = null
+    /**
+     * A dropped holder's claim, alive for a short window so a blink on a congested set does not
+     * cost the operator the camera mid-take. Guarded by [mutex], like the holder it stands in for.
+     */
+    private val controlLease = RelayControlLease()
+    private var controlHolderNameWhileParked: String? = null
+    private var leaseExpiryJob: Job? = null
     private var pendingRequestID: Long? = null
 
     /** The bound listener port, available after [start] returns successfully. */
@@ -199,6 +212,26 @@ class MonitorRelayHost(
                         JSONObject(String(decoded.payload, Charsets.UTF_8))
                     )
                 peer.name = hello.hostName
+                peer.watcherId = hello.watcherId
+                // The holder that dropped, coming back. Its claim resumes on this new socket
+                // without the operator having to notice the outage or grant control again.
+                val resumed = mutex.withLock {
+                    if (controlHolderID == null &&
+                        controlLease.claim(hello.watcherId, System.currentTimeMillis())
+                    ) {
+                        controlHolderID = peer.id
+                        controlHolderNameWhileParked = null
+                        leaseExpiryJob?.cancel()
+                        leaseExpiryJob = null
+                        true
+                    } else {
+                        false
+                    }
+                }
+                if (resumed) {
+                    broadcastControlToken()
+                    notifyControl()
+                }
                 val required = watcherPasscode
                 if (required.isEmpty() || hello.passcode == required) {
                     peer.authorized = true
@@ -239,6 +272,8 @@ class MonitorRelayHost(
                 val released = mutex.withLock {
                     if (controlHolderID == peer.id) {
                         controlHolderID = null
+                        controlLease.clear()
+                        controlHolderNameWhileParked = null
                         true
                     } else {
                         false
@@ -262,12 +297,22 @@ class MonitorRelayHost(
     }
 
     private suspend fun drop(peer: Peer) {
+        // A viewer that disappears cannot keep the camera hostage — but a link that BLINKS is not
+        // a viewer that disappeared, and on a congested set the two look identical for a few
+        // seconds. The claim is parked for a short window (`RelayControlLease`) so the same device
+        // can resume it on its way back in. Reclaiming never waits for this.
         val wasHolder = mutex.withLock {
             peers.remove(peer.id)
             peer.control.close()
             peer.frames.close()
             val held = controlHolderID == peer.id
-            if (held) controlHolderID = null
+            if (held) {
+                controlHolderID = null
+                if (controlLease.park(peer.watcherId, System.currentTimeMillis())) {
+                    controlHolderNameWhileParked = peer.name
+                    armLeaseExpiry()
+                }
+            }
             if (pendingRequestID == peer.id) pendingRequestID = null
             held
         }
@@ -318,9 +363,41 @@ class MonitorRelayHost(
         notifyControl()
     }
 
+    /**
+     * Ends a parked claim when its window runs out, so the operator gets the camera back without
+     * having to do anything. Must be called while holding [mutex].
+     */
+    private fun armLeaseExpiry() {
+        leaseExpiryJob?.cancel()
+        leaseExpiryJob =
+            scope.launch {
+                delay(RelayControlLease.DEFAULT_WINDOW_MILLIS)
+                val expired =
+                    mutex.withLock {
+                        if (controlLease.isParked(System.currentTimeMillis())) {
+                            false
+                        } else {
+                            controlLease.clear()
+                            controlHolderNameWhileParked = null
+                            true
+                        }
+                    }
+                if (expired) {
+                    broadcastControlToken()
+                    notifyControl()
+                }
+            }
+    }
+
     /** Takes the camera back — always available, this device owns the session. */
     suspend fun reclaimControl() {
-        mutex.withLock { controlHolderID = null }
+        mutex.withLock {
+            controlHolderID = null
+            controlLease.clear()
+            controlHolderNameWhileParked = null
+            leaseExpiryJob?.cancel()
+            leaseExpiryJob = null
+        }
         broadcastControlToken()
         notifyControl()
     }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/MonitorRelayWire.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/MonitorRelayWire.kt
@@ -158,6 +158,13 @@ object MonitorRelayWire {
          * per-chipset whack-a-mole.
          */
         val codecs: List<String>? = null,
+        /**
+         * Viewer → host: a stable per-install identity, so a watcher that drops and comes back is
+         * recognised as the same DEVICE and can resume the control it held (`RelayControlLease`).
+         * Null — including every payload from before the field — means the watcher cannot be
+         * recognised on return, and its control is released the moment the socket dies, as before.
+         */
+        val watcherId: String? = null,
     ) {
         fun toJson(): JSONObject =
             JSONObject().apply {
@@ -166,6 +173,7 @@ object MonitorRelayWire {
                 cameraName?.let { put("cameraName", it) }
                 passcode?.let { put("passcode", it) }
                 codecs?.let { put("codecs", org.json.JSONArray(it)) }
+                watcherId?.let { put("watcherId", it) }
             }
 
         companion object {
@@ -179,6 +187,7 @@ object MonitorRelayWire {
                         json.optJSONArray("codecs")?.let { array ->
                             (0 until array.length()).map(array::getString)
                         },
+                    watcherId = json.optStringOrNull("watcherId"),
                 )
         }
     }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/RelayWatchController.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/RelayWatchController.kt
@@ -53,6 +53,11 @@ class RelayWatchController(
     private val scope: CoroutineScope,
     private val deviceName: String,
     val broadcast: RelayBroadcast,
+    /**
+     * This install's stable relay identity, so a host recognises this DEVICE across a reconnect
+     * and the control it was holding survives a blink. Null keeps the pre-lease behaviour.
+     */
+    private val watcherId: String? = null,
     /** Fired once when this device latches jpeg-only — the shell persists the verdict. */
     private val onJpegOnlyLatched: (() -> Unit)? = null,
     /** Fired when a passcode is accepted for [broadcast] — the shell persists it per host. */
@@ -216,6 +221,7 @@ class RelayWatchController(
             deviceName,
             passcode,
             codecs = if (jpegOnly) listOf("jpeg") else null,
+            watcherId = watcherId,
         )
         armStallWatchdog()
     }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/RelayWatcherIdentity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/RelayWatcherIdentity.kt
@@ -1,0 +1,26 @@
+package com.opencapture.openzcine.relay
+
+import android.content.Context
+import java.util.UUID
+
+/**
+ * This install's stable relay identity.
+ *
+ * A host uses it to recognise a watcher across a reconnect, so a control token survives a blink on
+ * a congested set (`RelayControlLease`). Persisted rather than derived: a device name is not
+ * unique and an address is not stable, and this decides who may press record.
+ *
+ * App-private and never leaves the relay handshake — it names no person, device or network.
+ */
+public object RelayWatcherIdentity {
+    private const val PREFS = "openzcine.relay"
+    private const val KEY = "watcherId"
+
+    public fun current(context: Context): String {
+        val prefs = context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        prefs.getString(KEY, null)?.takeIf(String::isNotEmpty)?.let { return it }
+        val minted = UUID.randomUUID().toString()
+        prefs.edit().putString(KEY, minted).apply()
+        return minted
+    }
+}

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/relay/RelayControlLeaseTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/relay/RelayControlLeaseTest.kt
@@ -1,0 +1,98 @@
+package com.opencapture.openzcine.relay
+
+import com.opencapture.openzcine.core.RelayControlLease
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The Kotlin half of the control-lease table. Every case here is a case of the Swift core's
+ * `RelayControlLeaseTests` — the rule lives in two languages and only stays one rule because both
+ * halves are checked against the same rows.
+ */
+class RelayControlLeaseTest {
+    private val t0 = 1_000_000L
+
+    /** The blink this exists for: drop, come back inside the window, still holding the camera. */
+    @Test
+    fun `a watcher that comes back keeps the control it held`() {
+        val lease = RelayControlLease()
+
+        assertTrue(lease.park("watcher-a", t0))
+        assertTrue(lease.isParked(t0 + 5_000))
+        assertTrue(lease.claim("watcher-a", t0 + 5_000))
+        // Claimed once and only once — a second socket cannot inherit the same parked claim.
+        assertFalse(lease.claim("watcher-a", t0 + 6_000))
+    }
+
+    /**
+     * The window has to outlast the watcher's OWN idea of having dropped, or it can never be
+     * used: a stalled session is not declared dead for 8 s, and the rejoin ticks every 3 s after.
+     */
+    @Test
+    fun `the window outlasts the watchers own stall deadline`() {
+        assertTrue(RelayControlLease.DEFAULT_WINDOW_MILLIS >= 14_000)
+        val lease = RelayControlLease()
+        lease.park("watcher-a", t0)
+        assertTrue(lease.isParked(t0 + 14_000))
+    }
+
+    /** And it does end. A watcher that walked off set does not hold the camera indefinitely. */
+    @Test
+    fun `a watcher that never comes back loses the camera`() {
+        val lease = RelayControlLease(windowMillis = 20_000)
+        lease.park("watcher-a", t0)
+
+        assertFalse(lease.isParked(t0 + 20_001))
+        assertNull(lease.parkedWatcherId(t0 + 20_001))
+        assertFalse(lease.claim("watcher-a", t0 + 20_001))
+    }
+
+    /** A parked claim belongs to ONE device. This token presses record, so a near-miss is a miss. */
+    @Test
+    fun `only the watcher that held it can resume it`() {
+        val lease = RelayControlLease()
+        lease.park("watcher-a", t0)
+
+        assertFalse(lease.claim("watcher-b", t0 + 1_000))
+        assertFalse(lease.claim(null, t0 + 1_000))
+        assertFalse(lease.claim("", t0 + 1_000))
+        // Refused claims leave the real holder's claim intact.
+        assertTrue(lease.claim("watcher-a", t0 + 2_000))
+    }
+
+    /**
+     * A watcher we could never recognise on return is not parked at all — freezing the camera for
+     * a device that can never come back would be worse than the behaviour this replaces.
+     */
+    @Test
+    fun `an unrecognisable watcher releases immediately as before`() {
+        val lease = RelayControlLease()
+
+        assertFalse(lease.park(null, t0))
+        assertFalse(lease.isParked(t0))
+
+        assertFalse(lease.park("", t0))
+        assertFalse(lease.isParked(t0))
+    }
+
+    /** The operator never waits out the window, and a deliberate hand-back is not a disconnection. */
+    @Test
+    fun `reclaiming and releasing both end the claim at once`() {
+        val lease = RelayControlLease()
+        lease.park("watcher-a", t0)
+
+        lease.clear()
+
+        assertFalse(lease.isParked(t0 + 1_000))
+        assertFalse(lease.claim("watcher-a", t0 + 1_000))
+    }
+
+    /** Both halves agree on the number, not just the shape. */
+    @Test
+    fun `the window matches the swift core`() {
+        assertEquals(20_000L, RelayControlLease.DEFAULT_WINDOW_MILLIS)
+    }
+}

--- a/Apps/Android/core-api/src/main/kotlin/com/opencapture/openzcine/core/RelayControlLease.kt
+++ b/Apps/Android/core-api/src/main/kotlin/com/opencapture/openzcine/core/RelayControlLease.kt
@@ -1,0 +1,78 @@
+package com.opencapture.openzcine.core
+
+/**
+ * Keeps a watcher's camera control alive across a brief disconnection.
+ *
+ * Twin of the shared Swift core's `RelayControlLease`, checked against the same table.
+ *
+ * A held control token used to die with the socket. On a congested set that is wrong: a watcher
+ * whose link blinks loses the camera mid-take and has to ask for it back, and the operator has to
+ * notice and grant it again — for an outage neither of them saw. The token belongs to a PERSON
+ * holding a device, not to a TCP connection.
+ *
+ * It cannot be keyed on the connection, for the same reason it exists: the returning watcher
+ * arrives on a new socket. The hello's stable per-install `watcherId` is what the lease
+ * recognises. Anything weaker — a device name, an address — could hand camera control to the
+ * wrong person, and this is a token that presses record.
+ *
+ * Not thread-safe by itself; the host owns it under its own mutex.
+ */
+public class RelayControlLease(
+    /**
+     * How long a dropped holder keeps its claim.
+     *
+     * Twenty seconds, and it has to outlast the watcher's OWN idea of having dropped or it could
+     * never be used: a stalled viewer session is not declared dead for 8 s, and only then does a
+     * 3 s rejoin tick fire and have to re-find the broadcast. Short enough that a watcher who has
+     * genuinely walked away is not still holding the camera a minute later — and the operator
+     * never waits it out regardless, because reclaiming is always immediate.
+     */
+    public val windowMillis: Long = DEFAULT_WINDOW_MILLIS,
+) {
+    private var parkedWatcherId: String? = null
+    private var parkedUntilMillis: Long = 0
+
+    /** Whether a dropped holder is still owed its claim as of [nowMillis]. */
+    public fun isParked(nowMillis: Long): Boolean =
+        parkedWatcherId != null && nowMillis < parkedUntilMillis
+
+    /** The watcher a resumed claim would belong to, while one is owed. */
+    public fun parkedWatcherId(nowMillis: Long): String? =
+        if (isParked(nowMillis)) parkedWatcherId else null
+
+    /**
+     * The holder dropped. A claim is only parked for a watcher we can RECOGNISE on return — an
+     * anonymous watcher (one from before the field existed) releases immediately, exactly as it
+     * always did, rather than freezing the camera for a device that can never be matched.
+     */
+    public fun park(watcherId: String?, nowMillis: Long): Boolean {
+        if (watcherId.isNullOrEmpty()) {
+            clear()
+            return false
+        }
+        parkedWatcherId = watcherId
+        parkedUntilMillis = nowMillis + windowMillis
+        return true
+    }
+
+    /** Whether this hello is the parked watcher coming back, in which case the claim resumes. */
+    public fun claim(watcherId: String?, nowMillis: Long): Boolean {
+        if (watcherId.isNullOrEmpty()) return false
+        if (!isParked(nowMillis) || parkedWatcherId != watcherId) return false
+        clear()
+        return true
+    }
+
+    /**
+     * Drops the claim outright — the operator reclaiming, the watcher releasing deliberately, or
+     * the window running out. Deliberate release is not a disconnection and gets no grace.
+     */
+    public fun clear() {
+        parkedWatcherId = null
+        parkedUntilMillis = 0
+    }
+
+    public companion object {
+        public const val DEFAULT_WINDOW_MILLIS: Long = 20_000
+    }
+}

--- a/Sources/OpenZCineCore/MonitorRelayProtocol.swift
+++ b/Sources/OpenZCineCore/MonitorRelayProtocol.swift
@@ -135,13 +135,14 @@ public struct RelayPresence: Codable, Equatable, Sendable {
 public struct MonitorRelayHello: Codable, Equatable, Sendable {
     public init(
         version: Int, hostName: String, cameraName: String?, passcode: String? = nil,
-        codecs: [String]? = nil
+        codecs: [String]? = nil, watcherID: String? = nil
     ) {
         self.version = version
         self.hostName = hostName
         self.cameraName = cameraName
         self.passcode = passcode
         self.codecs = codecs
+        self.watcherID = watcherID
     }
 
     public let version: Int
@@ -158,6 +159,11 @@ public struct MonitorRelayHello: Codable, Equatable, Sendable {
     /// without Main10, software decoders that error on it) rejoins declaring `["jpeg"]` and
     /// the host serves it JPEG instead: codec negotiation, not per-chipset whack-a-mole.
     public let codecs: [String]?
+    /// Viewer → host only: a stable per-install identity, so a watcher that drops and comes back
+    /// is recognised as the same DEVICE and can resume the control it held (`RelayControlLease`).
+    /// Absent — including every payload from before the field — means the watcher cannot be
+    /// recognised on return, and its control is released the moment the socket dies, as before.
+    public let watcherID: String?
 
     /// Whether this viewer accepts HEVC frames (absent codec list = yes, legacy behavior).
     public var acceptsHEVC: Bool { codecs?.contains("hevc") ?? true }
@@ -455,4 +461,81 @@ public enum MonitorRelayFramePayload {
         return Decoded(
             metadata: metadata, image: Data(payload[(base + 4 + jsonLength)...]))
     }
+}
+
+/// Keeps a watcher's camera control alive across a brief disconnection.
+///
+/// A held control token used to die with the socket. On a congested set that is wrong: a watcher
+/// whose link blinks loses the camera mid-take and has to ask for it back, and the operator has to
+/// notice and grant it again — for an outage neither of them saw. The token belongs to a PERSON
+/// holding a device, not to a TCP connection.
+///
+/// The window has to outlast the watcher's own idea of "I have dropped", or it can never be used:
+/// a stalled viewer session is not declared dead for 8 s, and only then does a 3 s rejoin tick
+/// fire and have to re-find the broadcast. A window under about ten seconds would expire before
+/// the watcher had even started coming back.
+///
+/// It cannot be keyed on the connection, for the same reason it exists: the returning watcher
+/// arrives on a new socket. `MonitorRelayHello.watcherID` is a stable per-install identity, so the
+/// lease recognises the DEVICE. Anything weaker — a device name, an address — could hand camera
+/// control to the wrong person, and this is a token that presses record.
+public struct RelayControlLease: Equatable, Sendable {
+    /// How long a dropped holder keeps its claim.
+    ///
+    /// Twenty seconds: the watcher's own 8 s stall deadline, plus two 3 s rejoin ticks, plus the
+    /// Bonjour re-sighting and connect those ticks wait on. Long enough that the common blink is
+    /// invisible, short enough that a watcher who has genuinely walked away is not still holding
+    /// the camera a minute later. The operator never has to wait it out regardless — reclaiming
+    /// is always available and always immediate.
+    public static let defaultWindowSeconds: TimeInterval = 20
+
+    public init(windowSeconds: TimeInterval = RelayControlLease.defaultWindowSeconds) {
+        self.windowSeconds = windowSeconds
+    }
+
+    public let windowSeconds: TimeInterval
+
+    /// A tuple would not synthesize `Equatable`, and the lease is compared in tests.
+    private struct Parked: Equatable, Sendable {
+        let watcherID: String
+        let until: Date
+    }
+
+    private var parked: Parked?
+
+    /// Whether a dropped holder is still owed its claim as of [now].
+    public func isParked(at now: Date) -> Bool {
+        guard let parked else { return false }
+        return now < parked.until
+    }
+
+    /// The watcher a resumed claim would belong to, while one is owed.
+    public func parkedWatcherID(at now: Date) -> String? {
+        isParked(at: now) ? parked?.watcherID : nil
+    }
+
+    /// The holder dropped. A claim is only parked for a watcher we can RECOGNISE on return —
+    /// an anonymous watcher (one from before the field existed) releases immediately, exactly as
+    /// it always did, rather than freezing the camera for a device that can never be matched.
+    public mutating func park(watcherID: String?, now: Date) -> Bool {
+        guard let watcherID, !watcherID.isEmpty else {
+            parked = nil
+            return false
+        }
+        parked = Parked(watcherID: watcherID, until: now.addingTimeInterval(windowSeconds))
+        return true
+    }
+
+    /// Whether this hello is the parked watcher coming back, in which case the claim resumes.
+    public mutating func claim(watcherID: String?, now: Date) -> Bool {
+        guard let watcherID, !watcherID.isEmpty, isParked(at: now),
+            parked?.watcherID == watcherID
+        else { return false }
+        parked = nil
+        return true
+    }
+
+    /// Drops the claim outright — the operator reclaiming, the watcher releasing deliberately, or
+    /// the window running out. Deliberate release is not a disconnection and gets no grace.
+    public mutating func clear() { parked = nil }
 }

--- a/Tests/OpenZCineCoreTests/RelayControlLeaseTests.swift
+++ b/Tests/OpenZCineCoreTests/RelayControlLeaseTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+
+@testable import OpenZCineCore
+
+private let t0 = Date(timeIntervalSince1970: 1_000)
+
+/// The blink this exists for: the watcher's link drops and comes back inside the window, and it is
+/// still holding the camera. Nobody had to notice, and nobody had to ask for it again.
+@Test func aWatcherThatComesBackKeepsTheControlItHeld() {
+    var lease = RelayControlLease()
+
+    let parked = lease.park(watcherID: "watcher-a", now: t0)
+    #expect(parked)
+    #expect(lease.isParked(at: t0.addingTimeInterval(5)))
+    let resumed = lease.claim(watcherID: "watcher-a", now: t0.addingTimeInterval(5))
+    #expect(resumed)
+    // Claimed once and only once — a second socket cannot inherit the same parked claim.
+    let twice = lease.claim(watcherID: "watcher-a", now: t0.addingTimeInterval(6))
+    #expect(!twice)
+}
+
+/// The window has to outlast the watcher's OWN idea of having dropped, or it can never be used:
+/// a stalled session is not declared dead for 8 s, and the rejoin ticks every 3 s after that.
+@Test func theWindowOutlastsTheWatchersOwnStallDeadline() {
+    #expect(RelayControlLease.defaultWindowSeconds >= 14)
+    var lease = RelayControlLease()
+    _ = lease.park(watcherID: "watcher-a", now: t0)
+    // 8 s to notice the stall, then a 3 s tick, then another to re-find the broadcast.
+    #expect(lease.isParked(at: t0.addingTimeInterval(14)))
+}
+
+/// And it does end. A watcher that walked off set does not hold the camera indefinitely.
+@Test func aWatcherThatNeverComesBackLosesTheCamera() {
+    var lease = RelayControlLease(windowSeconds: 20)
+    _ = lease.park(watcherID: "watcher-a", now: t0)
+
+    let after = t0.addingTimeInterval(20.001)
+    #expect(!lease.isParked(at: after))
+    #expect(lease.parkedWatcherID(at: after) == nil)
+    let expired = lease.claim(watcherID: "watcher-a", now: after)
+    #expect(!expired)
+}
+
+/// A parked claim belongs to ONE device. This token presses record, so a near-miss is a miss.
+@Test func onlyTheWatcherThatHeldItCanResumeIt() {
+    var lease = RelayControlLease()
+    _ = lease.park(watcherID: "watcher-a", now: t0)
+
+    let wrongDevice = lease.claim(watcherID: "watcher-b", now: t0.addingTimeInterval(1))
+    let anonymous = lease.claim(watcherID: nil, now: t0.addingTimeInterval(1))
+    let empty = lease.claim(watcherID: "", now: t0.addingTimeInterval(1))
+    #expect(!wrongDevice)
+    #expect(!anonymous)
+    #expect(!empty)
+    // Refused claims leave the real holder's claim intact.
+    let realHolder = lease.claim(watcherID: "watcher-a", now: t0.addingTimeInterval(2))
+    #expect(realHolder)
+}
+
+/// A watcher we could never recognise on return is not parked at all — freezing the camera for a
+/// device that can never come back would be worse than the behaviour this replaces.
+@Test func anUnrecognisableWatcherReleasesImmediatelyAsBefore() {
+    var lease = RelayControlLease()
+
+    let parkedNil = lease.park(watcherID: nil, now: t0)
+    #expect(!parkedNil)
+    #expect(!lease.isParked(at: t0))
+
+    let parkedEmpty = lease.park(watcherID: "", now: t0)
+    #expect(!parkedEmpty)
+    #expect(!lease.isParked(at: t0))
+}
+
+/// The operator never waits out the window, and a deliberate hand-back is not a disconnection.
+@Test func reclaimingAndReleasingBothEndTheClaimAtOnce() {
+    var lease = RelayControlLease()
+    _ = lease.park(watcherID: "watcher-a", now: t0)
+
+    lease.clear()
+
+    #expect(!lease.isParked(at: t0.addingTimeInterval(1)))
+    let afterClear = lease.claim(watcherID: "watcher-a", now: t0.addingTimeInterval(1))
+    #expect(!afterClear)
+}

--- a/ios/Runner/MonitorRelayLink.swift
+++ b/ios/Runner/MonitorRelayLink.swift
@@ -229,6 +229,9 @@ final class MonitorRelayHost {
         /// From the hello's codec declaration (absent = true, legacy). A jpeg-only peer —
         /// hardware whose decoders reject the HEVC stream — gets the JPEG twin of each frame.
         var acceptsHEVC = true
+        /// The stable install identity from this peer's hello, when it sent one. What lets a
+        /// dropped holder be recognised on a NEW socket and resume its control.
+        var watcherID: String?
     }
 
     /// Fired when some peer is waiting on a keyframe the current stream position cannot give it.
@@ -239,6 +242,10 @@ final class MonitorRelayHost {
     /// The viewer currently allowed to drive the camera; nil means the host itself does.
     private(set) var controlHolder: ObjectIdentifier?
     private(set) var controlHolderName: String?
+    /// A dropped holder's claim, alive for a short window so a blink on a congested set does not
+    /// cost the operator the camera mid-take. See `RelayControlLease`.
+    private var controlLease = RelayControlLease()
+    private var leaseExpiryTask: Task<Void, Never>?
     /// A viewer that has asked and not yet been answered.
     private(set) var pendingRequestName: String?
     private var pendingRequest: ObjectIdentifier?
@@ -422,10 +429,28 @@ final class MonitorRelayHost {
         relayLogger.info("relay host: viewer left (\(max(0, self.peers.count - 1)) remain)")
         connection.cancel()
         let key = ObjectIdentifier(connection)
+        // Read before the removal: parking this claim needs the identity the peer introduced
+        // itself with, and the peer is about to stop existing.
+        let departingWatcherID = peers[key]?.watcherID
         peers.removeValue(forKey: key)
-        // A viewer that disappears cannot keep the camera hostage: control returns to the host,
-        // which is the device that actually holds the session and can always act.
-        if controlHolder == key { reclaimControl() }
+        // A viewer that disappears cannot keep the camera hostage — but a link that BLINKS is
+        // not a viewer that disappeared, and on a congested set the two look identical for a few
+        // seconds. The claim is parked for a short window (`RelayControlLease`) so the same
+        // device can resume it on its way back in; if it does not, control returns to the host,
+        // which holds the session and can always act. Reclaiming never waits for this.
+        if controlHolder == key {
+            let holderName = controlHolderName
+            if controlLease.park(watcherID: departingWatcherID, now: Date()) {
+                controlHolder = nil
+                controlHolderName = holderName
+                relayLogger.info("relay host: holder dropped — claim parked")
+                startLeaseExpiry()
+                publishControlToken()
+                onControlChanged?()
+            } else {
+                reclaimControl()
+            }
+        }
         if pendingRequest == key {
             pendingRequest = nil
             pendingRequestName = nil
@@ -486,7 +511,19 @@ final class MonitorRelayHost {
             else { return }
             peers[key]?.name = hello.hostName
             peers[key]?.acceptsHEVC = hello.acceptsHEVC
+            peers[key]?.watcherID = hello.watcherID
             if controlHolder == key { controlHolderName = hello.hostName }
+            // The holder that dropped, coming back. Its claim resumes on this new socket without
+            // the operator having to notice the outage or grant control a second time.
+            if controlHolder == nil, controlLease.claim(watcherID: hello.watcherID, now: Date()) {
+                leaseExpiryTask?.cancel()
+                leaseExpiryTask = nil
+                controlHolder = key
+                controlHolderName = hello.hostName
+                relayLogger.info("relay host: dropped holder resumed control")
+                publishControlToken()
+                onControlChanged?()
+            }
             if peers[key]?.authorized == false {
                 if hello.passcode == watcherPasscode {
                     peers[key]?.authorized = true
@@ -551,7 +588,27 @@ final class MonitorRelayHost {
 
     /// Takes the camera back. Always available: the host owns the session, so this can never fail
     /// or need the viewer's cooperation — which is what makes handing control out safe.
+    /// Ends a parked claim when its window runs out, so the operator gets the camera back without
+    /// having to do anything. Cancelled by a resume, by reclaiming, and by the host stopping.
+    private func startLeaseExpiry() {
+        leaseExpiryTask?.cancel()
+        leaseExpiryTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(RelayControlLease.defaultWindowSeconds))
+            guard !Task.isCancelled, let self, self.controlLease.isParked(at: Date()) == false
+            else {
+                // Slept short, or the claim was resumed while we slept. Either way the timer has
+                // no verdict to deliver.
+                return
+            }
+            relayLogger.info("relay host: parked claim expired — control returned")
+            self.reclaimControl()
+        }
+    }
+
     func reclaimControl() {
+        leaseExpiryTask?.cancel()
+        leaseExpiryTask = nil
+        controlLease.clear()
         controlHolder = nil
         controlHolderName = nil
         publishControlToken()
@@ -965,6 +1022,20 @@ final class MonitorRelayClient {
         if state != .idle { update(.idle) }
     }
 
+    /// This install's stable relay identity, so a host can recognise this DEVICE across a
+    /// reconnect and hand back the control it was holding (`RelayControlLease`). Persisted, not
+    /// derived: a device name is not unique and an address is not stable, and this decides who
+    /// may press record.
+    static var watcherID: String {
+        let key = "relay.watcherID"
+        if let existing = UserDefaults.standard.string(forKey: key), !existing.isEmpty {
+            return existing
+        }
+        let minted = UUID().uuidString
+        UserDefaults.standard.set(minted, forKey: key)
+        return minted
+    }
+
     /// Introduces this device so a control request can name who is asking — and carries the
     /// watcher passcode when the broadcast requires one.
     func introduce(deviceName: String, passcode: String? = nil) {
@@ -972,7 +1043,7 @@ final class MonitorRelayClient {
             let payload = try? JSONEncoder().encode(
                 MonitorRelayHello(
                     version: MonitorRelayProtocol.version, hostName: deviceName, cameraName: nil,
-                    passcode: passcode))
+                    passcode: passcode, watcherID: Self.watcherID))
         else { return }
         send(kind: .hello, payload: payload)
     }


### PR DESCRIPTION
Recovers a fix that was written for #320 and did not make it into the merge. The other
two relay fixes from that PR are on `main`; this one is not, so the reported bug is still
live.

## The bug

A watcher granted camera control lost it the instant its link blinked. On a congested set
that is wrong: the operator has to notice, and grant control again, for an outage neither
of them saw. The token belongs to a PERSON holding a device, not to a TCP connection.

## The fix

A dropped holder's claim is parked and resumes when the same device comes back.

**Twenty seconds, and the number is derived rather than chosen.** A stalled viewer session
is not declared dead for 8 s, and only then does a 3 s rejoin tick fire and have to re-find
the broadcast. Anything under about ten seconds would expire before the watcher had
started coming back — which is the same as not building it.

**It cannot key on the connection**, for the same reason it exists: the returning watcher
arrives on a new socket. So the hello carries a stable per-install id and the lease
recognises the DEVICE. Not the device *name* — two phones can share one, and this is a
token that presses record. A watcher too old to send an id is not parked at all, rather
than parked forever against an identity that can never match.

**Three things deliberately do not wait:** the operator reclaiming, a watcher handing
control back on purpose, and the window itself expiring. A deliberate release is not a
disconnection and gets no grace.

## Verification

The policy is pure and lives in the shared core, with a Kotlin twin checked against the
same table — six cases each, including the two that matter most: only the device that held
it can resume it, and a watcher that never returns does lose the camera.

`just check` · `just native-check` · `just android-check` · `just secrets` · `just hygiene`
— all green, cherry-picked onto current `main`.

**Not verified on hardware.** The test is two devices: grant control, interrupt the
watcher's link briefly, and confirm it still holds the camera when it returns — then leave
it off long enough to confirm the operator gets it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
