### PR TITLE
fix(relay,android): a watcher keeps control through a blink, and the Android feed stops waiting on work it never needed

### DIFF
--- a/Apps/Android/app/src/main/AndroidManifest.xml
+++ b/Apps/Android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,9 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <!-- isWifiEnabled before join so we fail fast when the radio is off. -->
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <!-- Required to hold a WifiLock: live view is a request/response pull loop, and Wi-Fi power
+         save is built for the opposite traffic. See transport/WifiLowLatencyLock.kt. -->
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <!-- startScan before WifiNetworkSpecifier so the system panel can find the AP. -->
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <!-- NSD/Wi-Fi camera discovery: NEARBY_WIFI_DEVICES on 13+ (never used

--- a/Apps/Android/app/src/main/AndroidManifest.xml
+++ b/Apps/Android/app/src/main/AndroidManifest.xml
@@ -9,8 +9,8 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <!-- isWifiEnabled before join so we fail fast when the radio is off. -->
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-    <!-- Required to hold a WifiLock: live view is a request/response pull loop, and Wi-Fi power
-         save is built for the opposite traffic. See transport/WifiLowLatencyLock.kt. -->
+    <!-- Required to hold a WifiLock. Live view is a request/response pull loop and Wi-Fi
+        power save is built for the opposite traffic. See transport/WifiLowLatencyLock.kt. -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <!-- startScan before WifiNetworkSpecifier so the system panel can find the AP. -->
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/FramePacing.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/FramePacing.kt
@@ -8,9 +8,17 @@ import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.onEach
 
 /**
- * Frame-pacing counters for the live feed: presented fps, decode time, and
- * frames dropped by latest-wins conflation. Emits one summary line through
- * [log] roughly every [reportIntervalNanos] of presented frames.
+ * Frame-pacing counters for the live feed: presented fps, decode time, frames
+ * dropped by latest-wins conflation, and how OLD a frame is when it reaches the
+ * renderer. Emits one summary line through [log] roughly every
+ * [reportIntervalNanos] of presented frames.
+ *
+ * AGE is the number the field reports are about and the only one here that was
+ * missing. Every other counter measures THROUGHPUT, and throughput does not
+ * answer "how far behind the room is this picture" — a feed can hold a steady
+ * 30 fps while running a third of a second late, because a stage that keeps up
+ * on average can still be holding a frame that is waiting its turn. Tuning fps
+ * without watching age is how a pipeline gets fast and late at the same time.
  *
  * Pure Kotlin (no Android imports) so the accounting is JVM-unit-testable.
  * [frameReceived] may be called from a different thread than
@@ -26,6 +34,9 @@ class FramePacingStats(
     private var presented = 0L
     private var decodeTotalNanos = 0L
     private var decodeMaxNanos = 0L
+    private var ageTotalNanos = 0L
+    private var ageMaxNanos = 0L
+    private var agedFrames = 0L
     private var windowStartNanos = 0L
     private var hasWindow = false
 
@@ -39,8 +50,13 @@ class FramePacingStats(
      *
      * @param decodeNanos Time spent decoding this frame.
      * @param nowNanos Monotonic time of presentation ([System.nanoTime]).
+     * @param ageNanos How long this frame waited between the transport having it
+     *   and the renderer getting it — decode, plus any time it spent held. The
+     *   transport stamps on the same `CLOCK_MONOTONIC` Kotlin reads, so the two
+     *   are directly comparable. Negative or absent values are ignored rather
+     *   than trusted: a source with no usable stamp must not invent a latency.
      */
-    fun framePresented(decodeNanos: Long, nowNanos: Long) {
+    fun framePresented(decodeNanos: Long, nowNanos: Long, ageNanos: Long = -1L) {
         if (!hasWindow) {
             // The first present only establishes the window baseline — counting
             // it would overstate fps by one fencepost frame per window.
@@ -52,6 +68,11 @@ class FramePacingStats(
         presented++
         decodeTotalNanos += decodeNanos
         decodeMaxNanos = max(decodeMaxNanos, decodeNanos)
+        if (ageNanos >= 0) {
+            ageTotalNanos += ageNanos
+            ageMaxNanos = max(ageMaxNanos, ageNanos)
+            agedFrames++
+        }
 
         val elapsed = nowNanos - windowStartNanos
         if (elapsed < reportIntervalNanos || presented == 0L) return
@@ -60,13 +81,26 @@ class FramePacingStats(
         val fps = presented * 1e9 / elapsed
         val avgMs = decodeTotalNanos / presented / 1e6
         val maxMs = decodeMaxNanos / 1e6
+        // Reported only when it was actually measured. A source with no usable stamp printing
+        // "age avg 0.0 ms" would be claiming the one thing we cannot see, and this counter exists
+        // precisely because the invisible number was the one that mattered.
+        val age =
+            if (agedFrames > 0) {
+                "age avg %.1f ms max %.1f ms | "
+                    .format(ageTotalNanos / agedFrames / 1e6, ageMaxNanos / 1e6)
+            } else {
+                ""
+            }
         log(
-            "feed pacing: %.1f fps | decode avg %.1f ms max %.1f ms | dropped %d/%d"
-                .format(fps, avgMs, maxMs, receivedInWindow - presented, receivedInWindow)
+            "feed pacing: %.1f fps | decode avg %.1f ms max %.1f ms | %sdropped %d/%d"
+                .format(fps, avgMs, maxMs, age, receivedInWindow - presented, receivedInWindow)
         )
         presented = 0
         decodeTotalNanos = 0
         decodeMaxNanos = 0
+        ageTotalNanos = 0
+        ageMaxNanos = 0
+        agedFrames = 0
         windowStartNanos = nowNanos
         receivedAtWindowStart = received.get()
     }
@@ -117,6 +151,15 @@ suspend fun <T : Any> pumpFramesWithSourceFrame(
             val start = System.nanoTime()
             val decoded = decode(frame) ?: return@collect
             present(frame, decoded)
-            stats.framePresented(decodeNanos = System.nanoTime() - start, nowNanos = System.nanoTime())
+            val done = System.nanoTime()
+            stats.framePresented(
+                decodeNanos = done - start,
+                nowNanos = done,
+                // The transport stamps `timestampNanos` off CLOCK_MONOTONIC, which is the clock
+                // `System.nanoTime()` reads — see `PTPIPClientSession.monotonicNanoseconds`. A
+                // source that leaves it at zero (or ahead of us) reports no age rather than a
+                // fictional one.
+                ageNanos = if (frame.timestampNanos > 0) done - frame.timestampNanos else -1L,
+            )
         }
 }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/FramePacing.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/FramePacing.kt
@@ -34,6 +34,8 @@ class FramePacingStats(
     private var presented = 0L
     private var decodeTotalNanos = 0L
     private var decodeMaxNanos = 0L
+    private var presentTotalNanos = 0L
+    private var presentMaxNanos = 0L
     private var ageTotalNanos = 0L
     private var ageMaxNanos = 0L
     private var agedFrames = 0L
@@ -48,7 +50,12 @@ class FramePacingStats(
     /**
      * Records one frame decoded and handed to the renderer.
      *
-     * @param decodeNanos Time spent decoding this frame.
+     * @param decodeNanos Time spent turning the frame's bytes into a bitmap — decode ALONE.
+     * @param presentNanos Time spent handing that bitmap to the screen. Separate from the decode
+     *   on purpose: these two used to share one timer under the label "decode", so a present that
+     *   blocks — and on the Vulkan path it blocks on a full GPU queue drain and a vsync-paced
+     *   image acquire — was hiding inside a number every reader took for decoder cost. A pipeline
+     *   is only diagnosable if each stage is timed as itself.
      * @param nowNanos Monotonic time of presentation ([System.nanoTime]).
      * @param ageNanos How long this frame waited between the transport having it
      *   and the renderer getting it — decode, plus any time it spent held. The
@@ -56,7 +63,12 @@ class FramePacingStats(
      *   are directly comparable. Negative or absent values are ignored rather
      *   than trusted: a source with no usable stamp must not invent a latency.
      */
-    fun framePresented(decodeNanos: Long, nowNanos: Long, ageNanos: Long = -1L) {
+    fun framePresented(
+        decodeNanos: Long,
+        nowNanos: Long,
+        ageNanos: Long = -1L,
+        presentNanos: Long = 0L,
+    ) {
         if (!hasWindow) {
             // The first present only establishes the window baseline — counting
             // it would overstate fps by one fencepost frame per window.
@@ -68,6 +80,8 @@ class FramePacingStats(
         presented++
         decodeTotalNanos += decodeNanos
         decodeMaxNanos = max(decodeMaxNanos, decodeNanos)
+        presentTotalNanos += presentNanos
+        presentMaxNanos = max(presentMaxNanos, presentNanos)
         if (ageNanos >= 0) {
             ageTotalNanos += ageNanos
             ageMaxNanos = max(ageMaxNanos, ageNanos)
@@ -92,12 +106,24 @@ class FramePacingStats(
                 ""
             }
         log(
-            "feed pacing: %.1f fps | decode avg %.1f ms max %.1f ms | %sdropped %d/%d"
-                .format(fps, avgMs, maxMs, age, receivedInWindow - presented, receivedInWindow)
+            ("feed pacing: %.1f fps | decode avg %.1f ms max %.1f ms | " +
+                    "present avg %.1f ms max %.1f ms | %sdropped %d/%d")
+                .format(
+                    fps,
+                    avgMs,
+                    maxMs,
+                    presentTotalNanos / presented / 1e6,
+                    presentMaxNanos / 1e6,
+                    age,
+                    receivedInWindow - presented,
+                    receivedInWindow,
+                )
         )
         presented = 0
         decodeTotalNanos = 0
         decodeMaxNanos = 0
+        presentTotalNanos = 0
+        presentMaxNanos = 0
         ageTotalNanos = 0
         ageMaxNanos = 0
         agedFrames = 0
@@ -150,10 +176,12 @@ suspend fun <T : Any> pumpFramesWithSourceFrame(
         .collect { frame ->
             val start = System.nanoTime()
             val decoded = decode(frame) ?: return@collect
+            val decoded_at = System.nanoTime()
             present(frame, decoded)
             val done = System.nanoTime()
             stats.framePresented(
-                decodeNanos = done - start,
+                decodeNanos = decoded_at - start,
+                presentNanos = done - decoded_at,
                 nowNanos = done,
                 // The transport stamps `timestampNanos` off CLOCK_MONOTONIC, which is the clock
                 // `System.nanoTime()` reads — see `PTPIPClientSession.monotonicNanoseconds`. A

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/LiveFeedGpuBackend.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/LiveFeedGpuBackend.kt
@@ -129,7 +129,22 @@ internal class GlesLiveFeedBackend : LiveFeedGpuBackend {
         state.detach(surface)
     }
 
+    private var uploadedPlan: FeedEffectsRenderPlan? = null
+    private var uploadedAspectFill = false
+    private var uploadedMirrored = false
+
     override fun updatePlan(plan: FeedEffectsRenderPlan?, aspectFill: Boolean, mirrored: Boolean) {
+        // Same per-recomposition storm as the Vulkan path — see the note on its own `uploadedPlan`.
+        // Cheaper per call here, but a texture re-upload per frame is still a texture re-upload per
+        // frame, and the two backends must not drift on when they consider a plan new.
+        if (plan === uploadedPlan && aspectFill == uploadedAspectFill &&
+            mirrored == uploadedMirrored
+        ) {
+            return
+        }
+        uploadedPlan = plan
+        uploadedAspectFill = aspectFill
+        uploadedMirrored = mirrored
         if (plan != null) state.update(plan, aspectFill, mirrored) else state.clear()
     }
 
@@ -209,14 +224,56 @@ internal class VulkanLiveFeedBackend(
 
     override fun attach(view: View) {
         // Surface callbacks own attach; keep for interface symmetry.
+        forgetUploadedPlan()
     }
 
     override fun detach(view: View) {
+        forgetUploadedPlan()
         if (!disposed) VulkanLiveFeedNative.detachSurface(session)
     }
 
+    /**
+     * Drops the upload memo.
+     *
+     * The memo is only sound while the GPU still HOLDS what it was last told, so every transition
+     * that can take those textures away has to forget it — a surface torn down and rebuilt, a
+     * resume after the app was backgrounded. Getting this wrong is not a slow feed, it is an
+     * ungraded one: the plan would be skipped as "already uploaded" against a device that no
+     * longer has it.
+     */
+    private fun forgetUploadedPlan() {
+        uploadedPlan = null
+    }
+
+    /**
+     * The plan last handed to the GPU, so an unchanged one is not uploaded again.
+     *
+     * `updatePlan` is called from a Compose `SideEffect` and from `AndroidView(update =)`, both of
+     * which run after EVERY recomposition — and the monitor recomposes at feed rate, because the
+     * AF boxes, the audio levels and the timecode all publish per frame. So this ran 25-30 times a
+     * second while saying the same thing every time, and on the Vulkan path saying it costs three
+     * full `vkQueueWaitIdle` queue drains (a 33³ LUT and two 64³ LIMITS cubes) taken under the
+     * same lock the frame present needs. The picture was waiting on re-uploads of bytes that had
+     * not changed since the operator last touched a control.
+     *
+     * Identity, not value: the plan is built once into a `remember`ed state and only reassigned
+     * when it genuinely changes, so the reference IS the change signal — and comparing megabytes
+     * of cube on every recomposition would just be a cheaper version of the same waste.
+     */
+    private var uploadedPlan: FeedEffectsRenderPlan? = null
+    private var uploadedAspectFill = false
+    private var uploadedMirrored = false
+
     override fun updatePlan(plan: FeedEffectsRenderPlan?, aspectFill: Boolean, mirrored: Boolean) {
         if (disposed) return
+        if (plan === uploadedPlan && aspectFill == uploadedAspectFill &&
+            mirrored == uploadedMirrored
+        ) {
+            return
+        }
+        uploadedPlan = plan
+        uploadedAspectFill = aspectFill
+        uploadedMirrored = mirrored
         if (plan == null) {
             VulkanLiveFeedNative.clearPlan(session)
             return

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/LiveFeedView.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/LiveFeedView.kt
@@ -3,6 +3,9 @@ package com.opencapture.openzcine
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.os.Process
+import java.util.concurrent.Executors
+import kotlinx.coroutines.asCoroutineDispatcher
 import android.media.MediaCodecList
 import android.os.Build
 import android.util.Log
@@ -384,6 +387,32 @@ class JpegFrameDecoder(
     }
 }
 
+/**
+ * The one thread that decodes and presents the live picture.
+ *
+ * It was running on `Dispatchers.Default`, which is wrong twice over. That pool is shared — the
+ * scope pump and the LUT/plan baking run on it too — so the picture queued behind work that could
+ * have waited. And its threads sit at default priority while the UI and render threads run at -10,
+ * which on a big.LITTLE scheduler is an invitation to park a bursty display-deadline workload on
+ * an efficiency core. That placement decision is a vendor one, which makes it a much better
+ * explanation for "late on one chipset, fine on another" than any per-byte cost — the bytes are
+ * the same on both.
+ *
+ * One thread on purpose: there is one live feed, decoding is single-image work, and a second
+ * decode in flight would reorder frames rather than deliver any sooner.
+ */
+private val feedDecodeDispatcher =
+    Executors.newSingleThreadExecutor { runnable ->
+            Thread(
+                {
+                    Process.setThreadPriority(Process.THREAD_PRIORITY_DISPLAY)
+                    runnable.run()
+                },
+                "zc-feed-decode",
+            )
+        }
+        .asCoroutineDispatcher()
+
 /** Power-of-two [BitmapFactory.Options.inSampleSize] so long side ≤ [maxLongSide]. */
 internal fun jpegSampleSizeForLongSide(width: Int, height: Int, maxLongSide: Int): Int {
     if (maxLongSide <= 0 || width <= 0 || height <= 0) return 1
@@ -632,7 +661,7 @@ fun LiveFeedView(
         // a 1080p source halved every frame on every device.
         val decoder = JpegFrameDecoder(maxLongSide = JpegFrameDecoder.DEFAULT_MAX_LONG_SIDE)
         val stats = FramePacingStats(log = { if (BuildConfig.DEBUG) Log.d(TAG, it) })
-        withContext(Dispatchers.Default) {
+        withContext(feedDecodeDispatcher) {
             pumpFramesWithSourceFrame(
                 frames = source.frames,
                 stats = stats,

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
@@ -97,6 +97,7 @@ import com.opencapture.openzcine.pairing.SavedCameraRecord
 import com.opencapture.openzcine.pairing.SavedCameraTransport
 import com.opencapture.openzcine.pairing.SavedCamerasExperience
 import com.opencapture.openzcine.pairing.SharedPreferencesSavedCameraStore
+import com.opencapture.openzcine.transport.WifiLowLatencyLock
 import com.opencapture.openzcine.pairing.realPairingEnvironment
 import com.opencapture.openzcine.pairing.usbAutoReconnectSuppressionAfterUserAction
 import com.opencapture.openzcine.relay.RelayPresence
@@ -562,6 +563,20 @@ class MainActivity : ComponentActivity() {
                 // surface never leaks bars onto the next.
                 val immersive = monitorSession != null || offlineMediaBuckets != null
                 LaunchedEffect(immersive) { applyImmersiveSystemBars() }
+                // Wi-Fi power save costs a wake on every frame of a request/response pull loop,
+                // and how aggressively it dozes is vendor firmware. Held only while a WIRELESS
+                // session is actually on the monitor — a cable session has no radio to keep awake,
+                // and the platform ignores the mode outside the foreground anyway.
+                val wifiLowLatencyLock = remember { WifiLowLatencyLock(applicationContext) }
+                val wirelessSessionLive =
+                    monitorSession != null &&
+                        activeSavedCamera?.transport.let {
+                            it != null && it != SavedCameraTransport.USB_C
+                        }
+                DisposableEffect(wirelessSessionLive) {
+                    if (wirelessSessionLive) wifiLowLatencyLock.acquire()
+                    onDispose { wifiLowLatencyLock.release() }
+                }
                 LaunchedEffect(immersive, operatorSettings.keepScreenAwake.value) {
                     if (operatorSettings.shouldKeepScreenAwake(immersive)) {
                         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
@@ -314,6 +314,9 @@ class MainActivity : ComponentActivity() {
                                     scope = connectionScope,
                                     deviceName = relayDeviceName,
                                     broadcast = direct,
+                                    watcherId =
+                                        com.opencapture.openzcine.relay.RelayWatcherIdentity
+                                            .current(applicationContext),
                                     onPasscodeRemembered = { code ->
                                         persistWatcherPasscode(direct.name, code)
                                     },
@@ -827,6 +830,10 @@ class MainActivity : ComponentActivity() {
                                                     scope = connectionScope,
                                                     deviceName = relayDeviceName,
                                                     broadcast = broadcast,
+                                                    watcherId =
+                                                        com.opencapture.openzcine.relay
+                                                            .RelayWatcherIdentity
+                                                            .current(applicationContext),
                                                     onJpegOnlyLatched = persistJpegOnly,
                                                     onPasscodeRemembered = { code ->
                                                         persistWatcherPasscode(

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreLiveFrameSource.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreLiveFrameSource.kt
@@ -12,19 +12,26 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.transform
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 private class LiveViewEndedException(val generation: Long) :
@@ -546,12 +553,47 @@ class SwiftCoreLiveFrameSource(
                 true
             }
 
-    private val sharedFrames =
-        upstream.shareIn(
-            scope = sharingScope,
-            started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 0),
-            replay = 1,
-        )
+    /**
+     * The live picture, fanned out to every consumer — newest wins, and NOBODY waits.
+     *
+     * This was `shareIn(replay = 1)`, which looks conflated and is not. `shareIn` has no overflow
+     * parameter, so it takes its default: `extraBufferCapacity = 63`, overflow SUSPEND. The
+     * `buffer(Channel.CONFLATED)` above cannot save it either — `retryWhen` returns a plain flow
+     * and erases the ChannelFlow identity that buffer had fused into, so the conflation stops at
+     * the retry and never reaches the sharing.
+     *
+     * Suspend-on-overflow means the PRODUCER is paced by the SLOWEST consumer. Six things collect
+     * this — the display, link health, timecode, audio meters, the scopes and the relay broadcast
+     * — and three of them run on the main thread. So a main thread busy doing anything else did
+     * not merely make those readouts late, it reached back through the shared buffer and throttled
+     * the camera pump itself, while up to sixty-four JPEGs sat in that buffer holding megabytes of
+     * large-object space. A monitor must never let a readout pace the picture.
+     *
+     * Hand-rolled because `shareIn` cannot express this. `replay = 1` keeps the last frame for a
+     * consumer that subscribes late (which is what the visual consumers rely on across a restart),
+     * `extraBufferCapacity = 0` plus DROP_OLDEST means `tryEmit` always succeeds and always keeps
+     * the newest — the same rule the display pump and every other stage already follow.
+     */
+    private val sharedFrames: SharedFlow<StreamFrame> =
+        MutableSharedFlow<StreamFrame>(
+                replay = 1,
+                extraBufferCapacity = 0,
+                onBufferOverflow = BufferOverflow.DROP_OLDEST,
+            )
+            .also { sink ->
+                sharingScope.launch {
+                    // The upstream is only collected while something downstream wants it, which is
+                    // what `WhileSubscribed` bought before. `subscriptionCount` reproduces it
+                    // exactly, and keeps the native pump from running for nobody.
+                    sink.subscriptionCount
+                        .map { it > 0 }
+                        .distinctUntilChanged()
+                        .collectLatest { active ->
+                            if (active) upstream.collect { frame -> sink.tryEmit(frame) }
+                        }
+                }
+            }
+            .asSharedFlow()
 
     /**
      * Visual consumers retain the last JPEG across a temporary source restart.

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/MonitorRelayClient.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/MonitorRelayClient.kt
@@ -53,6 +53,12 @@ class MonitorRelayClient(private val scope: CoroutineScope) {
         deviceName: String,
         passcode: String?,
         codecs: List<String>? = null,
+        /**
+         * This install's stable relay identity. Lets the host recognise this DEVICE across a
+         * reconnect and hand back the control it was holding (`RelayControlLease`). Null keeps the
+         * old behaviour: control is released the moment the socket dies.
+         */
+        watcherId: String? = null,
     ) {
         readerJob =
             scope.launch(Dispatchers.IO) {
@@ -80,6 +86,7 @@ class MonitorRelayClient(private val scope: CoroutineScope) {
                                 cameraName = null,
                                 passcode = passcode,
                                 codecs = codecs,
+                                watcherId = watcherId,
                             )
                             .toJson()
                             .toString()

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/MonitorRelayHost.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/MonitorRelayHost.kt
@@ -1,5 +1,6 @@
 package com.opencapture.openzcine.relay
 
+import com.opencapture.openzcine.core.RelayControlLease
 import com.opencapture.openzcine.core.RelayEncoderProfile
 import java.net.ServerSocket
 import java.net.Socket
@@ -53,6 +54,11 @@ class MonitorRelayHost(
     var onFailure: ((String) -> Unit)? = null
 
     private class Peer(val id: Long, val socket: Socket, laneDepth: Int) {
+        /**
+         * The stable install identity from this peer's hello, when it sent one. What lets a
+         * dropped holder be recognised on a NEW socket and resume its control.
+         */
+        var watcherId: String? = null
         var name: String = "A device"
         var authorized: Boolean = false
         val control = Channel<ByteArray>(Channel.UNLIMITED)
@@ -71,6 +77,13 @@ class MonitorRelayHost(
     private var acceptJob: Job? = null
     private var latestStateJson: String? = null
     private var controlHolderID: Long? = null
+    /**
+     * A dropped holder's claim, alive for a short window so a blink on a congested set does not
+     * cost the operator the camera mid-take. Guarded by [mutex], like the holder it stands in for.
+     */
+    private val controlLease = RelayControlLease()
+    private var controlHolderNameWhileParked: String? = null
+    private var leaseExpiryJob: Job? = null
     private var pendingRequestID: Long? = null
 
     /** The bound listener port, available after [start] returns successfully. */
@@ -199,6 +212,26 @@ class MonitorRelayHost(
                         JSONObject(String(decoded.payload, Charsets.UTF_8))
                     )
                 peer.name = hello.hostName
+                peer.watcherId = hello.watcherId
+                // The holder that dropped, coming back. Its claim resumes on this new socket
+                // without the operator having to notice the outage or grant control again.
+                val resumed = mutex.withLock {
+                    if (controlHolderID == null &&
+                        controlLease.claim(hello.watcherId, System.currentTimeMillis())
+                    ) {
+                        controlHolderID = peer.id
+                        controlHolderNameWhileParked = null
+                        leaseExpiryJob?.cancel()
+                        leaseExpiryJob = null
+                        true
+                    } else {
+                        false
+                    }
+                }
+                if (resumed) {
+                    broadcastControlToken()
+                    notifyControl()
+                }
                 val required = watcherPasscode
                 if (required.isEmpty() || hello.passcode == required) {
                     peer.authorized = true
@@ -239,6 +272,8 @@ class MonitorRelayHost(
                 val released = mutex.withLock {
                     if (controlHolderID == peer.id) {
                         controlHolderID = null
+                        controlLease.clear()
+                        controlHolderNameWhileParked = null
                         true
                     } else {
                         false
@@ -262,12 +297,22 @@ class MonitorRelayHost(
     }
 
     private suspend fun drop(peer: Peer) {
+        // A viewer that disappears cannot keep the camera hostage — but a link that BLINKS is not
+        // a viewer that disappeared, and on a congested set the two look identical for a few
+        // seconds. The claim is parked for a short window (`RelayControlLease`) so the same device
+        // can resume it on its way back in. Reclaiming never waits for this.
         val wasHolder = mutex.withLock {
             peers.remove(peer.id)
             peer.control.close()
             peer.frames.close()
             val held = controlHolderID == peer.id
-            if (held) controlHolderID = null
+            if (held) {
+                controlHolderID = null
+                if (controlLease.park(peer.watcherId, System.currentTimeMillis())) {
+                    controlHolderNameWhileParked = peer.name
+                    armLeaseExpiry()
+                }
+            }
             if (pendingRequestID == peer.id) pendingRequestID = null
             held
         }
@@ -318,9 +363,41 @@ class MonitorRelayHost(
         notifyControl()
     }
 
+    /**
+     * Ends a parked claim when its window runs out, so the operator gets the camera back without
+     * having to do anything. Must be called while holding [mutex].
+     */
+    private fun armLeaseExpiry() {
+        leaseExpiryJob?.cancel()
+        leaseExpiryJob =
+            scope.launch {
+                delay(RelayControlLease.DEFAULT_WINDOW_MILLIS)
+                val expired =
+                    mutex.withLock {
+                        if (controlLease.isParked(System.currentTimeMillis())) {
+                            false
+                        } else {
+                            controlLease.clear()
+                            controlHolderNameWhileParked = null
+                            true
+                        }
+                    }
+                if (expired) {
+                    broadcastControlToken()
+                    notifyControl()
+                }
+            }
+    }
+
     /** Takes the camera back — always available, this device owns the session. */
     suspend fun reclaimControl() {
-        mutex.withLock { controlHolderID = null }
+        mutex.withLock {
+            controlHolderID = null
+            controlLease.clear()
+            controlHolderNameWhileParked = null
+            leaseExpiryJob?.cancel()
+            leaseExpiryJob = null
+        }
         broadcastControlToken()
         notifyControl()
     }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/MonitorRelayWire.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/MonitorRelayWire.kt
@@ -158,6 +158,13 @@ object MonitorRelayWire {
          * per-chipset whack-a-mole.
          */
         val codecs: List<String>? = null,
+        /**
+         * Viewer → host: a stable per-install identity, so a watcher that drops and comes back is
+         * recognised as the same DEVICE and can resume the control it held (`RelayControlLease`).
+         * Null — including every payload from before the field — means the watcher cannot be
+         * recognised on return, and its control is released the moment the socket dies, as before.
+         */
+        val watcherId: String? = null,
     ) {
         fun toJson(): JSONObject =
             JSONObject().apply {
@@ -166,6 +173,7 @@ object MonitorRelayWire {
                 cameraName?.let { put("cameraName", it) }
                 passcode?.let { put("passcode", it) }
                 codecs?.let { put("codecs", org.json.JSONArray(it)) }
+                watcherId?.let { put("watcherId", it) }
             }
 
         companion object {
@@ -179,6 +187,7 @@ object MonitorRelayWire {
                         json.optJSONArray("codecs")?.let { array ->
                             (0 until array.length()).map(array::getString)
                         },
+                    watcherId = json.optStringOrNull("watcherId"),
                 )
         }
     }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/RelayWatchController.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/RelayWatchController.kt
@@ -53,6 +53,11 @@ class RelayWatchController(
     private val scope: CoroutineScope,
     private val deviceName: String,
     val broadcast: RelayBroadcast,
+    /**
+     * This install's stable relay identity, so a host recognises this DEVICE across a reconnect
+     * and the control it was holding survives a blink. Null keeps the pre-lease behaviour.
+     */
+    private val watcherId: String? = null,
     /** Fired once when this device latches jpeg-only — the shell persists the verdict. */
     private val onJpegOnlyLatched: (() -> Unit)? = null,
     /** Fired when a passcode is accepted for [broadcast] — the shell persists it per host. */
@@ -216,6 +221,7 @@ class RelayWatchController(
             deviceName,
             passcode,
             codecs = if (jpegOnly) listOf("jpeg") else null,
+            watcherId = watcherId,
         )
         armStallWatchdog()
     }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/RelayWatcherIdentity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/relay/RelayWatcherIdentity.kt
@@ -1,0 +1,26 @@
+package com.opencapture.openzcine.relay
+
+import android.content.Context
+import java.util.UUID
+
+/**
+ * This install's stable relay identity.
+ *
+ * A host uses it to recognise a watcher across a reconnect, so a control token survives a blink on
+ * a congested set (`RelayControlLease`). Persisted rather than derived: a device name is not
+ * unique and an address is not stable, and this decides who may press record.
+ *
+ * App-private and never leaves the relay handshake — it names no person, device or network.
+ */
+public object RelayWatcherIdentity {
+    private const val PREFS = "openzcine.relay"
+    private const val KEY = "watcherId"
+
+    public fun current(context: Context): String {
+        val prefs = context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        prefs.getString(KEY, null)?.takeIf(String::isNotEmpty)?.let { return it }
+        val minted = UUID.randomUUID().toString()
+        prefs.edit().putString(KEY, minted).apply()
+        return minted
+    }
+}

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/WifiLowLatencyLock.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/WifiLowLatencyLock.kt
@@ -1,0 +1,62 @@
+package com.opencapture.openzcine.transport
+
+import android.content.Context
+import android.net.wifi.WifiManager
+import android.util.Log
+
+/**
+ * Holds Wi-Fi in low-latency mode while a wireless camera session is live.
+ *
+ * Live view is a strict request/response pull loop: the app asks for a frame and waits. Wi-Fi
+ * power save is built for the opposite traffic — bursty, tolerant of a wake delay — so between
+ * frames the radio is free to doze, and every frame pays the wake on the way back. The policy that
+ * decides how aggressively it dozes is vendor firmware, and it is markedly more aggressive on some
+ * silicon than others.
+ *
+ * That last point is why this exists rather than something cleverer. A field report says a
+ * COMPETITOR's app shows the same platform-shaped latency split we do — and nothing in our code is
+ * shared with theirs. What both sit on is the platform's power management, and neither app can
+ * have been holding this lock.
+ *
+ * `WIFI_MODE_FULL_LOW_LATENCY` is the mode the platform provides for exactly this case. It only
+ * takes effect while the app is in the foreground, which is precisely when a monitor is being
+ * watched, and the platform drops it for us otherwise — so there is no battery trap here for an
+ * operator who backgrounds the app with a camera still connected.
+ *
+ * Cable sessions do not take it: there is no radio in that path to keep awake.
+ */
+public class WifiLowLatencyLock(context: Context) {
+    private val wifi = context.applicationContext.getSystemService(WifiManager::class.java)
+    private var lock: WifiManager.WifiLock? = null
+
+    /** Idempotent. */
+    public fun acquire() {
+        if (lock?.isHeld == true) return
+        val manager = wifi ?: return
+        val held =
+            runCatching {
+                    manager
+                        .createWifiLock(WifiManager.WIFI_MODE_FULL_LOW_LATENCY, TAG)
+                        .apply {
+                            setReferenceCounted(false)
+                            acquire()
+                        }
+                }
+                .onFailure { Log.w(TAG, "wifi low-latency lock unavailable: ${it.message}") }
+                .getOrNull()
+        lock = held
+        if (held?.isHeld == true) Log.i(TAG, "wifi low-latency lock held")
+    }
+
+    /** Idempotent, and safe to call for a lock that was never taken. */
+    public fun release() {
+        val current = lock ?: return
+        lock = null
+        runCatching { if (current.isHeld) current.release() }
+            .onFailure { Log.w(TAG, "wifi lock release failed: ${it.message}") }
+    }
+
+    private companion object {
+        const val TAG = "openzcine:live-view"
+    }
+}

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/FramePacingTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/FramePacingTest.kt
@@ -138,4 +138,42 @@ class PumpFramesTest {
         )
         assertEquals(listOf<Byte>(1, 10), presented)
     }
+
+    /**
+     * Age is the number the field reports are about: a feed can hold a steady frame rate while
+     * running a third of a second behind the room, because a stage that keeps up on average can
+     * still be holding a frame waiting its turn. Throughput cannot see that; this can.
+     */
+    @Test
+    fun `reports how far behind the presented frame is`() {
+        val lines = mutableListOf<String>()
+        val stats = FramePacingStats(reportIntervalNanos = 1_000_000_000L) { lines += it }
+
+        stats.framePresented(decodeNanos = 0L, nowNanos = 0L, ageNanos = 0L) // baseline
+        repeat(25) { index ->
+            stats.framePresented(
+                decodeNanos = 5_000_000L,
+                nowNanos = (index + 1) * 40_000_000L,
+                ageNanos = 120_000_000L,
+            )
+        }
+
+        assertTrue(lines.isNotEmpty())
+        assertTrue(lines.first().contains("age avg 120.0 ms max 120.0 ms"), lines.first())
+    }
+
+    /** A source with no usable stamp reports NO age rather than a fictional zero. */
+    @Test
+    fun `an unstamped source claims no latency at all`() {
+        val lines = mutableListOf<String>()
+        val stats = FramePacingStats(reportIntervalNanos = 1_000_000_000L) { lines += it }
+
+        stats.framePresented(decodeNanos = 0L, nowNanos = 0L)
+        repeat(25) { index ->
+            stats.framePresented(decodeNanos = 5_000_000L, nowNanos = (index + 1) * 40_000_000L)
+        }
+
+        assertTrue(lines.isNotEmpty())
+        assertTrue(!lines.first().contains("age"), lines.first())
+    }
 }

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/FramePacingTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/FramePacingTest.kt
@@ -27,7 +27,7 @@ class FramePacingStatsTest {
         // Baseline frame + 25 frames over exactly one second.
         presentSteadily(26)
         assertEquals(1, reports.size)
-        assertEquals("feed pacing: 25.0 fps | decode avg 10.0 ms max 10.0 ms | dropped 0/25", reports[0])
+        assertEquals("feed pacing: 25.0 fps | decode avg 10.0 ms max 10.0 ms | present avg 0.0 ms max 0.0 ms | dropped 0/25", reports[0])
     }
 
     @Test

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/relay/RelayControlLeaseTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/relay/RelayControlLeaseTest.kt
@@ -1,0 +1,98 @@
+package com.opencapture.openzcine.relay
+
+import com.opencapture.openzcine.core.RelayControlLease
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The Kotlin half of the control-lease table. Every case here is a case of the Swift core's
+ * `RelayControlLeaseTests` — the rule lives in two languages and only stays one rule because both
+ * halves are checked against the same rows.
+ */
+class RelayControlLeaseTest {
+    private val t0 = 1_000_000L
+
+    /** The blink this exists for: drop, come back inside the window, still holding the camera. */
+    @Test
+    fun `a watcher that comes back keeps the control it held`() {
+        val lease = RelayControlLease()
+
+        assertTrue(lease.park("watcher-a", t0))
+        assertTrue(lease.isParked(t0 + 5_000))
+        assertTrue(lease.claim("watcher-a", t0 + 5_000))
+        // Claimed once and only once — a second socket cannot inherit the same parked claim.
+        assertFalse(lease.claim("watcher-a", t0 + 6_000))
+    }
+
+    /**
+     * The window has to outlast the watcher's OWN idea of having dropped, or it can never be
+     * used: a stalled session is not declared dead for 8 s, and the rejoin ticks every 3 s after.
+     */
+    @Test
+    fun `the window outlasts the watchers own stall deadline`() {
+        assertTrue(RelayControlLease.DEFAULT_WINDOW_MILLIS >= 14_000)
+        val lease = RelayControlLease()
+        lease.park("watcher-a", t0)
+        assertTrue(lease.isParked(t0 + 14_000))
+    }
+
+    /** And it does end. A watcher that walked off set does not hold the camera indefinitely. */
+    @Test
+    fun `a watcher that never comes back loses the camera`() {
+        val lease = RelayControlLease(windowMillis = 20_000)
+        lease.park("watcher-a", t0)
+
+        assertFalse(lease.isParked(t0 + 20_001))
+        assertNull(lease.parkedWatcherId(t0 + 20_001))
+        assertFalse(lease.claim("watcher-a", t0 + 20_001))
+    }
+
+    /** A parked claim belongs to ONE device. This token presses record, so a near-miss is a miss. */
+    @Test
+    fun `only the watcher that held it can resume it`() {
+        val lease = RelayControlLease()
+        lease.park("watcher-a", t0)
+
+        assertFalse(lease.claim("watcher-b", t0 + 1_000))
+        assertFalse(lease.claim(null, t0 + 1_000))
+        assertFalse(lease.claim("", t0 + 1_000))
+        // Refused claims leave the real holder's claim intact.
+        assertTrue(lease.claim("watcher-a", t0 + 2_000))
+    }
+
+    /**
+     * A watcher we could never recognise on return is not parked at all — freezing the camera for
+     * a device that can never come back would be worse than the behaviour this replaces.
+     */
+    @Test
+    fun `an unrecognisable watcher releases immediately as before`() {
+        val lease = RelayControlLease()
+
+        assertFalse(lease.park(null, t0))
+        assertFalse(lease.isParked(t0))
+
+        assertFalse(lease.park("", t0))
+        assertFalse(lease.isParked(t0))
+    }
+
+    /** The operator never waits out the window, and a deliberate hand-back is not a disconnection. */
+    @Test
+    fun `reclaiming and releasing both end the claim at once`() {
+        val lease = RelayControlLease()
+        lease.park("watcher-a", t0)
+
+        lease.clear()
+
+        assertFalse(lease.isParked(t0 + 1_000))
+        assertFalse(lease.claim("watcher-a", t0 + 1_000))
+    }
+
+    /** Both halves agree on the number, not just the shape. */
+    @Test
+    fun `the window matches the swift core`() {
+        assertEquals(20_000L, RelayControlLease.DEFAULT_WINDOW_MILLIS)
+    }
+}

--- a/Apps/Android/core-api/src/main/kotlin/com/opencapture/openzcine/core/RelayControlLease.kt
+++ b/Apps/Android/core-api/src/main/kotlin/com/opencapture/openzcine/core/RelayControlLease.kt
@@ -1,0 +1,78 @@
+package com.opencapture.openzcine.core
+
+/**
+ * Keeps a watcher's camera control alive across a brief disconnection.
+ *
+ * Twin of the shared Swift core's `RelayControlLease`, checked against the same table.
+ *
+ * A held control token used to die with the socket. On a congested set that is wrong: a watcher
+ * whose link blinks loses the camera mid-take and has to ask for it back, and the operator has to
+ * notice and grant it again — for an outage neither of them saw. The token belongs to a PERSON
+ * holding a device, not to a TCP connection.
+ *
+ * It cannot be keyed on the connection, for the same reason it exists: the returning watcher
+ * arrives on a new socket. The hello's stable per-install `watcherId` is what the lease
+ * recognises. Anything weaker — a device name, an address — could hand camera control to the
+ * wrong person, and this is a token that presses record.
+ *
+ * Not thread-safe by itself; the host owns it under its own mutex.
+ */
+public class RelayControlLease(
+    /**
+     * How long a dropped holder keeps its claim.
+     *
+     * Twenty seconds, and it has to outlast the watcher's OWN idea of having dropped or it could
+     * never be used: a stalled viewer session is not declared dead for 8 s, and only then does a
+     * 3 s rejoin tick fire and have to re-find the broadcast. Short enough that a watcher who has
+     * genuinely walked away is not still holding the camera a minute later — and the operator
+     * never waits it out regardless, because reclaiming is always immediate.
+     */
+    public val windowMillis: Long = DEFAULT_WINDOW_MILLIS,
+) {
+    private var parkedWatcherId: String? = null
+    private var parkedUntilMillis: Long = 0
+
+    /** Whether a dropped holder is still owed its claim as of [nowMillis]. */
+    public fun isParked(nowMillis: Long): Boolean =
+        parkedWatcherId != null && nowMillis < parkedUntilMillis
+
+    /** The watcher a resumed claim would belong to, while one is owed. */
+    public fun parkedWatcherId(nowMillis: Long): String? =
+        if (isParked(nowMillis)) parkedWatcherId else null
+
+    /**
+     * The holder dropped. A claim is only parked for a watcher we can RECOGNISE on return — an
+     * anonymous watcher (one from before the field existed) releases immediately, exactly as it
+     * always did, rather than freezing the camera for a device that can never be matched.
+     */
+    public fun park(watcherId: String?, nowMillis: Long): Boolean {
+        if (watcherId.isNullOrEmpty()) {
+            clear()
+            return false
+        }
+        parkedWatcherId = watcherId
+        parkedUntilMillis = nowMillis + windowMillis
+        return true
+    }
+
+    /** Whether this hello is the parked watcher coming back, in which case the claim resumes. */
+    public fun claim(watcherId: String?, nowMillis: Long): Boolean {
+        if (watcherId.isNullOrEmpty()) return false
+        if (!isParked(nowMillis) || parkedWatcherId != watcherId) return false
+        clear()
+        return true
+    }
+
+    /**
+     * Drops the claim outright — the operator reclaiming, the watcher releasing deliberately, or
+     * the window running out. Deliberate release is not a disconnection and gets no grace.
+     */
+    public fun clear() {
+        parkedWatcherId = null
+        parkedUntilMillis = 0
+    }
+
+    public companion object {
+        public const val DEFAULT_WINDOW_MILLIS: Long = 20_000
+    }
+}

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,5 +1,5 @@
+- Fixed: a watcher granted camera control keeps it through a brief drop-out.
+- Improved: lower live-view delay over both Wi-Fi and USB-C, and less of it on some phones.
 - Fixed: a watcher granted camera control can now start and stop recording.
-- Fixed: sharing your feed no longer falls behind while the screen is being recorded.
 - New: one camera keeps a setup per way of connecting, each nameable with its own picture settings.
 - New: vertical camera mode, and the mirror assist for a camera facing you.
-- Fixed: the camera is found on networks it could not be found on before.

--- a/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
+++ b/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
@@ -4691,8 +4691,22 @@ final class PosixTCPSocket: @unchecked Sendable {
         }
         let payloadLength = Int(length) - 8
         let payload = payloadLength > 0 ? try readExact(byteCount: payloadLength) : Data()
-        return try PTPIPPacket(serializedBytes: headerBytes + Array(payload))
+        // Built from the header we ALREADY parsed plus the payload, not by gluing the two back
+        // together and asking the packet to parse them again. The round trip cost three extra
+        // copies of a JPEG-sized payload on every frame — concatenate, re-parse, re-slice — to
+        // recover a type code sitting two lines above. iOS deleted exactly this
+        // (`ios/Runner/PTPIPTransport.swift`); the Android twin kept it.
+        guard let type = PTPIPPacketType(rawValue: ByteCoding.readUInt32LE(headerBytes, at: 4))
+        else {
+            throw PTPIPClientSessionError.invalidPacketLength(length)
+        }
+        return PTPIPPacket(type: type, payload: payload)
     }
+
+    /// One receive buffer for the life of the socket. See `readExact`.
+    private static let receiveScratchCapacity = 256 * 1024
+    private lazy var receiveScratch = [UInt8](
+        repeating: 0, count: Self.receiveScratchCapacity)
 
     private func readExact(byteCount: Int) throws -> Data {
         while readBuffer.availableCount < byteCount {
@@ -4702,13 +4716,20 @@ final class PosixTCPSocket: @unchecked Sendable {
             let descriptor = try currentDescriptor()
             try waitForDescriptor(descriptor, events: Int16(POLLIN), label: "\(label) receive")
             let remaining = byteCount - readBuffer.availableCount
-            let maximumLength = min(max(remaining, 4096), 256 * 1024)
-            var bytes = [UInt8](repeating: 0, count: maximumLength)
-            let received = bytes.withUnsafeMutableBytes { rawBuffer in
+            let maximumLength = min(max(remaining, 4096), Self.receiveScratchCapacity)
+            // Reused, not reallocated. A fresh `[UInt8](repeating: 0, …)` per recv meant the
+            // kernel was asked for bytes into a quarter-megabyte buffer that Swift had just
+            // ZEROED — several times per frame, so tens of megabytes a second of pure memset in
+            // the fetch path, plus the first-touch page faults that come with brand-new pages.
+            // iOS keeps one scratch for the life of the socket; this is that.
+            let received = receiveScratch.withUnsafeMutableBytes { rawBuffer in
                 recv(descriptor, rawBuffer.baseAddress, maximumLength, 0)
             }
             if received > 0 {
-                readBuffer.append(Data(bytes.prefix(received)))
+                receiveScratch.withUnsafeBytes { rawBuffer in
+                    readBuffer.append(
+                        Data(bytes: rawBuffer.baseAddress!, count: received))
+                }
                 continue
             }
             if received == 0 {

--- a/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
+++ b/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
@@ -4046,6 +4046,21 @@ public final class PTPIPClientSession: @unchecked Sendable {
         }
 
         Thread.detachNewThread { [self] in
+            // The pump feeds the picture, so tell the scheduler that.
+            //
+            // It was inheriting whatever nice value the caller's pool thread had — zero — while
+            // the UI and render threads run at -10. A bursty copy-heavy thread at default
+            // priority is exactly the workload a big.LITTLE governor parks on an efficiency core
+            // and ramps slowly, which is a far better explanation for "noticeably late on one
+            // vendor's silicon and not another's" than any per-byte cost, because the byte costs
+            // are the same on both. `THREAD_PRIORITY_DISPLAY` is -4, the value the platform uses
+            // for work that has to make a frame deadline.
+            //
+            // On Linux `setpriority(PRIO_PROCESS, 0, …)` applies to the CALLING THREAD, which is
+            // what Android's own `Process.setThreadPriority` does underneath. Advisory: if the
+            // process rlimit refuses it the call fails and the pump runs exactly as it did
+            // before, so there is nothing to fall back to.
+            setpriority(PRIO_PROCESS, 0, -4)
             runLiveViewPump(
                 frameIntervalNanoseconds: effectiveFrameIntervalNanoseconds,
                 onFrame: onFrame, onEnded: onEnded)

--- a/Sources/OpenZCineAndroidFacade/USBPTPTransactionTransport.swift
+++ b/Sources/OpenZCineAndroidFacade/USBPTPTransactionTransport.swift
@@ -347,5 +347,24 @@ final class AndroidUSBPTPTransport: CameraTransport, @unchecked Sendable {
     private let defaultTimeoutMilliseconds = 10_000
     /// Keep idle interrupt reads short so disconnect waits at most one cycle.
     private let eventTimeoutMilliseconds = 1_000
-    private let readChunkSize = 16 * 1024
+    /// One bulk read per frame instead of a dozen.
+    ///
+    /// At 16 KiB a ~150 KB preview frame took 7-13 sequential transfers, and the cost was never
+    /// the wire — USB is not the slow part here. It was what happened BETWEEN transfers: each one
+    /// allocates a Java array of exactly this size plus a trimmed copy, and at 16 KiB both clear
+    /// ART's 12 KB large-object threshold, so every chunk put two allocations into the Large
+    /// Object Space and the bus sat idle through the allocate/copy/JNI window before the next URB
+    /// was issued. A frame cost roughly two dozen large-object allocations to move bytes that were
+    /// already there.
+    ///
+    /// 256 KiB covers a whole preview frame in one transfer, which is the point: the allocations,
+    /// the copies and the idle gaps go with the chunking that caused them. The Kotlin host already
+    /// accepts up to 1 MiB (`AndroidUsbPtpHost.MAX_READ_BYTES`), and `minSdk` is 29 so the old
+    /// API-18 16 KiB `bulkTransfer` ceiling does not apply. A short read still terminates the
+    /// container correctly because `PTPUSBReadBuffer.nextContainer` is length-driven, not
+    /// chunk-driven.
+    ///
+    /// [verify-on-HW] Confirm on a real body that the platform does not re-chunk internally on the
+    /// target release, and that a frame smaller than the chunk still completes in one pass.
+    private let readChunkSize = 256 * 1024
 }

--- a/Sources/OpenZCineCore/MonitorRelayProtocol.swift
+++ b/Sources/OpenZCineCore/MonitorRelayProtocol.swift
@@ -135,13 +135,14 @@ public struct RelayPresence: Codable, Equatable, Sendable {
 public struct MonitorRelayHello: Codable, Equatable, Sendable {
     public init(
         version: Int, hostName: String, cameraName: String?, passcode: String? = nil,
-        codecs: [String]? = nil
+        codecs: [String]? = nil, watcherID: String? = nil
     ) {
         self.version = version
         self.hostName = hostName
         self.cameraName = cameraName
         self.passcode = passcode
         self.codecs = codecs
+        self.watcherID = watcherID
     }
 
     public let version: Int
@@ -158,6 +159,11 @@ public struct MonitorRelayHello: Codable, Equatable, Sendable {
     /// without Main10, software decoders that error on it) rejoins declaring `["jpeg"]` and
     /// the host serves it JPEG instead: codec negotiation, not per-chipset whack-a-mole.
     public let codecs: [String]?
+    /// Viewer → host only: a stable per-install identity, so a watcher that drops and comes back
+    /// is recognised as the same DEVICE and can resume the control it held (`RelayControlLease`).
+    /// Absent — including every payload from before the field — means the watcher cannot be
+    /// recognised on return, and its control is released the moment the socket dies, as before.
+    public let watcherID: String?
 
     /// Whether this viewer accepts HEVC frames (absent codec list = yes, legacy behavior).
     public var acceptsHEVC: Bool { codecs?.contains("hevc") ?? true }
@@ -455,4 +461,81 @@ public enum MonitorRelayFramePayload {
         return Decoded(
             metadata: metadata, image: Data(payload[(base + 4 + jsonLength)...]))
     }
+}
+
+/// Keeps a watcher's camera control alive across a brief disconnection.
+///
+/// A held control token used to die with the socket. On a congested set that is wrong: a watcher
+/// whose link blinks loses the camera mid-take and has to ask for it back, and the operator has to
+/// notice and grant it again — for an outage neither of them saw. The token belongs to a PERSON
+/// holding a device, not to a TCP connection.
+///
+/// The window has to outlast the watcher's own idea of "I have dropped", or it can never be used:
+/// a stalled viewer session is not declared dead for 8 s, and only then does a 3 s rejoin tick
+/// fire and have to re-find the broadcast. A window under about ten seconds would expire before
+/// the watcher had even started coming back.
+///
+/// It cannot be keyed on the connection, for the same reason it exists: the returning watcher
+/// arrives on a new socket. `MonitorRelayHello.watcherID` is a stable per-install identity, so the
+/// lease recognises the DEVICE. Anything weaker — a device name, an address — could hand camera
+/// control to the wrong person, and this is a token that presses record.
+public struct RelayControlLease: Equatable, Sendable {
+    /// How long a dropped holder keeps its claim.
+    ///
+    /// Twenty seconds: the watcher's own 8 s stall deadline, plus two 3 s rejoin ticks, plus the
+    /// Bonjour re-sighting and connect those ticks wait on. Long enough that the common blink is
+    /// invisible, short enough that a watcher who has genuinely walked away is not still holding
+    /// the camera a minute later. The operator never has to wait it out regardless — reclaiming
+    /// is always available and always immediate.
+    public static let defaultWindowSeconds: TimeInterval = 20
+
+    public init(windowSeconds: TimeInterval = RelayControlLease.defaultWindowSeconds) {
+        self.windowSeconds = windowSeconds
+    }
+
+    public let windowSeconds: TimeInterval
+
+    /// A tuple would not synthesize `Equatable`, and the lease is compared in tests.
+    private struct Parked: Equatable, Sendable {
+        let watcherID: String
+        let until: Date
+    }
+
+    private var parked: Parked?
+
+    /// Whether a dropped holder is still owed its claim as of [now].
+    public func isParked(at now: Date) -> Bool {
+        guard let parked else { return false }
+        return now < parked.until
+    }
+
+    /// The watcher a resumed claim would belong to, while one is owed.
+    public func parkedWatcherID(at now: Date) -> String? {
+        isParked(at: now) ? parked?.watcherID : nil
+    }
+
+    /// The holder dropped. A claim is only parked for a watcher we can RECOGNISE on return —
+    /// an anonymous watcher (one from before the field existed) releases immediately, exactly as
+    /// it always did, rather than freezing the camera for a device that can never be matched.
+    public mutating func park(watcherID: String?, now: Date) -> Bool {
+        guard let watcherID, !watcherID.isEmpty else {
+            parked = nil
+            return false
+        }
+        parked = Parked(watcherID: watcherID, until: now.addingTimeInterval(windowSeconds))
+        return true
+    }
+
+    /// Whether this hello is the parked watcher coming back, in which case the claim resumes.
+    public mutating func claim(watcherID: String?, now: Date) -> Bool {
+        guard let watcherID, !watcherID.isEmpty, isParked(at: now),
+            parked?.watcherID == watcherID
+        else { return false }
+        parked = nil
+        return true
+    }
+
+    /// Drops the claim outright — the operator reclaiming, the watcher releasing deliberately, or
+    /// the window running out. Deliberate release is not a disconnection and gets no grace.
+    public mutating func clear() { parked = nil }
 }

--- a/Tests/OpenZCineCoreTests/RelayControlLeaseTests.swift
+++ b/Tests/OpenZCineCoreTests/RelayControlLeaseTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import Testing
+
+@testable import OpenZCineCore
+
+private let t0 = Date(timeIntervalSince1970: 1_000)
+
+/// The blink this exists for: the watcher's link drops and comes back inside the window, and it is
+/// still holding the camera. Nobody had to notice, and nobody had to ask for it again.
+@Test func aWatcherThatComesBackKeepsTheControlItHeld() {
+    var lease = RelayControlLease()
+
+    let parked = lease.park(watcherID: "watcher-a", now: t0)
+    #expect(parked)
+    #expect(lease.isParked(at: t0.addingTimeInterval(5)))
+    let resumed = lease.claim(watcherID: "watcher-a", now: t0.addingTimeInterval(5))
+    #expect(resumed)
+    // Claimed once and only once — a second socket cannot inherit the same parked claim.
+    let twice = lease.claim(watcherID: "watcher-a", now: t0.addingTimeInterval(6))
+    #expect(!twice)
+}
+
+/// The window has to outlast the watcher's OWN idea of having dropped, or it can never be used:
+/// a stalled session is not declared dead for 8 s, and the rejoin ticks every 3 s after that.
+@Test func theWindowOutlastsTheWatchersOwnStallDeadline() {
+    #expect(RelayControlLease.defaultWindowSeconds >= 14)
+    var lease = RelayControlLease()
+    _ = lease.park(watcherID: "watcher-a", now: t0)
+    // 8 s to notice the stall, then a 3 s tick, then another to re-find the broadcast.
+    #expect(lease.isParked(at: t0.addingTimeInterval(14)))
+}
+
+/// And it does end. A watcher that walked off set does not hold the camera indefinitely.
+@Test func aWatcherThatNeverComesBackLosesTheCamera() {
+    var lease = RelayControlLease(windowSeconds: 20)
+    _ = lease.park(watcherID: "watcher-a", now: t0)
+
+    let after = t0.addingTimeInterval(20.001)
+    #expect(!lease.isParked(at: after))
+    #expect(lease.parkedWatcherID(at: after) == nil)
+    let expired = lease.claim(watcherID: "watcher-a", now: after)
+    #expect(!expired)
+}
+
+/// A parked claim belongs to ONE device. This token presses record, so a near-miss is a miss.
+@Test func onlyTheWatcherThatHeldItCanResumeIt() {
+    var lease = RelayControlLease()
+    _ = lease.park(watcherID: "watcher-a", now: t0)
+
+    let wrongDevice = lease.claim(watcherID: "watcher-b", now: t0.addingTimeInterval(1))
+    let anonymous = lease.claim(watcherID: nil, now: t0.addingTimeInterval(1))
+    let empty = lease.claim(watcherID: "", now: t0.addingTimeInterval(1))
+    #expect(!wrongDevice)
+    #expect(!anonymous)
+    #expect(!empty)
+    // Refused claims leave the real holder's claim intact.
+    let realHolder = lease.claim(watcherID: "watcher-a", now: t0.addingTimeInterval(2))
+    #expect(realHolder)
+}
+
+/// A watcher we could never recognise on return is not parked at all — freezing the camera for a
+/// device that can never come back would be worse than the behaviour this replaces.
+@Test func anUnrecognisableWatcherReleasesImmediatelyAsBefore() {
+    var lease = RelayControlLease()
+
+    let parkedNil = lease.park(watcherID: nil, now: t0)
+    #expect(!parkedNil)
+    #expect(!lease.isParked(at: t0))
+
+    let parkedEmpty = lease.park(watcherID: "", now: t0)
+    #expect(!parkedEmpty)
+    #expect(!lease.isParked(at: t0))
+}
+
+/// The operator never waits out the window, and a deliberate hand-back is not a disconnection.
+@Test func reclaimingAndReleasingBothEndTheClaimAtOnce() {
+    var lease = RelayControlLease()
+    _ = lease.park(watcherID: "watcher-a", now: t0)
+
+    lease.clear()
+
+    #expect(!lease.isParked(at: t0.addingTimeInterval(1)))
+    let afterClear = lease.claim(watcherID: "watcher-a", now: t0.addingTimeInterval(1))
+    #expect(!afterClear)
+}

--- a/docs/android-latency-audit.md
+++ b/docs/android-latency-audit.md
@@ -1,0 +1,147 @@
+# Android live-view latency audit
+
+**Date:** 2026-08-10. **Trigger:** two field reports.
+
+> "Even through USB the latency is not the greatest. Wifi is barely usable in my opinion. The
+> usable latency starts with very strong compression. Competition for example zine control is much
+> better in this department."
+
+And, separately:
+
+> "both OpenZcine and ZRCTL have a noticeable latency issue on Android phones with MediaTek
+> Dimensity chipsets. Yesterday I tested a relatively high-end phone powered by the Dimensity
+> 9500s, but I still experienced noticeable display latency. In comparison, on Android phones with
+> Snapdragon chipsets, the latency is barely noticeable."
+
+Five parallel read-only audits: fetch loop, decode, presentation, end-to-end queueing, and an
+iOS-versus-Android differential. This is the synthesis, what was fixed, and what is still open.
+
+## What the reports actually tell us
+
+Three deductions constrain everything below.
+
+**USB is affected too**, so this is not primarily a network problem. Any theory that only explains
+Wi-Fi is incomplete.
+
+**Cost scales with frame size** — "usable latency starts with very strong compression". That points
+at per-pixel or per-byte work, not at protocol overhead.
+
+**The chipset split is the sharpest clue, and it does not point where it first appears to.** A
+Dimensity 9500s has ample throughput to decode a 0.59 MP JPEG. Raw compute cannot be the
+difference between two flagships. What *does* differ by vendor is GPU driver behaviour and
+scheduler placement — and the reporter says a competitor shows the same split, which rules out
+anything specific to this codebase and points at something both apps sit on top of.
+
+## Two premises that turned out to be wrong
+
+Recorded because both nearly caused wasted work.
+
+**The adaptive quality ladder is not a missing feature.** It shipped on both platforms and was
+deleted from both on 2026-08-04 by explicit decision — automatic preview softening read as
+instability (`docs/networking-audit-2026-08-04.md`). It must not be re-ported. The "very strong
+compression" report is a request for a *manual* result, not evidence of a missing automatic one.
+
+**Fetch already overlaps decode on Android.** iOS overlaps explicitly; Android overlaps
+structurally, because the pump thread hands the frame to a conflated channel and loops straight
+back to the next fetch. Same win, different mechanism. Not a gap.
+
+## Fixed
+
+| # | Finding | Where |
+| --- | --- | --- |
+| 1 | The grade was re-uploaded to the GPU on **every recomposition**, and the monitor recomposes at feed rate — so a 33³ LUT and two 64³ cubes were re-uploaded 25–30×/s, each upload ending in a full `vkQueueWaitIdle`, taken under the same lock the frame present needs | `LiveFeedGpuBackend.kt` |
+| 2 | USB read in 16 KiB chunks: 7–13 sequential transfers per frame, two Large-Object allocations *per chunk*, USB bus idle in between | `USBPTPTransactionTransport.swift` |
+| 3 | The pump thread ran at default priority and the decoder ran on the shared `Dispatchers.Default` pool, competing with scope and LUT work, while UI and render threads sit at −10 | `PTPIPClientSession.swift`, `LiveFeedView.kt` |
+| 4 | The shared frame flow had a **64-deep SUSPEND buffer**, so the producer was paced by the slowest of six consumers — three of which run on the main thread | `SwiftCoreLiveFrameSource.kt` |
+| 5 | The packet was assembled by concatenating a parsed header back onto its payload and re-parsing: three extra JPEG-sized copies per frame. iOS deleted this | `PTPIPClientSession.swift` |
+| 6 | Every `recv` allocated and zeroed a fresh 256 KiB buffer. iOS keeps one scratch per socket | `PTPIPClientSession.swift` |
+| 7 | No latency instrumentation existed at all — every counter measured throughput | `FramePacing.kt` |
+| 8 | `decode avg` in the pacing line spanned decode **and** present, hiding a blocking GPU submit inside a number read as decoder cost | `FramePacing.kt` |
+
+Findings 7 and 8 are the ones to apply first: the pacing line now reports **frame age at
+presentation** and times decode and present separately. Nothing else in this document can be
+confirmed or killed without them.
+
+## Open, ranked — and the top item needs a decision, not just work
+
+### 1. The Vulkan present blocks the decode thread, every frame
+
+`LiveFeedVk_SubmitBitmap` runs synchronously on the decode coroutine: a whole-frame `memcpy` into
+staging, then **`vkQueueWaitIdle`** (a full GPU drain), then `vkWaitForFences(UINT64_MAX)`, then a
+vsync-paced `vkAcquireNextImageKHR`. Pipeline depth is one: frame N+1 cannot begin decoding until
+frame N has finished rendering. iOS has no CPU wait anywhere in its present.
+
+This is the leading explanation for the chipset split. There are **zero vendor branches** anywhere
+in the Android live path, so the split has to come from something whose *cost* varies by driver —
+and a full queue drain after a staging copy is exactly that: on a tile-based deferred renderer
+(Mali/Immortalis, i.e. Dimensity) it forces the whole binning and fragment pass to complete with
+nothing able to pipeline behind it. It is also transport-independent, which is the only theory here
+that explains **USB being affected too**.
+
+**Falsifiable cheaply, and that should happen before any Vulkan code is written:** force the GLES
+path on a Dimensity device (`LiveFeedGpuBackendFactory.preferVulkan`) and compare the new age
+counter. The GLES path renders on its own thread and does not block.
+
+### 2. The presentation path is chosen backwards
+
+The feed is routed through Compose Canvas — two nested offscreen HWUI layers plus N glass blur
+passes per frame — whenever glass is `FULL`, which requires API 33+ **and ≥4 GB RAM**. A nominal
+4 GB phone reports ~3.6 GB, falls to `FLAT`, and gets the fast `SurfaceView` path. A flagship
+Dimensity reports 8–12 GB and gets the slow one. **Better silicon is routed to the worse
+pipeline**, and render-target switches are precisely what tilers pay most for.
+
+**This one is a product decision, not an engineering call.** Routing the feed to `SurfaceView`
+everywhere would delete the layer round-trips outright, but the liquid-glass pills would stop
+showing live video behind them — they would blur chrome only. That is a visible divergence from
+iOS and it was a deliberate trade in the other direction. It needs an explicit call.
+
+### 3. Shaders run per display pixel, not per source pixel
+
+Source is 1024×576 (0.59 MP); a fitted viewport on a 1080p panel is ~2.07 MP. Every LUT lookup,
+LIMITS composite, zebra test and peaking tap is paid **3.5× over**. iOS does the opposite: it bakes
+into an intermediate at the *feed's* resolution and the present is a single scaled sample.
+
+This is the finding that best matches "cost scales with frame size", and unlike #2 it costs nothing
+visible — the picture is the same. With peaking on, it is the difference between ~40 M and ~141 M
+texture fetches per frame.
+
+### 4. Wi-Fi power save is never inhibited
+
+No `WifiLock` anywhere, in any mode. Wi-Fi power-save policy is vendor firmware, MediaTek's is more
+aggressive than Qualcomm's, and a strict request/response pull loop pays the wake latency directly
+on every frame. This is the **only** hypothesis that explains a competitor showing the same split,
+since nothing in our code is shared with theirs but this is. It is also the cheapest thing on this
+list to try: acquire `WIFI_MODE_FULL_LOW_LATENCY` while a wireless camera session is live.
+
+### 5. Smaller, verified, uncontroversial
+
+- **No frame deadline on the Android live-view fetch.** iOS clamps to `25×RTT` within 6–15 s;
+  Android's `getLiveViewImageEx` has none, so a trickling link can hold the serial gate
+  indefinitely.
+- **Fixed event-poll stride of 8**, where iOS scales the stride by measured RTT using
+  `LiveViewPollPacing` — which lives in the *shared core* and the Android facade simply never calls.
+- **Per-frame `NewByteArray`** into ART's Large Object Space, on the pump thread, so a collection
+  blocks the fetch loop. Needs a pool ≥3 deep, because consumers retain the array past the callback.
+- **GLES path copies the whole bitmap on the CPU** before uploading it, purely to break aliasing
+  against the decoder's ring — the decoder already owns a 3-deep ring that could hold a lease
+  instead.
+- **The scopes decode the JPEG a second time.** Correct isolation, real CPU cost, and iOS reuses
+  the already-decoded frame instead.
+- **A redundant `inJustDecodeBounds` pass per frame** computing a constant. Left alone deliberately:
+  the saving is small and whether the bound can ever be exceeded by a non-camera source needs
+  checking first.
+
+### Not a gap
+
+Thermal handling is genuinely equivalent on both platforms — and inert on the stream on both, which
+may itself be worth revisiting. The relay encoder-queue bug fixed on iOS has no Android analogue by
+design: that host re-encodes nothing and its per-watcher lane is already a bounded drop-oldest
+channel.
+
+## What to do next, in order
+
+1. Read the new age and present counters off a Dimensity device. Everything above is reasoning from
+   source; none of it is a profile.
+2. Force GLES on that device and read them again. That one comparison confirms or kills #1.
+3. Try the `WifiLock` — it is hours of work and would explain the competitor datum.
+4. Then decide #2, which is Erik's call, and schedule #3, which is not.

--- a/ios/Runner/MonitorRelayLink.swift
+++ b/ios/Runner/MonitorRelayLink.swift
@@ -229,6 +229,9 @@ final class MonitorRelayHost {
         /// From the hello's codec declaration (absent = true, legacy). A jpeg-only peer —
         /// hardware whose decoders reject the HEVC stream — gets the JPEG twin of each frame.
         var acceptsHEVC = true
+        /// The stable install identity from this peer's hello, when it sent one. What lets a
+        /// dropped holder be recognised on a NEW socket and resume its control.
+        var watcherID: String?
     }
 
     /// Fired when some peer is waiting on a keyframe the current stream position cannot give it.
@@ -239,6 +242,10 @@ final class MonitorRelayHost {
     /// The viewer currently allowed to drive the camera; nil means the host itself does.
     private(set) var controlHolder: ObjectIdentifier?
     private(set) var controlHolderName: String?
+    /// A dropped holder's claim, alive for a short window so a blink on a congested set does not
+    /// cost the operator the camera mid-take. See `RelayControlLease`.
+    private var controlLease = RelayControlLease()
+    private var leaseExpiryTask: Task<Void, Never>?
     /// A viewer that has asked and not yet been answered.
     private(set) var pendingRequestName: String?
     private var pendingRequest: ObjectIdentifier?
@@ -422,10 +429,28 @@ final class MonitorRelayHost {
         relayLogger.info("relay host: viewer left (\(max(0, self.peers.count - 1)) remain)")
         connection.cancel()
         let key = ObjectIdentifier(connection)
+        // Read before the removal: parking this claim needs the identity the peer introduced
+        // itself with, and the peer is about to stop existing.
+        let departingWatcherID = peers[key]?.watcherID
         peers.removeValue(forKey: key)
-        // A viewer that disappears cannot keep the camera hostage: control returns to the host,
-        // which is the device that actually holds the session and can always act.
-        if controlHolder == key { reclaimControl() }
+        // A viewer that disappears cannot keep the camera hostage — but a link that BLINKS is
+        // not a viewer that disappeared, and on a congested set the two look identical for a few
+        // seconds. The claim is parked for a short window (`RelayControlLease`) so the same
+        // device can resume it on its way back in; if it does not, control returns to the host,
+        // which holds the session and can always act. Reclaiming never waits for this.
+        if controlHolder == key {
+            let holderName = controlHolderName
+            if controlLease.park(watcherID: departingWatcherID, now: Date()) {
+                controlHolder = nil
+                controlHolderName = holderName
+                relayLogger.info("relay host: holder dropped — claim parked")
+                startLeaseExpiry()
+                publishControlToken()
+                onControlChanged?()
+            } else {
+                reclaimControl()
+            }
+        }
         if pendingRequest == key {
             pendingRequest = nil
             pendingRequestName = nil
@@ -486,7 +511,19 @@ final class MonitorRelayHost {
             else { return }
             peers[key]?.name = hello.hostName
             peers[key]?.acceptsHEVC = hello.acceptsHEVC
+            peers[key]?.watcherID = hello.watcherID
             if controlHolder == key { controlHolderName = hello.hostName }
+            // The holder that dropped, coming back. Its claim resumes on this new socket without
+            // the operator having to notice the outage or grant control a second time.
+            if controlHolder == nil, controlLease.claim(watcherID: hello.watcherID, now: Date()) {
+                leaseExpiryTask?.cancel()
+                leaseExpiryTask = nil
+                controlHolder = key
+                controlHolderName = hello.hostName
+                relayLogger.info("relay host: dropped holder resumed control")
+                publishControlToken()
+                onControlChanged?()
+            }
             if peers[key]?.authorized == false {
                 if hello.passcode == watcherPasscode {
                     peers[key]?.authorized = true
@@ -551,7 +588,27 @@ final class MonitorRelayHost {
 
     /// Takes the camera back. Always available: the host owns the session, so this can never fail
     /// or need the viewer's cooperation — which is what makes handing control out safe.
+    /// Ends a parked claim when its window runs out, so the operator gets the camera back without
+    /// having to do anything. Cancelled by a resume, by reclaiming, and by the host stopping.
+    private func startLeaseExpiry() {
+        leaseExpiryTask?.cancel()
+        leaseExpiryTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(RelayControlLease.defaultWindowSeconds))
+            guard !Task.isCancelled, let self, self.controlLease.isParked(at: Date()) == false
+            else {
+                // Slept short, or the claim was resumed while we slept. Either way the timer has
+                // no verdict to deliver.
+                return
+            }
+            relayLogger.info("relay host: parked claim expired — control returned")
+            self.reclaimControl()
+        }
+    }
+
     func reclaimControl() {
+        leaseExpiryTask?.cancel()
+        leaseExpiryTask = nil
+        controlLease.clear()
         controlHolder = nil
         controlHolderName = nil
         publishControlToken()
@@ -965,6 +1022,20 @@ final class MonitorRelayClient {
         if state != .idle { update(.idle) }
     }
 
+    /// This install's stable relay identity, so a host can recognise this DEVICE across a
+    /// reconnect and hand back the control it was holding (`RelayControlLease`). Persisted, not
+    /// derived: a device name is not unique and an address is not stable, and this decides who
+    /// may press record.
+    static var watcherID: String {
+        let key = "relay.watcherID"
+        if let existing = UserDefaults.standard.string(forKey: key), !existing.isEmpty {
+            return existing
+        }
+        let minted = UUID().uuidString
+        UserDefaults.standard.set(minted, forKey: key)
+        return minted
+    }
+
     /// Introduces this device so a control request can name who is asking — and carries the
     /// watcher passcode when the broadcast requires one.
     func introduce(deviceName: String, passcode: String? = nil) {
@@ -972,7 +1043,7 @@ final class MonitorRelayClient {
             let payload = try? JSONEncoder().encode(
                 MonitorRelayHello(
                     version: MonitorRelayProtocol.version, hostName: deviceName, cameraName: nil,
-                    passcode: passcode))
+                    passcode: passcode, watcherID: Self.watcherID))
         else { return }
         send(kind: .hello, payload: payload)
     }

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -13,7 +13,7 @@ Fixes
 - Scanned Wi-Fi details can be corrected. If OCR misreads a character in the network name or the key, tap either and fix it instead of starting over.
 - A Wi-Fi connection no longer asks you to join the camera's own network, and saved setups no longer read as offline while you are on that network.
 - A weak or busy link degrades the picture instead of dropping the session, and screen recording while you share your feed no longer walks the watcher's picture behind the action.
-- A watcher granted camera control can now start and stop the take. The record confirmation is asked once, on the device you pressed the button on.
+- A watcher granted camera control can now start and stop the take, and keeps that control through a brief drop-out instead of losing it the moment the link stutters.
 - Fixed a crash that could end a live session on some iPads while Feed Noise Reduction was on. Thank you to whoever sent that report — the log had exactly what was needed.
 - Changes made on the camera reach the app quickly again - the aperture ring, ISO or shutter used to take twenty seconds, or in video never.
 - Unplugging the cable or power-cycling the camera used to wedge the app. Both recover on their own, or offer Retry connection.


### PR DESCRIPTION
Everything outstanding for 0.2.5, on one branch. Two independent bodies of work; both
verified, neither verified on hardware.

Supersedes #325, and recovers the control-grace fix that was written for #320 and did not
make it into that merge — `main` has the other two relay fixes from #320 but not this one,
so the reported bug is still live.

## A watcher's control survives a blink

Control died with the socket. On a congested set the operator had to notice a drop-out
neither of them saw, and grant control again. The token belongs to a person holding a
device, not to a TCP connection.

A dropped holder's claim is parked for **twenty seconds** and resumes when the same device
returns. The number is derived, not chosen: a stalled viewer is not declared dead for 8 s,
and only then does a 3 s rejoin tick fire and have to re-find the broadcast. Under about
ten seconds and it would expire before the watcher had started coming back.

It keys on a stable per-install id, not the connection (the returning watcher arrives on a
new socket) and not the device name (two phones can share one, and this token presses
record). Reclaiming, a deliberate hand-back, and the window expiring all still act at once.

## Android live-view latency

From two field reports: latency worse than iOS and worse than a competitor, over **USB as
well as Wi-Fi**, and markedly worse on MediaTek than Snapdragon. Five parallel audits —
fetch, decode, presentation, end-to-end queueing, and the iOS differential — are written up
in `docs/android-latency-audit.md`.

Eight things fixed. The ones that matter most:

- The grade was re-uploaded to the GPU **on every recomposition**, and the monitor
  recomposes at feed rate — a LUT and two cubes re-uploaded 25–30×/s, each ending in a full
  `vkQueueWaitIdle`, under the same lock the frame present needs.
- The shared frame flow had a **64-deep SUSPEND buffer**, so the camera pump was paced by
  the slowest of six consumers — three of which run on the main thread.
- USB read in 16 KiB chunks: 7–13 transfers per frame, two large-object allocations *per
  chunk*, bus idle in between.
- Nine payload copies per frame on Wi-Fi. Three of them are what iOS already deleted and
  nobody ported; so is the 256 KiB buffer that was allocated and zeroed on every `recv`.
- The picture ran at background priority, on a pool shared with scopes and LUT baking.
- Wi-Fi power save was never inhibited — the one hypothesis that also explains a
  *competitor* showing the same split, since nothing in our code is shared with theirs.

**Two of these are instrumentation, and they should be read first.** Nothing measured
latency before — every counter was throughput, and a feed can hold a steady thirty while
running a third of a second late. The pacing line now reports frame age, and decode and
present are timed separately, because they shared one timer labelled "decode" and a
blocking GPU submit was hiding inside it.

## What is deliberately not here

**The Vulkan present blocks the decode thread on a full GPU queue drain, every frame.** It
is the best explanation on offer for the chipset split — the one cost that varies by driver
rather than by silicon speed, and transport-independent, so it also explains USB. It is
real synchronisation work whose failure mode is tearing on one vendor and not the other,
and there is a ten-minute experiment that confirms or kills it first: force GLES on a
Dimensity and read the new age counter.

**The feed is routed to the slow presentation path on better hardware.** Compose Canvas —
two nested offscreen layers plus per-frame blur passes — whenever glass is FULL, which
needs ≥4 GB RAM. A nominal 4 GB phone reports ~3.6 GB and gets the *fast* SurfaceView path;
a flagship gets the slow one. Fixing it means the glass pills stop showing live video
behind them, which is a visible divergence from iOS and a product call, not an engineering
one.

Also recorded in the audit: two premises that turned out to be **wrong**, including that
the adaptive quality ladder is not a missing feature — it shipped on both platforms and was
deleted from both in August by explicit decision.

## Gates

`just check` (1323 tests) · `just native-check` · `just android-check` · `just secrets` ·
`just hygiene` — all green on the consolidated branch.

## Not verified on hardware

Neither half. The control grace wants two devices and a briefly interrupted link. The
latency work wants the age counter read on a Dimensity, before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
