### PR TITLE
feat: a switch to turn off auto-rotation of the monitoring image

### DIFF
--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
@@ -1480,7 +1480,9 @@ internal fun MonitorScreen(
         // that hides the readout instead of parking a frozen 00:00:00:00 on set. The same collector
         // that owns `liveFeedRotation` latches it, and a source change resets it.
         var cameraReportsTimecode by remember { mutableStateOf(false) }
-        val isVerticalFeed = liveFeedRotation.isVertical
+        val displayedFeedRotation =
+            liveFeedRotation.displayed(autoRotateEnabled = operatorSettings.autoRotateFeedEnabled.value)
+        val isVerticalFeed = displayedFeedRotation.isVertical
         val portraitAspect = operatorSettings.portraitFeedAspect
         // Zone/chrome layout: vertical mode always lays out as FILL, matching iOS — the fill
         // zones are exactly the vertical viewer (feed spanning the bands, floating assist rail,
@@ -2308,7 +2310,7 @@ internal fun MonitorScreen(
                 // Vertical mode first: the whole feed stack — raster, AF boxes, punch-in,
                 // gestures — lays out in the camera's own frame and rotates upright as one,
                 // inside the zone clip.
-                Modifier.liveFeedBodyRotation(liveFeedRotation)
+                Modifier.liveFeedBodyRotation(displayedFeedRotation)
                     // Punch-in goes LAST and wraps the WHOLE feed stack, not just the raster: the
                     // AF box and focus ring are siblings of it, so scaling the raster alone would
                     // leave them behind at unmagnified positions over a magnified picture. Inside
@@ -2443,7 +2445,7 @@ internal fun MonitorScreen(
                         // the Compose layer and never rotate with it.
                         preferComposablePresentation =
                             glass.tier == GlassTier.FULL ||
-                                liveFeedRotation != LiveFeedRotation.LANDSCAPE,
+                                displayedFeedRotation != LiveFeedRotation.LANDSCAPE,
                     )
                     // Presentation-only texture: after the camera frame/effect renderer, before
                     // every geometry-bearing assist. Scopes continue sampling monitorFrameSource.

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/OperatorSettings.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/OperatorSettings.kt
@@ -867,6 +867,13 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
         Toggle("controls.mediaRemoteShutter.v1", default = true)
     public val hapticsEnabled: Toggle = Toggle("controls.haptics", default = true)
     public val keepScreenAwake: Toggle = Toggle("controls.keepScreenAwake", default = true)
+    /**
+     * Turns the monitoring image upright from the body's live-view orientation. Off
+     * keeps the picture in the camera's native landscape sensor orientation. Display
+     * only — the recording is never affected. Default on, matching iOS
+     * `autoRotateFeedEnabled`.
+     */
+    public val autoRotateFeedEnabled: Toggle = Toggle("controls.autoRotateFeed", default = true)
 
     // Sharing (the monitor relay) — iOS `relayWatcherPasscode` / `relayAllowsControlRequests`.
     // The share switch itself is runtime state, exactly like iOS's `isRelayBroadcasting`.
@@ -1502,6 +1509,7 @@ public class OperatorSettings(private val preferences: SharedPreferences) {
             mediaRemoteShutterEnabled,
             hapticsEnabled,
             keepScreenAwake,
+            autoRotateFeedEnabled,
             mfDriveScrubEnabled,
             guidesVisible,
             guideMaskEnabled,

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/OperatorSettingsScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/settings/OperatorSettingsScreen.kt
@@ -1833,8 +1833,8 @@ private fun ControlsRows(
     onToggle: (OperatorSettings.Toggle) -> Unit,
 ) {
     // iOS Controls is one switch card: Record Confirmation, Bluetooth Remote
-    // Shutter, Haptics, Keep Screen Awake. The one caption below is Android-only, for an
-    // Android-only behaviour (see the comment on it).
+    // Shutter, Haptics, Keep Screen Awake, Auto-Rotate Feed. The one caption below is
+    // Android-only, for an Android-only behaviour (see the comment on it).
     SettingsRowCard {
         SettingsSwitchRow(
             stringResource(R.string.settings_record_confirmation),
@@ -1861,6 +1861,13 @@ private fun ControlsRows(
         }
         SettingsSwitchRow(stringResource(R.string.settings_keep_awake), isOn = settings.keepScreenAwake.value) {
             onToggle(settings.keepScreenAwake)
+        }
+        SettingsSwitchRow(
+            stringResource(R.string.settings_auto_rotate_feed),
+            isOn = settings.autoRotateFeedEnabled.value,
+            help = stringResource(R.string.help_controls_auto_rotate_feed),
+        ) {
+            onToggle(settings.autoRotateFeedEnabled)
         }
     }
 }

--- a/Apps/Android/app/src/main/res/values/strings.xml
+++ b/Apps/Android/app/src/main/res/values/strings.xml
@@ -742,6 +742,7 @@
     <string name="saved_setup_router_name_permission">To keep more than one router setup for this camera, OpenZCine needs to read the name of the network you are on — Android treats a network name as location information. Without it, every router shares one setup, exactly as before.</string>
     <string name="saved_setup_router_name_permission_action">Allow network names</string>
     <string name="settings_processing">Processing</string>
+    <string name="settings_auto_rotate_feed">Auto-Rotate Feed</string>
     <string name="settings_feed_upscaler">Feed Upscaler</string>
     <string name="settings_feed_noise_reduction">Feed Noise Reduction</string>
     <string name="settings_coming_soon">Coming soon</string>
@@ -1121,6 +1122,7 @@
     <string name="help_link_held_by">Which device the camera is currently taking commands from.</string>
     <string name="help_link_stream_preset">Combines Nikon live-view stream size and compression grade into three operator-facing choices.</string>
     <string name="help_link_quality_bias">Steers the selected stream preset toward smaller frames or more image detail.</string>
+    <string name="help_controls_auto_rotate_feed">Turns the monitoring image upright when the camera is held on its side or upside down. Off keeps the picture in the camera\'s native orientation. Display only — the recording is never affected.</string>
     <string name="help_link_feed_upscaler">How the live-view frame is enlarged to fill the panel. The camera sends far fewer pixels than the panel has, so something always does this; Android runs the plain sample today and the hardware-assisted paths are not built yet.</string>
     <string name="help_link_feed_noise_reduction">Averages the live view against the frames either side of it to reduce sensor noise. Not built on Android yet; the recording is never affected either way.</string>
     <string name="help_sharing_watcher">This device is watching another device\'s broadcast. Sharing is done from the broadcasting device — re-sharing a received feed would stack a second encode and a second hop of delay on everyone downstream.</string>

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/settings/OperatorSettingsTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/settings/OperatorSettingsTest.kt
@@ -62,6 +62,7 @@ class OperatorSettingsTest {
         assertTrue(settings.mediaRemoteShutterEnabled.value)
         assertTrue(settings.hapticsEnabled.value)
         assertTrue(settings.keepScreenAwake.value)
+        assertTrue(settings.autoRotateFeedEnabled.value)
         // The focus dial is opt-in on a fresh install, in video and photo mode alike.
         assertFalse(settings.mfDriveScrubEnabled.value)
         assertFalse(settings.guidesVisible.value)
@@ -234,6 +235,7 @@ class OperatorSettingsTest {
             recordConfirmationEnabled.toggle()
             mediaRemoteShutterEnabled.toggle()
             keepScreenAwake.toggle()
+            autoRotateFeedEnabled.toggle()
         }
 
         val restored = OperatorSettings(store)
@@ -245,6 +247,7 @@ class OperatorSettingsTest {
         assertFalse(restored.mediaRemoteShutterEnabled.value)
         assertFalse(restored.shouldKeepScreenAwake(monitorPresented = true))
         assertFalse(restored.shouldKeepScreenAwake(monitorPresented = false))
+        assertFalse(restored.autoRotateFeedEnabled.value)
     }
 
     @Test

--- a/Apps/Android/core-api/src/main/kotlin/com/opencapture/openzcine/core/LiveFrameSource.kt
+++ b/Apps/Android/core-api/src/main/kotlin/com/opencapture/openzcine/core/LiveFrameSource.kt
@@ -135,6 +135,13 @@ public enum class LiveFeedRotation(public val displayDegreesClockwise: Float) {
     /** True when the frame presents tall — layout swaps the feed's sides. */
     public val isVertical: Boolean
         get() = this == PORTRAIT_GRIP_UP || this == PORTRAIT_GRIP_DOWN
+
+    /**
+     * Rotation the monitor applies. Off keeps the raster in the camera's native
+     * landscape sensor orientation even when the body is on its side or upside down.
+     */
+    public fun displayed(autoRotateEnabled: Boolean): LiveFeedRotation =
+        if (autoRotateEnabled) this else LANDSCAPE
 }
 
 /** Camera-owned timecode parsed from the same live-view header as [LiveFrame]. */

--- a/Apps/Android/core-api/src/test/kotlin/com/opencapture/openzcine/core/LiveFeedRotationTest.kt
+++ b/Apps/Android/core-api/src/test/kotlin/com/opencapture/openzcine/core/LiveFeedRotationTest.kt
@@ -1,0 +1,16 @@
+package com.opencapture.openzcine.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** Pins the display-rotation helper to the shared Swift `PTPLiveViewRotation.displayed`. */
+class LiveFeedRotationTest {
+
+    @Test
+    fun `auto-rotate off keeps every body orientation as landscape`() {
+        for (rotation in LiveFeedRotation.entries) {
+            assertEquals(rotation, rotation.displayed(autoRotateEnabled = true))
+            assertEquals(LiveFeedRotation.LANDSCAPE, rotation.displayed(autoRotateEnabled = false))
+        }
+    }
+}

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,4 +1,5 @@
+- New: Settings > Controls has Auto-Rotate Feed. Turn it off if you want the picture to stay put when the camera is on its side.
 - Fixed: settings popups always close - the X and tapping outside work even during a slow camera write.
-- Fixed: connecting through the camera's own Wi-Fi finds the camera after joining instead of failing with an address error.
+- Fixed: joining the camera's own Wi-Fi finds the camera instead of failing with an address error.
 - Fixed: stills focus settings no longer change how video focus taps behave.
 - New: your camera's clock syncs to the phone on connect - never while recording.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ All notable changes to this project are documented here. The format is based on
   fixed as part of the same work.)
 - **Vertical camera mode** (iOS + Android): turn the body on its side and the picture follows,
   in video and photo, with a portrait layout built for it.
+- **Auto-Rotate Feed switch** (iOS + Android): turn off upright rotation of the monitoring
+  image when the camera is on its side. On by default, under Settings → Controls; the
+  recording is never affected.
 - **Pinch-to-zoom on the live view** (iOS + Android), replacing the fixed 2×/3×/4× magnifier;
   tap-to-focus follows the zoom.
 - **Feed processing** (iOS): a Feed Upscaler (Off / Fast / Quality / AI) and temporal Feed Noise

--- a/Sources/OpenZCineCore/OperatorPreferences.swift
+++ b/Sources/OpenZCineCore/OperatorPreferences.swift
@@ -493,6 +493,7 @@ public struct OperatorPreferences: Codable, Equatable, Sendable {
         bluetoothShutterEnabled: Bool = true,
         hapticsEnabled: Bool,
         keepScreenAwake: Bool,
+        autoRotateFeedEnabled: Bool = true,
         streamPreset: StreamPreset,
         qualityBias: QualityBias,
         portraitFeedAspect: PortraitFeedAspect = .fit16x9,
@@ -523,6 +524,7 @@ public struct OperatorPreferences: Codable, Equatable, Sendable {
         self.bluetoothShutterEnabled = bluetoothShutterEnabled
         self.hapticsEnabled = hapticsEnabled
         self.keepScreenAwake = keepScreenAwake
+        self.autoRotateFeedEnabled = autoRotateFeedEnabled
         self.streamPreset = streamPreset
         self.qualityBias = qualityBias
         self.portraitFeedAspect = portraitFeedAspect
@@ -565,6 +567,10 @@ public struct OperatorPreferences: Codable, Equatable, Sendable {
     public var bluetoothShutterEnabled: Bool
     public var hapticsEnabled: Bool
     public var keepScreenAwake: Bool
+    /// Turns the monitoring image upright from the body's live-view orientation. Off keeps the
+    /// picture in the camera's native landscape sensor orientation. Display only — the recording
+    /// is never affected.
+    public var autoRotateFeedEnabled: Bool
     public var streamPreset: StreamPreset
     public var qualityBias: QualityBias
     /// Which aspect the portrait feed renders at (operator pinch, persisted).
@@ -669,7 +675,8 @@ public struct OperatorPreferences: Codable, Equatable, Sendable {
         case liveViewVisibleAssistTools, playbackVisibleAssistTools
         case visibleAssistTools
         case recordConfirmationEnabled, recordHoldEnabled, bluetoothShutterEnabled, hapticsEnabled,
-            keepScreenAwake, streamPreset, qualityBias, portraitFeedAspect, scopeActivationOrder
+            keepScreenAwake, autoRotateFeedEnabled, streamPreset, qualityBias, portraitFeedAspect,
+            scopeActivationOrder
         case cleanViewPinnedTools
         case cleanChrome, commandChrome
         case cleanChromeV2
@@ -720,6 +727,10 @@ public struct OperatorPreferences: Codable, Equatable, Sendable {
             try container.decodeIfPresent(Bool.self, forKey: .bluetoothShutterEnabled) ?? true
         hapticsEnabled = try container.decode(Bool.self, forKey: .hapticsEnabled)
         keepScreenAwake = try container.decodeIfPresent(Bool.self, forKey: .keepScreenAwake) ?? true
+        // Predates this switch. Absent means the operator never chose, so the default-on that
+        // shipped with vertical mode applies; an explicitly saved false is a real opt-out.
+        autoRotateFeedEnabled =
+            try container.decodeIfPresent(Bool.self, forKey: .autoRotateFeedEnabled) ?? true
         streamPreset = try container.decode(StreamPreset.self, forKey: .streamPreset)
         qualityBias = try container.decode(QualityBias.self, forKey: .qualityBias)
         portraitFeedAspect =
@@ -811,6 +822,7 @@ public struct OperatorPreferences: Codable, Equatable, Sendable {
         try container.encode(bluetoothShutterEnabled, forKey: .bluetoothShutterEnabled)
         try container.encode(hapticsEnabled, forKey: .hapticsEnabled)
         try container.encode(keepScreenAwake, forKey: .keepScreenAwake)
+        try container.encode(autoRotateFeedEnabled, forKey: .autoRotateFeedEnabled)
         try container.encode(streamPreset, forKey: .streamPreset)
         try container.encode(qualityBias, forKey: .qualityBias)
         try container.encode(portraitFeedAspect, forKey: .portraitFeedAspect)
@@ -853,6 +865,7 @@ public struct OperatorPreferences: Codable, Equatable, Sendable {
         recordConfirmationEnabled: true,
         hapticsEnabled: true,
         keepScreenAwake: true,
+        autoRotateFeedEnabled: true,
         // The smallest preset is ~320x240 — too little real detail for the focus and exposure
         // assists to read, and most of what a detector finds there is compression structure
         // rather than the lens. Default to the largest stream the body will send; the operator

--- a/Sources/OpenZCineCore/PTPLiveViewObject.swift
+++ b/Sources/OpenZCineCore/PTPLiveViewObject.swift
@@ -64,6 +64,12 @@ public enum PTPLiveViewRotation: UInt8, Equatable, Sendable, CaseIterable {
 
     /// True when the frame presents tall — layout swaps the feed's width and height.
     public var isVertical: Bool { self == .portraitGripUp || self == .portraitGripDown }
+
+    /// Rotation the monitor applies. Off keeps the raster in the camera's native landscape
+    /// sensor orientation even when the body is on its side or upside down.
+    public func displayed(autoRotateEnabled: Bool) -> PTPLiveViewRotation {
+        autoRotateEnabled ? self : .landscape
+    }
 }
 
 /// The camera's audio-level readout from the LiveViewObject header — the same segmented meter the

--- a/Tests/OpenZCineCoreTests/LiveViewHeaderTests.swift
+++ b/Tests/OpenZCineCoreTests/LiveViewHeaderTests.swift
@@ -97,4 +97,11 @@ struct LiveViewHeaderTests {
         #expect(!PTPLiveViewRotation.landscape.isVertical)
         #expect(!PTPLiveViewRotation.upsideDown.isVertical)
     }
+
+    @Test func rotationDisplayHonoursTheAutoRotateSwitch() {
+        for rotation in PTPLiveViewRotation.allCases {
+            #expect(rotation.displayed(autoRotateEnabled: true) == rotation)
+            #expect(rotation.displayed(autoRotateEnabled: false) == .landscape)
+        }
+    }
 }

--- a/Tests/OpenZCineCoreTests/OperatorPreferencesTests.swift
+++ b/Tests/OpenZCineCoreTests/OperatorPreferencesTests.swift
@@ -23,6 +23,27 @@ import Testing
     #expect(OperatorPreferences.defaults.keepScreenAwake)
 }
 
+@Test func operatorPreferencesDefaultAutoRotateFeedEnabled() {
+    #expect(OperatorPreferences.defaults.autoRotateFeedEnabled)
+}
+
+@Test func operatorPreferencesAutoRotateFeedRoundTripsAndOlderBlobsDecodeToOn() throws {
+    var preferences = OperatorPreferences.defaults
+    preferences.autoRotateFeedEnabled = false
+    let decoded = try JSONDecoder().decode(
+        OperatorPreferences.self, from: try JSONEncoder().encode(preferences))
+    #expect(!decoded.autoRotateFeedEnabled)
+
+    var dict = try #require(
+        try JSONSerialization.jsonObject(
+            with: try JSONEncoder().encode(OperatorPreferences.defaults)) as? [String: Any])
+    dict.removeValue(forKey: "autoRotateFeedEnabled")
+    let legacy = try JSONDecoder().decode(
+        OperatorPreferences.self,
+        from: try JSONSerialization.data(withJSONObject: dict))
+    #expect(legacy.autoRotateFeedEnabled)
+}
+
 @Test func theDispKeyCanNeverBeHidden() {
     // The only visible way to change mode. It was briefly a switch with the feed swipe as the
     // fallback; an escape route the operator has to already know about is not an escape route.

--- a/ios/Runner/MonitorExperience.swift
+++ b/ios/Runner/MonitorExperience.swift
@@ -481,7 +481,7 @@ struct LiveFeedModule: View {
                 // inside it. The rotation wraps the whole feed stack — raster, AF boxes, zoom,
                 // gestures — so every existing coordinate mapping keeps operating in the
                 // camera's own (pre-rotation) space.
-                let feedRotation = model.liveFeedRotation
+                let feedRotation = model.displayedFeedRotation
                 let sourceAspect =
                     hdmiAspect
                     ?? (isPhotography

--- a/ios/Runner/MonitorPanels.swift
+++ b/ios/Runner/MonitorPanels.swift
@@ -4504,6 +4504,12 @@ struct OperatorSettingsPanel: View {
                     "Prevents auto-lock while the live monitor or clip playback is active. Exposure assists increase GPU load — disable tools you are not using. iOS may still dim when the device overheats.",
                 isOn: model.preferences.keepScreenAwake
             ) { model.preferences.keepScreenAwake.toggle() }
+            SettingsSwitchInlineRow(
+                title: "Auto-Rotate Feed",
+                help:
+                    "Turns the monitoring image upright when the camera is held on its side or upside down. Off keeps the picture in the camera's native orientation. Display only — the recording is never affected.",
+                isOn: model.preferences.autoRotateFeedEnabled
+            ) { model.preferences.autoRotateFeedEnabled.toggle() }
         }
 
     }

--- a/ios/Runner/MonitorUnified.swift
+++ b/ios/Runner/MonitorUnified.swift
@@ -2030,7 +2030,7 @@ struct MonitorShell: View {
         // the vertical viewer — feed spanning topBar→systemBar (the 9:16 picture pillarboxes
         // inside), the floating vertical assist rail, and the capture bar over the feed's
         // bottom edge — where fit's stacked toolbar/tile bands would strand the controls.
-        let isVerticalFeed = model.liveFeedRotation.isVertical
+        let isVerticalFeed = model.displayedFeedRotation.isVertical
         // Vertical is tested before photography, so a vertically held stills body reaches fill.
         let zoneAspect: PortraitFeedAspect =
             model.displayMode == .command

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -2055,10 +2055,15 @@ final class NativeAppModel {
     /// Camera-reported audio levels from the live-view header's sound indicator (bytes 824–827),
     /// mapped onto the meter's dBFS scale for the audio-levels panel. Silent until frames carry it.
     var liveAudioLevels: AudioMeterLevels = .silent
-    /// How the body is held, from the live-view header's rotation byte (839). Drives vertical
-    /// mode: the feed rotates upright and its displayed aspect inverts while the camera is on
-    /// its side. Only the camera's own stream ever sets this; HDMI capture stays `.landscape`.
+    /// How the body is held, from the live-view header's rotation byte (839). The body's own
+    /// orientation always lands here so flipping Auto-Rotate Feed back on can restore it.
+    /// Only the camera's own stream ever sets this; HDMI capture stays `.landscape`.
     var liveFeedRotation: PTPLiveViewRotation = .landscape
+    /// Rotation the monitor applies. Off (``OperatorPreferences/autoRotateFeedEnabled``) keeps
+    /// the picture in the camera's native landscape sensor orientation.
+    var displayedFeedRotation: PTPLiveViewRotation {
+        liveFeedRotation.displayed(autoRotateEnabled: preferences.autoRotateFeedEnabled)
+    }
     /// Latest scope sample plus derived traffic-light readings — one publish per throttle tick.
     var scopeAssist: ScopeAssistBundle = .empty
     /// Convenience accessor for scope panels that only need bins / points.
@@ -12252,7 +12257,7 @@ final class NativeAppModel {
     /// vertical body refused extra scopes for a zone that wasn't even mounted).
     var scopeCapActive: Bool {
         monitorIsPortrait && preferences.portraitFeedAspect == .fit16x9
-            && !liveFeedRotation.isVertical && activeScopeCount >= 2
+            && !displayedFeedRotation.isVertical && activeScopeCount >= 2
     }
 
     /// Whether activating `tool` is blocked by the fit-mode cap (a scope not yet active while the

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -2,7 +2,7 @@ New and changed
 
 - Share what you see. Turn on Share This Feed in Settings > Link and other devices list it under Nearby Broadcasts, each with its own scopes and LUTs. A watcher can ask for camera control and the broadcaster hands it over; watchers with hardware that can't decode HEVC are served JPEG automatically. It needs no network - devices find each other directly.
 - One camera, many setups. Its own access point, a cable, a hotspot, and as many Wi-Fi networks as you use - each saved separately instead of overwriting the last, shown as tabs on the camera's row, and renameable so "Wi-Fi (2)" can become "Studio". Stream Preset and Quality Bias are remembered per setup, so what you pick for the camera's own network no longer follows you onto a cable.
-- Rotation, both ways. Turn the body on its side and the picture follows (video and photo), and the iPhone itself now works in both landscape directions - the picture and controls swap sides so nothing ever hides behind the Dynamic Island.
+- Rotation, both ways. Turn the body on its side and the picture follows (video and photo), and the iPhone itself now works in both landscape directions. Settings > Controls has Auto-Rotate Feed if you want the monitoring image to stay put.
 - Pinch the live view to zoom anywhere in the frame - the old fixed 2x/3x/4x magnifier is retired - and tap-to-focus follows the zoom instead of fighting it. The focus dial works in video as well as photo, off by default in the FOCUS popup.
 - Settings > Link > Processing: Feed Upscaler (Off, Fast, Quality, AI) and Feed Noise Reduction. AI infers detail the camera never captured, so judge critical focus on Quality or Fast. Link Health now shows the measured rate the link is actually carrying.
 - On the wrist: photo mode with a shutter and a shots-remaining readout, the crown magnifies the preview and a drag pans it. On iPad the picture can come from the camera's HDMI output through a USB capture device while exposure, focus, record and media keep working over the camera link.
@@ -21,7 +21,7 @@ Fixes
 What to test
 
 - Save the same body on two different Wi-Fi networks. Each should stay its own setup with its own Stream Preset and Quality Bias, and renaming one should not touch the other.
-- Turn the camera on its side, in video and in photo. Then flip the iPhone to the opposite landscape mid-session: the picture and controls should swap sides on their own, with nothing under the island.
+- Turn the camera on its side, then turn Auto-Rotate Feed off in Settings > Controls: the picture should stay put. Turn it back on and the picture should stand up. Then flip the iPhone to the opposite landscape: picture and controls swap sides, nothing under the island.
 - Turn on Share This Feed, ask for control from the second device, and start a take from it. Then screen-record on the sharing device and check the watcher stays with the action.
 - Watch a dim high-ISO shot with Feed Noise Reduction on and off, then step the Feed Upscaler through Fast, Quality and AI on the same framing.
 - With the body in full-time AF for video, change stills focus settings and tap around the feed: the FOCUS readout should hold, and focus should stay continuous. Set the camera clock a minute off, connect, and check it corrects.


### PR DESCRIPTION
## What & why

Operators asked how to turn off auto-rotation of the monitoring image after vertical camera mode shipped. Settings → **Controls** now has **Auto-Rotate Feed** on iOS and Android.

- On by default, so existing upright-feed behaviour is unchanged.
- Off keeps the live picture in the camera's native landscape orientation, including layout (no vertical-mode remount).
- Display only — the recording is never affected.
- The body's real orientation is still stored, so flipping the switch back on restores the upright picture without reconnecting.
- Older saved preferences without the key stay on.

Closes #336. Kaneo OPE-164.

## TestFlight notes

Reviewed `ios/TestFlight/WhatToTest.en-US.txt`: Auto-Rotate Feed is called out under rotation, with a tester step to turn it off and on while the body is on its side.

## Google Play notes

Reviewed `Apps/Android/distribution/whatsnew/whatsnew-en-US`: first bullet is the new Controls switch.

## Checklist

- [x] `just check` not re-run in full this turn; TestFlight notes, Play notes, hygiene, secrets, and markdown lint passed. `just native-check` and `just android-check` passed during implementation.
- [x] Native production changes: `just native-check` passed.
- [x] Android: `just android-check` passed. Verified on device by Erik.
- [x] Legacy prototype/reference changes are not included.
- [x] Commits follow Conventional Commits.
- [x] No proprietary assets (`vendor/`, `ref/`) are included.
- [x] Docs/CHANGELOG updated.
- [x] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy.
- [x] Play-triggering changes include reviewed `Apps/Android/distribution/whatsnew/whatsnew-en-US` copy.
- [x] Not a release PR — no marketing-version bump.

## Test plan

- [ ] iOS: Settings → Controls shows Auto-Rotate Feed, on by default.
- [ ] Android: the same switch in the same place.
- [ ] With the body on its side and the switch on, the picture stands up (video and photo).
- [ ] Turn the switch off: the picture stays in the camera's native orientation, without reconnecting.
- [ ] Turn it back on: the picture stands up again from the latest body orientation.
- [ ] Relanch: the off choice is still off.
- [ ] Recording is unaffected either way.