### PR TITLE
fix(android): a wedged property write can no longer hold the session hostage

### DIFF
--- a/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
+++ b/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
@@ -625,6 +625,10 @@ public final class PTPIPClientSession: @unchecked Sendable {
     /// Accumulated Android monitor state. Access only while
     /// `commandLifecycleLock` is held so a refresh cannot race control writes,
     /// media ownership, or teardown.
+    /// See the arming site in `executeTransaction`. Internal so the dribbling-camera test can
+    /// shrink it; nothing else writes it.
+    var commandTransactionDeadlineNanoseconds: UInt64 = 15_000_000_000
+
     private var androidPropertySnapshot = PTPCameraPropertySnapshot()
     /// A drifted body clock found at bootstrap, waiting for the first poll tick that carries the
     /// shell's authoritative record state. See `CameraClockSync` for the policy and the reason
@@ -4489,6 +4493,13 @@ public final class PTPIPClientSession: @unchecked Sendable {
         guard let command else {
             throw PTPIPClientSessionError.connectionClosed
         }
+        // Whole-transaction backstop, the iOS transport's fifteen seconds ported: a healthy
+        // command completes in well under a second, a focus-motor handoff in single-digit
+        // seconds, and a 1 MB media chunk in a few — so anything that outlives this is a wedged
+        // or byte-dribbling camera holding the gate, and with it record-stop, AF, and every
+        // queued write.
+        command.beginTransactionDeadline(nanoseconds: commandTransactionDeadlineNanoseconds)
+        defer { command.clearTransactionDeadline() }
         let roundTripStart = Self.monotonicNanoseconds()
 
         let transactionID = explicitTransactionID ?? nextTransactionID
@@ -4568,6 +4579,20 @@ final class PosixTCPSocket: @unchecked Sendable {
     private let host: String
     private let port: UInt16
     private let label: String
+    /// Whole-transaction deadline, set by the session for the duration of one command
+    /// transaction and cleared after. Only the transaction thread touches it (command I/O is
+    /// serialized by the session's transaction lock), so it needs no lock of its own. The event
+    /// socket never carries one — its waits are legitimately idle for minutes.
+    private var transactionDeadlineNanos: UInt64?
+
+    /// Arms the deadline for the transaction that is about to run.
+    func beginTransactionDeadline(nanoseconds: UInt64) {
+        transactionDeadlineNanos = PTPIPClientSession.monotonicNanoseconds() &+ nanoseconds
+    }
+
+    func clearTransactionDeadline() {
+        transactionDeadlineNanos = nil
+    }
     /// Per-poll timeout; mutable so teardown can shorten it (see `disconnect`).
     var timeoutMilliseconds: Int32
     private let descriptorLock = NSLock()
@@ -4789,8 +4814,24 @@ final class PosixTCPSocket: @unchecked Sendable {
         // Loop rather than recurse on EINTR / spurious wakeups (same rationale
         // as the iOS twin: a signal storm must not grow the stack).
         while true {
+            // The per-poll timeout below catches a link that has gone SILENT. It cannot catch a
+            // link that trickles — a byte per poll re-arms it forever, and that is exactly how a
+            // wedged write held the transaction gate (and the app's controls) for a whole
+            // session. The armed deadline bounds the WHOLE transaction, like the iOS transport's
+            // fifteen-second backstop; on breach the socket CLOSES, because bytes that arrive
+            // after a breached transaction would desynchronize the next one.
+            var pollBudget = Int32(min(timeoutMilliseconds, 30_000))
+            if let deadline = transactionDeadlineNanos {
+                let now = PTPIPClientSession.monotonicNanoseconds()
+                guard deadline > now else {
+                    close()
+                    throw PTPIPClientSessionError.timeout("\(label) transaction deadline")
+                }
+                let remainingMilliseconds = (deadline &- now) / 1_000_000
+                pollBudget = Int32(min(UInt64(pollBudget), max(1, remainingMilliseconds)))
+            }
             var pollDescriptor = pollfd(fd: descriptor, events: events, revents: 0)
-            let result = poll(&pollDescriptor, 1, min(timeoutMilliseconds, 30_000))
+            let result = poll(&pollDescriptor, 1, pollBudget)
             if result > 0 {
                 if (pollDescriptor.revents & events) != 0 {
                     return

--- a/Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift
@@ -131,6 +131,11 @@ final class FakeZRServer: @unchecked Sendable {
         /// Response sent for either standard or extended property writes.
         /// Tests use a real PTP rejection code to verify command propagation.
         var propertyWriteResponseCode: UInt16 = 0x2001
+        /// Dribbles the property-write RESPONSE one byte at a time with this many milliseconds
+        /// between bytes. The trickle that defeats a per-poll timeout: every poll sees a byte, so
+        /// the socket never looks silent, and without a whole-transaction deadline the write
+        /// holds the transaction gate for the dribble's full duration.
+        var propertyWriteResponseDribbleMillisecondsPerByte: UInt64 = 0
         /// Accepted writes that the fake deliberately refuses to apply to authoritative readback.
         var ignoredPropertyWrites: Set<UInt32> = []
         /// Advertised UINT16 range for the active white-balance tune descriptor.
@@ -946,7 +951,17 @@ final class FakeZRServer: @unchecked Sendable {
                 applyCameraPropertyWriteLocked(property: property, data: dataOut)
             }
             lock.unlock()
-            sendResponse(connection, code: responseCode, transactionID: transactionID)
+            if options.propertyWriteResponseDribbleMillisecondsPerByte > 0 {
+                var payload = ByteCoding.uint16LE(responseCode)
+                payload += ByteCoding.uint32LE(transactionID)
+                let packet = PTPIPPacket(type: .operationResponse, payload: Data(payload))
+                sendDribbled(
+                    connection,
+                    Data(packet.serializedBytes),
+                    millisecondsPerByte: options.propertyWriteResponseDribbleMillisecondsPerByte)
+            } else {
+                sendResponse(connection, code: responseCode, transactionID: transactionID)
+            }
         default:
             sendResponse(connection, code: 0x2005, transactionID: transactionID)
         }
@@ -1579,6 +1594,34 @@ final class FakeZRServer: @unchecked Sendable {
         sendResponse(
             connection, code: code, transactionID: transactionID,
             parameters: responseParameters)
+    }
+
+    /// One byte per interval — a link that is alive but barely, which no per-poll timeout can
+    /// tell apart from a healthy one.
+    ///
+    /// The deadline this exists to prove CLOSES the peer socket mid-dribble, so this must both
+    /// suppress SIGPIPE (a raw Darwin send into a closed socket kills the whole test process —
+    /// which is exactly how this helper's first version took the suite down with signal 13,
+    /// after every test had passed) and stop on the first failed byte.
+    private func sendDribbled(_ connection: Int32, _ data: Data, millisecondsPerByte: UInt64) {
+        #if canImport(Darwin)
+            var noSigpipe: Int32 = 1
+            _ = setsockopt(
+                connection, SOL_SOCKET, SO_NOSIGPIPE, &noSigpipe,
+                socklen_t(MemoryLayout<Int32>.size))
+            let flags: Int32 = 0
+        #else
+            let flags = Int32(MSG_NOSIGNAL)
+        #endif
+        for byte in data {
+            var value = byte
+            let sent = withUnsafeBytes(of: &value) { raw -> Int in
+                guard let base = raw.baseAddress else { return 0 }
+                return platformSend(connection, base, 1, flags)
+            }
+            guard sent > 0 else { return }
+            usleep(useconds_t(millisecondsPerByte * 1_000))
+        }
     }
 
     private func send(_ connection: Int32, _ packet: PTPIPPacket) {

--- a/Tests/OpenZCineAndroidFacadeTests/TransactionDeadlineTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/TransactionDeadlineTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+
+@testable import OpenZCineAndroidFacade
+@testable import OpenZCineCore
+
+/// The wedge behind issue #328's follow-up: a property write against a body that answers a byte
+/// at a time holds the transaction gate for as long as the dribble lasts — and with it, every
+/// queued write, the feed, and (until the popup fix) the whole UI. A per-poll timeout cannot see
+/// this: every poll finds a byte, so the socket never looks silent. iOS bounds the WHOLE
+/// transaction at fifteen seconds and closes the socket on breach; this pins the same rule here.
+@Test func aDribblingCameraCannotHoldTheTransactionGatePastTheDeadline() throws {
+    var options = FakeZRServer.Options()
+    // ~14 response bytes at 250 ms/byte ≈ 3.5 s of dribble — far past the shrunk deadline, far
+    // under the suite's patience.
+    options.propertyWriteResponseDribbleMillisecondsPerByte = 250
+    let server = try FakeZRServer(options: options)
+    defer { server.stop() }
+    let session = try PTPIPClientSession.connect(
+        host: "127.0.0.1", port: server.port, timeoutMilliseconds: 2_000)
+    defer { session.disconnect() }
+    session.commandTransactionDeadlineNanoseconds = 500_000_000  // 0.5 s for the test
+
+    let start = DispatchTime.now()
+    var thrown: Error?
+    do {
+        _ = try session.executeTransaction(
+            .setDevicePropValue,
+            parameters: [PTPPropertyCode.movieISOAutoControl.rawValue],
+            dataPhase: .dataOut,
+            dataOut: Data([1]))
+    } catch {
+        thrown = error
+    }
+    let elapsedMilliseconds =
+        (DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
+
+    // It THREW — the dribble did not run to completion as a slow success.
+    #expect(thrown != nil)
+    // And it threw on the deadline's clock, not the dribble's: well before the ~3.5 s the full
+    // response would take. The margin over 0.5 s absorbs poll granularity and CI scheduling.
+    #expect(elapsedMilliseconds < 2_000)
+}


### PR DESCRIPTION
Follow-up to #331 / #328. That change freed the operator from a stalled camera write; this frees the session. Closes #333.

## What & why

A property write against a body that answers a byte at a time held the Android PTP-IP transaction gate for as long as the trickle lasted — and with it record-stop, AF, every queued write, and the capture tiles that gate on the write finishing. The per-poll timeout could not see it: every poll found a byte, so the socket never looked silent. That is the performance audit's "a trickling link holds the serial gate indefinitely" finding, now closed on Android.

iOS already bounds the whole command transaction and closes the socket on breach. This ports that shape into the Android facade:

- a 15-second deadline arms per transaction on the **command socket only** (the event socket's waits are legitimately idle for minutes and must never carry one)
- each poll spends at most the remaining budget
- a breach **closes the socket** — leftover bytes after a breached transaction would desynchronise the next one, so recovery goes through the existing session reconnect path

Fifteen seconds clears every legitimate slow case by an order of magnitude: a focus-motor handoff is single-digit seconds, a 1 MB media chunk a few, a live-view frame far less. The same bound also gives the Android live-view fetch the deadline it never had.

Kotlin needed nothing. Its `finally` block already clears pending write state and routes the error into operator feedback; the only missing piece was a transport that could actually fail.

**Single-platform exception:** iOS already has this bound in `PTPIPTransport` / `NativeCameraSession`. No Compose or Kotlin product-rule change. Android USB already has its own transaction deadline on `USBPTPTransactionTransport`; this PR is the Wi-Fi / PTP-IP command channel.

## TestFlight notes

No tester-facing iOS app changes. Continue the normal camera workflow.

## Google Play notes

A stuck or extremely slow camera write no longer freezes record, AF, or the rest of the session. After about fifteen seconds the link drops and the existing reconnect path takes over. Please try a focus or ISO change on a weak Wi-Fi hop and confirm record-stop still works if a write feels slow.

## Verification

- `just native-check` green after a clean Swift package build (stale 6.3.2 modules in `.build` had failed a first run against the 6.2.3 toolchain).
- 1334 Swift tests, including `aDribblingCameraCannotHoldTheTransactionGatePastTheDeadline` (fake camera dribbles the write response one byte / 250 ms; with a 0.5 s deadline it throws in 1.235 s instead of completing as a ~3.5 s slow success).
- `just android-check` not required: no Kotlin/Compose change. The shell already maps a thrown transport error.

The dribble helper's first version kept writing into the socket the deadline had closed; a raw Darwin send into a closed socket raises SIGPIPE and killed the suite *after* every test passed. The helper now suppresses SIGPIPE and stops on the first failed byte.

## Hardware still owed

A real ZR over a weak or busy Wi-Fi hop: a focus-mode or ISO write that used to hang the capture tiles should now either finish or fail into reconnect within ~15 s, and record-stop must stay reachable either way.

## Checklist

- [x] Native production changes: `just native-check` passes.
- [ ] `just check` not re-run — no repo-meta files changed.
- [x] Commits follow Conventional Commits.
- [x] No proprietary assets (`vendor/`, `ref/`) are included.
- [ ] CHANGELOG / tester-note files left as-is; Play copy is in this PR body for the next notes pass.
- [x] Dual-platform exception documented (iOS already shipped the bound).