### PR TITLE
feat(ios): the iPhone rotates into both landscapes

### DIFF
--- a/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
+++ b/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
@@ -80,6 +80,17 @@ public struct MonitorFeedFrame: Equatable, Sendable {
         self.width = width
         self.height = height
     }
+
+    /// Mirrors the frame around the viewport's vertical center line — the same operation the
+    /// module frames carry, so the feed can follow the one-mirror-at-the-exit rule they follow.
+    public func mirroredHorizontally(in viewportWidth: Double) -> MonitorFeedFrame {
+        MonitorFeedFrame(
+            x: max(0, viewportWidth) - x - width,
+            y: y,
+            width: width,
+            height: height
+        )
+    }
 }
 
 /// Named anchors for placing a fixed-size module inside a layout region.
@@ -283,22 +294,29 @@ public enum MonitorFeedLayout {
             x = min(max(remainingWidth / 2, leadingInset), maxX)
         } else if MonitorBatteryRailLayout.usesClassicSideNotch(safeArea: safeArea) {
             // Classic iPhones report equal horizontal safe areas even though only one side has
-            // the notch. Use physical orientation to clear that side, then bias the feed slightly
-            // toward the opposite control rail to close its oversized black gap.
+            // the notch: clear the leading side, biased slightly toward the opposite control
+            // rail to close its oversized black gap. STANDARD space only — the exit mirror
+            // below owns the other side, for this arm and every other one. (This arm used to
+            // mirror in place, which for its equal insets happened to equal the exit mirror —
+            // and the island arm below did not mirror at all, so the chrome flipped around a
+            // picture that stayed put: the capture rail overlaid the feed's left edge and a
+            // dead lane sat inboard of the island.)
             let availableShift = max(
                 0,
                 remainingWidth - max(0, safeArea.leading) - max(0, safeArea.trailing)
             )
             let railwardShift = min(classicNotchRailwardShift, availableShift)
-            x =
-                horizontalDirection == .mirrored
-                ? max(0, remainingWidth - safeArea.trailing - railwardShift)
-                : min(remainingWidth, safeArea.leading + railwardShift)
+            x = min(remainingWidth, safeArea.leading + railwardShift)
         } else {
             x = min(remainingWidth, leadingInset)
         }
 
-        return MonitorFeedFrame(x: x, y: 0, width: width, height: viewportHeight)
+        let standard = MonitorFeedFrame(x: x, y: 0, width: width, height: viewportHeight)
+        // ONE mirror, at the exit, for every arm above — the same rule the module frames follow.
+        // A direction-aware arm here and a direction-blind one there is exactly how the two
+        // halves of the screen ended up disagreeing about which side the island was on.
+        guard horizontalDirection == .mirrored else { return standard }
+        return standard.mirroredHorizontally(in: viewportWidth)
     }
 
     /// Fits the feed to the visible viewport without expanding the source frame.
@@ -478,10 +496,11 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
     public func mirroredChromeHorizontally(in viewportWidth: Double) -> MonitorLiveViewModuleLayout
     {
         MonitorLiveViewModuleLayout(
-            feed: feed,
+            feed: feed.mirroredHorizontally(in: viewportWidth),
             batteryRail: batteryRail.mirroredHorizontally(in: viewportWidth),
-            // Top deck floats over the feed, which is not mirrored, so it stays put too.
-            topInfoDeck: topInfoDeck,
+            // The deck rides the feed, so it mirrors WITH the feed. Leaving both put while the
+            // chrome flipped is what parked the capture cluster on the picture.
+            topInfoDeck: topInfoDeck.mirroredHorizontally(in: viewportWidth),
             bottomAssistTools: bottomAssistTools.mirroredHorizontally(in: viewportWidth),
             bottomCaptureSettings: bottomCaptureSettings.mirroredHorizontally(in: viewportWidth),
             rightRailControls: rightRailControls.mirroredHorizontally(in: viewportWidth),
@@ -533,11 +552,15 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
             height: bottomRegion.height
         )
         let rightRailWidth = Self.rightRailWidth(for: chrome.width)
+        // STANDARD space, deliberately: every frame in this function is built for the standard
+        // direction and the single exit mirror flips the finished layout — feed and deck
+        // included. Threading the direction into some frames here and mirroring others at the
+        // exit is how the rails ended up computed in the island lane they do not fit in.
         let feed = MonitorFeedLayout.fullBleedFrame(
             viewportWidth: viewportWidth,
             viewportHeight: viewportHeight,
             safeArea: feedSafeArea,
-            horizontalDirection: horizontalDirection
+            horizontalDirection: .standard
         )
         let usesClassicSideNotch = MonitorBatteryRailLayout.usesClassicSideNotch(
             safeArea: feedSafeArea
@@ -554,8 +577,7 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
             ? min(MonitorFeedLayout.classicNotchRailwardShift, availableClassicShift)
             : 0
         let railReferenceFeed = MonitorFeedFrame(
-            x: feed.x
-                + (horizontalDirection == .mirrored ? classicShift : -classicShift),
+            x: feed.x - classicShift,
             y: feed.y,
             width: feed.width,
             height: feed.height
@@ -625,18 +647,22 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
         let layout = MonitorLiveViewModuleLayout(
             feed: feed,
             batteryRail: batteryRail,
-            topInfoDeck: Self.deckFrameClearingRail(
-                deck: MonitorModuleFrame(
+            topInfoDeck: constrained
+                ? MonitorModuleFrame(
                     x: deckLeft,
                     y: chrome.y,
                     width: max(0, deckRight - deckLeft),
                     height: topInfoDeckHeight
+                )
+                : Self.deckFrameClearingRail(
+                    deck: MonitorModuleFrame(
+                        x: deckLeft,
+                        y: chrome.y,
+                        width: max(0, deckRight - deckLeft),
+                        height: topInfoDeckHeight
+                    ),
+                    rail: rightRailControls
                 ),
-                rail: rightRailControls,
-                constrained: constrained,
-                horizontalDirection: horizontalDirection,
-                viewportWidth: viewportWidth
-            ),
             bottomAssistTools: Self.bottomAssistFrame(
                 in: bottomRegion,
                 width: bottomModuleWidth,
@@ -705,30 +731,17 @@ public struct MonitorLiveViewModuleLayout: Equatable, Sendable {
     /// unclipped span.
     private static func deckFrameClearingRail(
         deck: MonitorModuleFrame,
-        rail: MonitorModuleFrame,
-        constrained: Bool,
-        horizontalDirection: MonitorHorizontalLayoutDirection,
-        viewportWidth: Double
+        rail: MonitorModuleFrame
     ) -> MonitorModuleFrame {
-        guard !constrained else { return deck }
-
-        // The deck is already in final coordinates (it hangs off the feed, which the caller built
-        // for the requested direction); the rail is mirrored later, so mirror it here to compare.
-        let mirrored = horizontalDirection == .mirrored
-        let rail = mirrored ? rail.mirroredHorizontally(in: viewportWidth) : rail
-        let left =
-            mirrored
-            ? max(deck.x, rail.x + rail.width + topInfoDeckControlGap)
-            : deck.x
-        let right =
-            mirrored
-            ? deck.x + deck.width
-            : min(deck.x + deck.width, rail.x - topInfoDeckControlGap)
-
+        // Standard space, like everything else in `fit` — the deck's trailing end clears the
+        // rail, and the exit mirror carries both to the other side together. The half-mirrored
+        // comparison this used to do was only ever needed because the feed skipped the exit
+        // mirror the modules took.
+        let right = min(deck.x + deck.width, rail.x - topInfoDeckControlGap)
         return MonitorModuleFrame(
-            x: left,
+            x: deck.x,
             y: deck.y,
-            width: max(0, right - left),
+            width: max(0, right - deck.x),
             height: deck.height
         )
     }

--- a/Tests/OpenZCineCoreTests/MonitorLayoutPolicyTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorLayoutPolicyTests.swift
@@ -394,16 +394,13 @@ import Testing
     #expect(layout.rightRailLaneCenterLine.height == 390)
 }
 
-@Test func liveViewModuleFramesMirrorChromeButNotFeedForLandscapeRight() {
+@Test func liveViewModuleFramesMirrorFeedAndChromeTogetherForLandscapeRight() {
+    // This test used to pin the OPPOSITE: "mirror chrome but not feed". That pinned rule is the
+    // one the first hardware pass of the second landscape refuted — the chrome flipped around a
+    // picture that stayed put, so the capture cluster sat ON the feed and a dead lane sat
+    // inboard of the island. The layout mirrors as one piece or not at all.
     let chromeInsets = MonitorChromeLayout.insets(
         feedSafeArea: MonitorEdgeInsets(top: 0, leading: 59, bottom: 21, trailing: 44)
-    )
-    let landscapeLeft = MonitorLiveViewModuleLayout.fit(
-        viewportWidth: 844,
-        viewportHeight: 390,
-        feedSafeArea: MonitorEdgeInsets(top: 0, leading: 59, bottom: 21, trailing: 44),
-        chromeInsets: chromeInsets,
-        bottomBarHeight: 54
     )
     let landscapeRight = MonitorLiveViewModuleLayout.fit(
         viewportWidth: 844,
@@ -422,9 +419,20 @@ import Testing
         horizontalDirection: .standard
     )
 
-    #expect(landscapeRight.feed.x == 0)
-    #expect(landscapeRight.feed.width == landscapeLeft.feed.width)
-    #expect(landscapeRight.batteryRail.x == 790)
+    // Every frame is the mirror of its standard twin — feed included, and the deck WITH it.
+    #expect(
+        landscapeRight.feed
+            == unmirroredLandscapeRight.feed.mirroredHorizontally(in: 844)
+    )
+    #expect(
+        abs(
+            landscapeRight.topInfoDeck.x
+                - unmirroredLandscapeRight.topInfoDeck.mirroredHorizontally(in: 844).x) < 0.5
+    )
+    #expect(
+        landscapeRight.batteryRail
+            == unmirroredLandscapeRight.batteryRail.mirroredHorizontally(in: 844)
+    )
     #expect(
         landscapeRight.rightRailControls
             == unmirroredLandscapeRight.rightRailControls.mirroredHorizontally(in: 844)
@@ -433,8 +441,14 @@ import Testing
         landscapeRight.rightRailLaneCenterLine
             == unmirroredLandscapeRight.rightRailLaneCenterLine.mirroredHorizontally(in: 844)
     )
-    #expect(landscapeRight.bottomAssistTools.x == 429)
-    #expect(landscapeRight.bottomCaptureSettings.x == 18)
+    #expect(
+        landscapeRight.bottomAssistTools
+            == unmirroredLandscapeRight.bottomAssistTools.mirroredHorizontally(in: 844)
+    )
+    #expect(
+        landscapeRight.bottomCaptureSettings
+            == unmirroredLandscapeRight.bottomCaptureSettings.mirroredHorizontally(in: 844)
+    )
 }
 
 @Test func liveViewTopInfoDeckDoesNotDependOnBottomBars() {
@@ -1156,4 +1170,64 @@ import Testing
     #expect(abs(frame.width - 500 * 9 / 16) < 0.5)
     #expect(abs(frame.x - (390 - 500 * 9.0 / 16) / 2) < 0.5)
     #expect(frame.y == 0)
+}
+
+/// The mirrored feed is the MIRROR of the standard feed — on every phone, not only the classic
+/// notch. The island phone's arm ignored the direction, so the picture stayed put while the
+/// chrome flipped around it: the capture rail overlaid the feed's left edge and a dead black
+/// lane sat inboard of the island (field report, first hardware pass of the second landscape).
+@Test func feedLayoutMirrorsOnIslandPhones() {
+    // iPhone 16 Pro-class landscape: symmetric 59pt island lanes.
+    let safeArea = MonitorEdgeInsets(top: 0, leading: 59, bottom: 21, trailing: 59)
+    let standard = MonitorFeedLayout.fullBleedFrame(
+        viewportWidth: 874,
+        viewportHeight: 402,
+        safeArea: safeArea
+    )
+    let mirrored = MonitorFeedLayout.fullBleedFrame(
+        viewportWidth: 874,
+        viewportHeight: 402,
+        safeArea: safeArea,
+        horizontalDirection: .mirrored
+    )
+
+    // Standard clears the leading island; mirrored clears the trailing one.
+    #expect(standard.x == 59)
+    #expect(mirrored.x == 874 - standard.x - standard.width)
+    #expect(mirrored.width == standard.width)
+    // The island lane is free on the side that has an island.
+    #expect(mirrored.x + mirrored.width <= 874 - 59)
+}
+
+/// The whole map mirrors as one piece: the feed, the deck over it, and the rails around it.
+/// Mirroring the chrome around an unmirrored feed is what put the record cluster ON the
+/// picture and the recording rail in a 59pt island lane it does not fit in.
+@Test func zoneMapMirrorsFeedDeckAndRailsTogether() {
+    let safeArea = MonitorEdgeInsets(top: 0, leading: 59, bottom: 21, trailing: 59)
+    let standard = MonitorLiveViewModuleLayout.fit(
+        viewportWidth: 874,
+        viewportHeight: 402,
+        feedSafeArea: safeArea,
+        chromeInsets: MonitorEdgeInsets.chrome(for: .zero),
+        bottomBarHeight: 56
+    )
+    let mirrored = MonitorLiveViewModuleLayout.fit(
+        viewportWidth: 874,
+        viewportHeight: 402,
+        feedSafeArea: safeArea,
+        chromeInsets: MonitorEdgeInsets.chrome(for: .zero),
+        bottomBarHeight: 56,
+        horizontalDirection: .mirrored
+    )
+
+    // The feed mirrors with its chrome, not independently of it.
+    #expect(mirrored.feed.x == 874 - standard.feed.x - standard.feed.width)
+    // The deck rides the feed.
+    #expect(
+        abs(mirrored.topInfoDeck.x - (874 - standard.topInfoDeck.x - standard.topInfoDeck.width))
+            < 0.5)
+    // The rail keeps its full lane on the other side — it must never be squeezed into the
+    // island lane. Same width both directions is the whole claim.
+    #expect(abs(mirrored.rightRailControls.width - standard.rightRailControls.width) < 0.5)
+    #expect(mirrored.rightRailControls.x < mirrored.feed.x)
 }

--- a/ios/Runner/DemoHarness.swift
+++ b/ios/Runner/DemoHarness.swift
@@ -765,9 +765,14 @@ enum DemoHarness {
                 let scenes = UIApplication.shared.connectedScenes
                     .compactMap { $0 as? UIWindowScene }
                 let mask: UIInterfaceOrientationMask =
-                    // The app supports interface LandscapeRight only (see Info.plist) — requesting
-                    // the unsupported side would silently no-op.
-                    raw == "landscape" ? .landscapeRight : .portrait
+                    switch raw {
+                    // "landscape" keeps its historical meaning (interface LandscapeRight, notch
+                    // left) so existing capture scripts stay valid; the explicit names reach each
+                    // side now that Info.plist allows both.
+                    case "landscape", "landscapeRight": .landscapeRight
+                    case "landscapeLeft": .landscapeLeft
+                    default: .portrait
+                    }
                 scenes.first?.requestGeometryUpdate(.iOS(interfaceOrientations: mask))
             }
             if let raw = env["ZC_DEMO_FEED_ASPECT"], env["ZC_DEMO_AUTOSTART"] != "1",

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -111,6 +111,7 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<!-- iPad: all four orientations. No island, so the one-landscape-side rule above does not

--- a/ios/Runner/MonitorExperience.swift
+++ b/ios/Runner/MonitorExperience.swift
@@ -72,10 +72,15 @@ struct MonitorExperience: View {
 
 private struct LiveViewShell: View {
     @Environment(NativeAppModel.self) private var model
+    /// OBSERVED state, not a body-time read. The two landscapes are invisible to layout —
+    /// same size, symmetric safe areas — so flipping between them changes nothing SwiftUI
+    /// already watches, and a body-time read of the orientation stayed stale until some other
+    /// invalidation (a DISP tap was the field repro) happened to rebuild the shell. Portrait
+    /// transitions only ever worked because the SIZE change re-ran the body.
+    @State private var deviceOrientation = MonitorDeviceOrientationReader.current()
 
     var body: some View {
         GeometryReader { proxy in
-            let deviceOrientation = MonitorDeviceOrientationReader.current()
             let screenWidth = MonitorDeviceOrientationReader.currentViewportWidth()
             let context = LiveViewLayoutContext(
                 proxy: proxy,
@@ -90,6 +95,9 @@ private struct LiveViewShell: View {
             MonitorShell(context: context)
                 .environment(model)
                 .animation(.easeInOut(duration: 0.3), value: context.isPortrait)
+                // The landscape-to-landscape flip animates for the same reason the portrait one
+                // does — the modules glide to their mirrored frames under stable identity.
+                .animation(.easeInOut(duration: 0.3), value: context.horizontalDirection)
                 .frame(width: proxy.size.width, height: proxy.size.height)
                 .ignoresSafeArea(.container, edges: .all)
                 // Tally + full-screen panel overlay the already-extended (physical-screen) layer
@@ -129,6 +137,38 @@ private struct LiveViewShell: View {
         // Snappy panel insert/remove so dismissing a popup feels near-instant.
         .animation(.easeOut(duration: 0.10), value: model.activePanel)
         .animation(.easeInOut(duration: 0.18), value: model.displayMode)
+        .onAppear {
+            // Rotation notifications only flow while something has asked for them; without this
+            // the subscription below never fires on devices nothing else has enabled it on.
+            UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+            deviceOrientation = MonitorDeviceOrientationReader.current()
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: UIDevice.orientationDidChangeNotification)
+        ) { _ in
+            // Read on the NEXT runloop turn: the notification reports the DEVICE moving, and the
+            // scene's interface orientation — the thing the layout keys on — commits a beat
+            // later. Reading synchronously here races it and can latch the outgoing orientation,
+            // which would be this bug again with an extra step.
+            DispatchQueue.main.async {
+                deviceOrientation = MonitorDeviceOrientationReader.current()
+            }
+        }
+        .onReceive(
+            // The INTERFACE can rotate without the device moving — `requestGeometryUpdate`
+            // (the demo harness's headless rotation) and windowing moves land that way, and the
+            // device notification above stays silent for all of them. This is the notification
+            // UIKit posts when the interface orientation itself commits. Referenced by its wire
+            // name: the symbolic constant is deprecated (the STATUS BAR framing is what Apple
+            // retired, not the event), and the name string is documented API surface.
+            NotificationCenter.default.publisher(
+                for: Notification.Name("UIApplicationDidChangeStatusBarOrientationNotification"))
+        ) { _ in
+            DispatchQueue.main.async {
+                deviceOrientation = MonitorDeviceOrientationReader.current()
+            }
+        }
     }
 }
 

--- a/ios/Runner/MonitorExperience.swift
+++ b/ios/Runner/MonitorExperience.swift
@@ -77,7 +77,8 @@ private struct LiveViewShell: View {
     /// already watches, and a body-time read of the orientation stayed stale until some other
     /// invalidation (a DISP tap was the field repro) happened to rebuild the shell. Portrait
     /// transitions only ever worked because the SIZE change re-ran the body.
-    @State private var deviceOrientation = MonitorDeviceOrientationReader.current()
+    @State private var orientationObserver = InterfaceOrientationObserver()
+    private var deviceOrientation: MonitorDeviceOrientation { orientationObserver.orientation }
 
     var body: some View {
         GeometryReader { proxy in
@@ -137,39 +138,59 @@ private struct LiveViewShell: View {
         // Snappy panel insert/remove so dismissing a popup feels near-instant.
         .animation(.easeOut(duration: 0.10), value: model.activePanel)
         .animation(.easeInOut(duration: 0.18), value: model.displayMode)
-        .onAppear {
-            // Rotation notifications only flow while something has asked for them; without this
-            // the subscription below never fires on devices nothing else has enabled it on.
-            UIDevice.current.beginGeneratingDeviceOrientationNotifications()
-            deviceOrientation = MonitorDeviceOrientationReader.current()
+        .onAppear { orientationObserver.start() }
+    }
+}
+
+/// Publishes the interface orientation as observable state.
+///
+/// The first cut of this listened for NOTIFICATIONS — the device one, and the deprecated
+/// status-bar one for interface-only rotations. Hardware refuted it: neither arrived on a
+/// physical phone, and because the orientation had just become captured state rather than a
+/// body-time read, the staleness this exists to fix came back WORSE — nothing, not even the
+/// DISP tap that used to jog it, could refresh a value no notification ever updated.
+///
+/// `UIWindowScene.effectiveGeometry` is the structural signal: documented KVO-compliant, it
+/// covers every way the interface can turn — a hand rotating the phone, a geometry request
+/// (the demo harness's headless rotation), a windowing change — and it fires when the new
+/// geometry has COMMITTED, so there is no next-runloop race to lose. The device-rotation
+/// notification stays as a belt-and-braces second source; where it works it is merely
+/// redundant.
+@MainActor
+@Observable
+final class InterfaceOrientationObserver {
+    private(set) var orientation = MonitorDeviceOrientationReader.current()
+    @ObservationIgnored private var geometryObservation: NSKeyValueObservation?
+    @ObservationIgnored private var deviceObserver: (any NSObjectProtocol)?
+
+    func start() {
+        refresh()
+        guard geometryObservation == nil else { return }
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        let scene =
+            scenes.first { $0.activationState == .foregroundActive }
+            ?? scenes.first
+        geometryObservation = scene?.observe(\.effectiveGeometry, options: [.new]) {
+            [weak self] _, _ in
+            Task { @MainActor [weak self] in self?.refresh() }
         }
-        .onReceive(
-            NotificationCenter.default.publisher(
-                for: UIDevice.orientationDidChangeNotification)
-        ) { _ in
-            // Read on the NEXT runloop turn: the notification reports the DEVICE moving, and the
-            // scene's interface orientation — the thing the layout keys on — commits a beat
-            // later. Reading synchronously here races it and can latch the outgoing orientation,
-            // which would be this bug again with an extra step.
-            DispatchQueue.main.async {
-                deviceOrientation = MonitorDeviceOrientationReader.current()
-            }
-        }
-        .onReceive(
-            // The INTERFACE can rotate without the device moving — `requestGeometryUpdate`
-            // (the demo harness's headless rotation) and windowing moves land that way, and the
-            // device notification above stays silent for all of them. This is the notification
-            // UIKit posts when the interface orientation itself commits. Referenced by its wire
-            // name: the symbolic constant is deprecated (the STATUS BAR framing is what Apple
-            // retired, not the event), and the name string is documented API surface.
-            NotificationCenter.default.publisher(
-                for: Notification.Name("UIApplicationDidChangeStatusBarOrientationNotification"))
-        ) { _ in
-            DispatchQueue.main.async {
-                deviceOrientation = MonitorDeviceOrientationReader.current()
-            }
+        UIDevice.current.beginGeneratingDeviceOrientationNotifications()
+        deviceObserver = NotificationCenter.default.addObserver(
+            forName: UIDevice.orientationDidChangeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.refresh() }
         }
     }
+
+    private func refresh() {
+        let current = MonitorDeviceOrientationReader.current()
+        guard current != orientation else { return }
+        orientation = current
+    }
+
+    // No deinit removal: block-based observers die with their token on modern runtimes, and the
+    // observer lives exactly as long as the shell that owns the monitor anyway. Reaching the
+    // MainActor-isolated token from a nonisolated deinit is what Swift 6 rightly refuses.
 }
 
 struct LiveViewLayoutContext {

--- a/ios/Runner/MonitorUnified.swift
+++ b/ios/Runner/MonitorUnified.swift
@@ -1867,19 +1867,43 @@ struct MonitorShell: View {
                 // bottom-left lane; fall back to the assist bar's leading edge plus the same
                 // clearance the rail layout produced (indicator width 38 + 24). Photography's
                 // lock-side assist rail owns that lane instead, so clear past it there.
-                let photographyRailTrailing =
-                    max(
+                // The module frames in `map` arrive already MIRRORED for the layout direction —
+                // that is how the battery rail lands on the correct side without this code
+                // knowing. But this lane is DERIVED: "sit just past the rail, toward the feed".
+                // Which way "toward the feed" points flips with the direction, and extending a
+                // right-edge rail rightwards parked the button under the Dynamic Island, a
+                // sliver on screen. (iPad has shipped the same lane off-screen in its second
+                // landscape since the mirrored layout landed — no island there, just a bezel —
+                // which is how it went unseen: this button only mounts with an AF point active.)
+                let mirroredLane = context.horizontalDirection == .mirrored
+                let photographyRailEdge =
+                    mirroredLane
+                    ? min(
+                        map.systemSlots.lock.x,
+                        Double(context.viewportWidth)
+                            - MonitorBatteryRailLayout.batteryPillTrailing(
+                                safeArea: context.feedSafeArea)
+                    ) - 12 - Double(MonitorAssistStrip.expandedWidth)
+                    : max(
                         map.systemSlots.lock.x + map.systemSlots.lock.width,
                         MonitorBatteryRailLayout.batteryPillTrailing(
                             safeArea: context.feedSafeArea)
                     ) + 12 + Double(MonitorAssistStrip.expandedWidth)
-                let assistLeadingX = map.assistStrip.map { CGFloat($0.frame.x) } ?? 96
+                let assistInlineX =
+                    map.assistStrip.map {
+                        mirroredLane
+                            ? CGFloat($0.frame.x + $0.frame.width) - 62
+                            : CGFloat($0.frame.x) + 62
+                    } ?? (mirroredLane ? CGFloat(context.viewportWidth) - 96 : 96)
                 let x =
                     isPhotographyBand && chrome.assistToolbarVisible
-                    ? CGFloat(photographyRailTrailing) + 24 + size / 2
+                    ? CGFloat(photographyRailEdge)
+                        + (mirroredLane ? -(24 + size / 2) : 24 + size / 2)
                     : battery.style == .batteryInline
-                        ? assistLeadingX + 62
-                        : CGFloat(rail.x + rail.width) + 24
+                        ? assistInlineX
+                        : mirroredLane
+                            ? CGFloat(rail.x) - 24
+                            : CGFloat(rail.x + rail.width) + 24
                 let baseY =
                     map.assistStrip.map { CGFloat($0.frame.y) - 30 }
                     ?? CGFloat(context.viewportHeight) - 40
@@ -1922,7 +1946,12 @@ struct MonitorShell: View {
                     .environment(model)
                     .frame(height: min(280, CGFloat(context.viewportHeight) * 0.55))
                     .position(
-                        x: CGFloat(map.systemSlots.record.x) - 34,
+                        // "Beside the record button, toward the feed" — the record slot mirrors
+                        // to the LEFT rail in the mirrored layout, so the scrub steps right of it
+                        // there rather than off the screen edge.
+                        x: context.horizontalDirection == .mirrored
+                            ? CGFloat(map.systemSlots.record.x + map.systemSlots.record.width) + 34
+                            : CGFloat(map.systemSlots.record.x) - 34,
                         y: CGFloat(context.viewportHeight) / 2
                     )
                     .transition(.opacity)

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -2,7 +2,7 @@ New and changed
 
 - Share what you see. Turn on Share This Feed in Settings > Link and other devices list it under Nearby Broadcasts, each with its own scopes and LUTs. A watcher can ask for camera control and the broadcaster hands it over; watchers with hardware that can't decode HEVC are served JPEG automatically. It needs no network - devices find each other directly.
 - One camera, many setups. Its own access point, a cable, a hotspot, and as many Wi-Fi networks as you use - each saved separately instead of overwriting the last, shown as tabs on the camera's row, and renameable so "Wi-Fi (2)" can become "Studio". Stream Preset and Quality Bias are remembered per setup, so what you pick for the camera's own network no longer follows you onto a cable.
-- Vertical camera mode. Turn the body on its side and the picture follows, in video and in photo, with a portrait layout built for it rather than the landscape one squeezed.
+- Rotation, both ways. Turn the body on its side and the picture follows (video and photo), and the iPhone itself now works in both landscape directions - the picture and controls swap sides so nothing ever hides behind the Dynamic Island.
 - Pinch the live view to zoom anywhere in the frame - the old fixed 2x/3x/4x magnifier is retired - and tap-to-focus follows the zoom instead of fighting it. The focus dial works in video as well as photo, off by default in the FOCUS popup.
 - Settings > Link > Processing: Feed Upscaler (Off, Fast, Quality, AI) and Feed Noise Reduction. AI infers detail the camera never captured, so judge critical focus on Quality or Fast. Link Health now shows the measured rate the link is actually carrying.
 - On the wrist: photo mode with a shutter and a shots-remaining readout, the crown magnifies the preview and a drag pans it. On iPad the picture can come from the camera's HDMI output through a USB capture device while exposure, focus, record and media keep working over the camera link.
@@ -21,7 +21,7 @@ Fixes
 What to test
 
 - Save the same body on two different Wi-Fi networks. Each should stay its own setup with its own Stream Preset and Quality Bias, and renaming one should not touch the other.
-- Turn the camera on its side, in video and in photo. The picture should stay upright and the controls should still be reachable.
+- Turn the camera on its side, in video and in photo. Then flip the iPhone to the opposite landscape mid-session: the picture and controls should swap sides on their own, with nothing under the island.
 - Turn on Share This Feed, ask for control from the second device, and start a take from it. Then screen-record on the sharing device and check the watcher stays with the action.
 - Watch a dim high-ISO shot with Feed Noise Reduction on and off, then step the Feed Upscaler through Fast, Quality and AI on the same framing.
 - Pair a camera by scanning its screen, and deliberately correct a character in the key before connecting.


### PR DESCRIPTION
The iPhone now rotates into both landscape directions. This was avoided for fear of
handling the notch on the other side; most of that fear turned out to be already paid
for, and the rest was found by hardware.

## Why this was cheaper than feared

The iPad work had already built a mirrored layout into the shared core
(`MonitorHorizontalLayoutDirection`), and UIKit reports landscape safe-area insets
symmetrically on notched iPhones — the system deliberately hides which side the island
sits on. The untested combination was mirrored WITH an island: iPad runs mirrored with no
cutout, iPhone ran the cutout with no mirroring.

## What unlocking it found — three rounds, two of them Erik's hardware passes

**Round 1 (sim):** two direction-naive lanes, both the same shape — a position derived
from an already-mirrored module frame by stepping in a hard-coded screen direction. The
focus-recall button parked under the island with a sliver showing; the focus-by-wire
scrub would have hung off the clean bezel. Both now step toward the feed, whichever side
their anchor sits. Bonus: iPad has shipped the focus-recall half of this bug in its
second landscape since the mirrored layout landed — off a bezel instead of under an
island, unseen because the button only mounts with an active AF point. Fixed there too.

**Round 2 (hardware):** the picture did not flip with its chrome. The zone map's exit
mirror carried every module and deliberately skipped the feed — with a comment blessing
it and a test pinning it. The layout now mirrors as ONE piece: everything is built in
standard space and a single exit mirror carries feed, deck, and chrome together. That
also deleted the deck helper's half-mirrored compensation, and the classic-notch test
survived unchanged (its in-place mirror was mathematically the exit mirror). The test
that pinned "mirror chrome but not feed" now pins the opposite, because the field
refuted it.

**Round 3 (hardware):** rotation stopped landing at all. The first rotation fix listened
for notifications; neither arrived on a physical phone, and because the orientation had
become captured state, even the DISP tap that used to jog it could no longer help. The
orientation is now observed at the structural source — `UIWindowScene.effectiveGeometry`,
documented KVO-compliant, firing when the new geometry has COMMITTED — which covers a
hand rotating the phone, a geometry request, and windowing changes alike. The device
notification stays as a redundant second source.

## The invariant that settled the verification

In PHYSICAL buffer space, the correct layouts for both landscapes are identical: picture
hugging the island side, controls owning the clean bezel, whichever way the phone is
held. The interface mirror and the buffer flip cancel exactly. Screenshots were measured
in buffer space for precisely this reason — interface-space measurement produced two
false alarms before the invariant was found.

## Verification

- Unit: the mirrored feed is the mirror of the standard feed on island phones; the whole
  zone map mirrors together (feed, deck, rails); the classic-notch expectations unchanged.
- Simulator, measured not eyeballed: mirrored feed 100..815pt on a 100..815 target;
  standard unchanged at 62..777; live 180° device rotation and an interface-only forced
  rotation both landing record ~824pt / feed 63..776 in buffer space.
- Hardware: verified by Erik on an iPhone 16 Pro Max — mid-session rotation now lands
  without interaction, picture and controls swap sides correctly.
- One stale binary was caught mid-verification by checksum; every screenshot in this PR's
  history is from a verified-fresh build.
- The demo harness's orientation hook accepts explicit landscape sides so headless
  verification can reach both; "landscape" keeps its historical meaning for existing
  capture scripts.

Android needs nothing — it has supported both landscapes all along. This is parity
restored, not scope added.

Gates: `just check` · `just native-check` · `just secrets` · `just hygiene` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
