### PR TITLE
docs: put the Android open beta on openzcine.app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,9 @@ cinema-line cameras — primarily the **Nikon ZR**. Built openly with agentic co
 clean, exemplary engineering standards.
 
 > **Status:** Native iOS and Android implementation milestone. Production work targets the portable
-> Swift business/protocol core, a SwiftUI iOS shell, and a Jetpack Compose Android shell. Android is
-> not publicly released yet. The older Flutter prototype remains only as a protocol/live-view
-> reference while useful.
+> Swift business/protocol core, a SwiftUI iOS shell, and a Jetpack Compose Android shell. Both
+> shells ship in public beta — iOS on TestFlight, Android on Google Play. The older Flutter
+> prototype remains only as a protocol/live-view reference while useful.
 
 ## Stack & tooling
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 <p align="center">
   <a href="https://testflight.apple.com/join/xu4d6UK8"><strong>Join the TestFlight beta</strong></a>
   &nbsp;·&nbsp;
+  <a href="https://play.google.com/store/apps/details?id=com.opencapture.openzcine"><strong>Join the Android beta</strong></a>
+  &nbsp;·&nbsp;
   <a href="https://openzcine.app/">Visit openzcine.app</a>
   &nbsp;·&nbsp;
   <a href="https://github.com/erik-sutton95/OpenZCine/discussions/22">Explore the roadmap</a>
@@ -26,8 +28,8 @@
 ## Made for the shot
 
 OpenZCine turns an iPhone, iPad, or Android phone into a production monitor and remote for Nikon Z
-cinema cameras, with current development and testing centered on the **Nikon ZR**. The iOS beta is
-public today; Android and Google Play availability are coming soon.
+cinema cameras, with current development and testing centered on the **Nikon ZR**. The iOS TestFlight
+and Android Google Play betas are both public today.
 
 - **Read the image like a colorist.** Waveform, RGB parade, histogram, and vectorscope run live
   beside the image you are judging.
@@ -76,7 +78,7 @@ public today; Android and Google Play availability are coming soon.
   </a>
 </p>
 
-## Available in the iOS open beta
+## Available in the open beta
 
 - Resilient Wi-Fi discovery, pairing, saved-camera profiles, and automatic reconnect
 - Live-view monitoring, timecode, battery, storage, temperature, and camera warning readouts
@@ -85,14 +87,12 @@ public today; Android and Google Play availability are coming soon.
 - Professional scopes, exposure and focus assists, framing tools, and customizable monitor layouts
 - On-device clip browsing, playback review, LUT preview, LUT-baked export, and Frame.io delivery
 - Adaptive live-view thermal management during long sessions and recording
-- Native iPhone and iPad layouts, an Apple Watch companion, and Bluetooth shutter integration
-  under hardware validation
+- Native iPhone, iPad, and Android layouts, plus Apple Watch and Wear OS companions, with
+  Bluetooth shutter integration under hardware validation
 - USB-C tethered transport foundation alongside the primary Wi-Fi workflow
 
-The native Android phone and Wear OS implementations live in this repository. They are not
-available through Google Play yet. Nikon ZR is the primary hardware target today; USB-C transport,
-both wearable companions, and wider phone/tablet coverage continue to be hardened with real-world
-testing.
+Nikon ZR is the primary hardware target today. USB-C transport, both wearable companions, and
+wider phone/tablet coverage continue to be hardened with real-world testing.
 
 ## Roadmap shaped in the open
 

--- a/site/assets/README.md
+++ b/site/assets/README.md
@@ -41,5 +41,7 @@ The deployed `site/` tree should remain free of PSD files, full-resolution PNG s
 capture filenames, and other non-runtime material.
 
 GitHub Pages replaces `TESTFLIGHT_URL` from the public repository variable of the same name. The
-deployment fails unless it is a valid `https://testflight.apple.com/join/...` URL. Run
-`just site-check` before committing landing-page changes.
+deployment fails unless it is a valid `https://testflight.apple.com/join/...` URL. The Android CTA
+uses the public Play Store listing
+(`https://play.google.com/store/apps/details?id=com.opencapture.openzcine`). Run `just site-check`
+before committing landing-page changes.

--- a/site/index.html
+++ b/site/index.html
@@ -6,7 +6,7 @@
 
   <!-- Primary meta -->
   <title>OpenZCine: Open-source field monitor for Nikon Z</title>
-  <meta name="description" content="OpenZCine is a free, open-source field-monitor app for Nikon Z mirrorless cameras. Pro monitoring scopes, playback, Camera-to-Cloud export with LUT baking.">
+  <meta name="description" content="OpenZCine is a free, open-source field-monitor app for Nikon Z mirrorless cameras on iOS and Android. Pro monitoring scopes, playback, Camera-to-Cloud export with LUT baking.">
   <meta name="theme-color" content="#0A0908">
   <meta name="referrer" content="no-referrer">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests">
@@ -14,7 +14,7 @@
   <!-- Open Graph / social -->
   <meta property="og:type" content="website">
   <meta property="og:title" content="OpenZCine: Open-source field monitor for Nikon Z">
-  <meta property="og:description" content="Free, open-source field-monitor app for Nikon Z. Pro scopes, playback, C2C export with LUT baking.">
+  <meta property="og:description" content="Free, open-source field-monitor app for Nikon Z on iOS and Android. Pro scopes, playback, C2C export with LUT baking.">
   <meta property="og:image" content="assets/screens/hero-set.webp">
   <meta name="twitter:card" content="summary_large_image">
 
@@ -59,7 +59,7 @@
       </nav>
       <div class="nav__cta">
         <a class="nav__github" href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener" aria-label="OpenZCine on GitHub">★ GitHub</a>
-        <a class="btn btn--primary btn--magnetic" href="TESTFLIGHT_URL"><span class="btn__rec" aria-hidden="true"></span>Join the beta</a>
+        <a class="btn btn--primary btn--magnetic" href="#download"><span class="btn__rec" aria-hidden="true"></span>Join the beta</a>
       </div>
     </div>
   </header>
@@ -81,9 +81,7 @@
           built-in, RED, or custom LUT baking. Free and open source.</p>
         <div class="hero__cta" data-intro>
           <a class="btn btn--primary btn--magnetic" href="TESTFLIGHT_URL"><span class="btn__rec" aria-hidden="true"></span>Join the TestFlight beta</a>
-          <span class="btn btn--disabled" data-coming-soon="android" aria-disabled="true">
-            Android <span class="btn__status">Coming soon</span>
-          </span>
+          <a class="btn btn--ghost btn--magnetic" href="https://play.google.com/store/apps/details?id=com.opencapture.openzcine" target="_blank" rel="noopener">Join the Android beta<span class="btn__arrow" aria-hidden="true">→</span></a>
           <a class="btn btn--ghost btn--magnetic" href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">★ Star on GitHub<span class="btn__arrow" aria-hidden="true">→</span></a>
         </div>
 
@@ -362,7 +360,7 @@
           <h3>Platforms</h3>
           <ul class="ticks">
             <li>iPhone · iPad · Apple Watch <span class="badge">today</span></li>
-            <li>Android <span class="badge badge--soon">soon</span></li>
+            <li>Android · Wear OS <span class="badge">today</span></li>
           </ul>
         </article>
         <article class="feat glass">
@@ -381,12 +379,10 @@
     <section class="section" id="download">
       <div class="container cta-final">
         <h2>Ready to monitor like a pro?</h2>
-        <p class="lead">Join the TestFlight beta and help shape OpenZCine.</p>
+        <p class="lead">Join the open beta on iPhone or Android and help shape OpenZCine.</p>
         <div class="hero__cta">
           <a class="btn btn--primary btn--magnetic" href="TESTFLIGHT_URL"><span class="btn__rec" aria-hidden="true"></span>Join the TestFlight beta</a>
-          <span class="btn btn--disabled" data-coming-soon="android" aria-disabled="true">
-            Android <span class="btn__status">Coming soon</span>
-          </span>
+          <a class="btn btn--ghost btn--magnetic" href="https://play.google.com/store/apps/details?id=com.opencapture.openzcine" target="_blank" rel="noopener">Join the Android beta<span class="btn__arrow" aria-hidden="true">→</span></a>
           <a class="btn btn--ghost btn--magnetic" href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">★ Star on GitHub<span class="btn__arrow" aria-hidden="true">→</span></a>
         </div>
       </div>

--- a/site/privacy/index.html
+++ b/site/privacy/index.html
@@ -51,7 +51,7 @@
         <a href="/">Home</a>
         <a href="/support/">Support</a>
         <a href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">GitHub</a>
-        <a class="btn btn--primary" href="TESTFLIGHT_URL"><span class="btn__rec" aria-hidden="true"></span>Join the beta</a>
+        <a class="btn btn--primary" href="/#download"><span class="btn__rec" aria-hidden="true"></span>Join the beta</a>
       </nav>
     </div>
   </header>
@@ -61,7 +61,7 @@
       <div class="container legal-article">
         <span class="section-label"><span class="rec-dot"></span> Privacy Policy</span>
         <h1>Your footage is nobody's business.</h1>
-        <p class="legal-updated">Last updated: July 16, 2026</p>
+        <p class="legal-updated">Last updated: August 20, 2026</p>
       </div>
     </section>
 
@@ -147,6 +147,11 @@
           <strong>Apple TestFlight diagnostics.</strong> When you install a beta through
           TestFlight, Apple may provide crash and diagnostic reports to the developer under
           Apple's TestFlight and privacy terms. OpenZCine adds no third-party crash-reporting SDK.
+        </li>
+        <li>
+          <strong>Google Play diagnostics.</strong> When you install a beta through Google Play,
+          Google may provide crash and diagnostic reports to the developer under Google Play's
+          terms. OpenZCine adds no third-party crash-reporting SDK.
         </li>
         <li>
           <strong>Frame.io upload (optional).</strong> If you connect your own Frame.io account,

--- a/site/support/index.html
+++ b/site/support/index.html
@@ -36,7 +36,7 @@
       <nav class="support-nav__links" aria-label="Support navigation">
         <a href="/">Home</a>
         <a href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">GitHub</a>
-        <a class="btn btn--primary" href="TESTFLIGHT_URL"><span class="btn__rec" aria-hidden="true"></span>Join the beta</a>
+        <a class="btn btn--primary" href="/#download"><span class="btn__rec" aria-hidden="true"></span>Join the beta</a>
       </nav>
     </div>
   </header>
@@ -47,7 +47,7 @@
         <span class="section-label"><span class="rec-dot"></span> Support Center</span>
         <h1>Get the shot.<br><span class="gold">We’ll help with the rest.</span></h1>
         <p class="lead">Connect your Nikon ZR, shape the monitor, control the camera, review the take, and send it on. OpenZCine is in active beta, so this guide also calls out what still needs real-world hardening.</p>
-        <p class="support-notice"><strong>Current focus:</strong> iPhone and iPad with Nikon ZR over Wi-Fi. USB-C, Apple Watch, and the full iPad experience are available but still being hardened across more setups.</p>
+        <p class="support-notice"><strong>Current focus:</strong> iPhone, iPad, and Android with Nikon ZR over Wi-Fi. USB-C, Apple Watch, Wear OS, and the full tablet experience are available but still being hardened across more setups.</p>
       </div>
     </section>
 

--- a/site/terms/index.html
+++ b/site/terms/index.html
@@ -51,7 +51,7 @@
         <a href="/">Home</a>
         <a href="/support/">Support</a>
         <a href="https://github.com/erik-sutton95/OpenZCine" target="_blank" rel="noopener">GitHub</a>
-        <a class="btn btn--primary" href="TESTFLIGHT_URL"><span class="btn__rec" aria-hidden="true"></span>Join the beta</a>
+        <a class="btn btn--primary" href="/#download"><span class="btn__rec" aria-hidden="true"></span>Join the beta</a>
       </nav>
     </div>
   </header>
@@ -61,7 +61,7 @@
       <div class="container legal-article">
         <span class="section-label"><span class="rec-dot"></span> Terms of Use</span>
         <h1>Short, because there's not much to agree to.</h1>
-        <p class="legal-updated">Last updated: July 16, 2026</p>
+        <p class="legal-updated">Last updated: August 20, 2026</p>
       </div>
     </section>
 
@@ -83,7 +83,10 @@
         If you install the app from the App Store, that binary is additionally subject to Apple's
         standard
         <a href="https://www.apple.com/legal/internet-services/itunes/dev/stdeula/" target="_blank" rel="noopener">Licensed
-        Application End User License Agreement</a>.
+        Application End User License Agreement</a>. If you install it from Google Play, that
+        distribution is additionally subject to
+        <a href="https://play.google.com/about/play-terms/" target="_blank" rel="noopener">Google
+        Play's Terms of Service</a>.
       </p>
 
       <h2>Camera control disclaimer</h2>


### PR DESCRIPTION
## Summary

The Android app is on Google Play. The landing page still said Coming soon. This wires the public listing into the same places TestFlight already lives.

Play listing: https://play.google.com/store/apps/details?id=com.opencapture.openzcine

## What changed

- Hero and final download CTAs: **Join the Android beta** → Play Store (TestFlight stays the gold button).
- Nav / support / privacy / terms “Join the beta” now jumps to `#download` so both stores are on one screen.
- Platforms row: Android · Wear OS is **today**, not soon.
- README, privacy (Play diagnostics), and terms (Play Terms of Service) match.

## Test plan

- [x] `just check`
- [x] Play listing loads and offers Install
- [ ] After merge, confirm openzcine.app hero/download buttons open the Play listing
- [ ] Confirm TestFlight still replaces `TESTFLIGHT_URL` on Pages deploy

Kaneo: OPE-165