### PR TITLE
fix: native share and save to photos, and Share while connected

### DIFF
--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaDeliveryPopup.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaDeliveryPopup.kt
@@ -135,7 +135,7 @@ internal fun MediaDeliveryPopup(
             frameioController != null
     val hopBusy =
         frameioController?.let { frameioHopBlocksDismissal(it.internetHopState) } == true
-    val hasDeliverable = readyCount > 0 || (cameraConnected && clipCount > 0)
+    val hasDeliverable = canDeliverMedia(readyCount, clipCount, cameraConnected)
     val frameioProjectReady =
         frameioController?.selectedDestination != null || onCameraAp == true
     val canContinue =

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaPlaybackScreen.kt
@@ -412,9 +412,7 @@ private fun PlaybackClipSession(
     }
 
     fun beginShare(configuration: MediaDeliveryConfiguration) {
-        // The button arms only once this clip's full file has landed; the coordinator's cache
-        // pre-pass then finds it and transfers nothing.
-        if (shareableEntry == null || deliveryInProgress || actionInProgress) return
+        if (deliveryInProgress || actionInProgress) return
         val coordinator = mediaDeliveryCoordinator
         if (coordinator != null) {
             activePlayer?.pause()
@@ -434,7 +432,7 @@ private fun PlaybackClipSession(
     }
 
     fun beginGallerySave(configuration: MediaDeliveryConfiguration) {
-        if (shareableEntry == null || deliveryInProgress || actionInProgress) return
+        if (deliveryInProgress || actionInProgress) return
         val coordinator = mediaDeliveryCoordinator
         if (coordinator != null) {
             activePlayer?.pause()
@@ -450,7 +448,6 @@ private fun PlaybackClipSession(
     }
 
     fun beginFrameioDelivery(options: FrameioDeliveryOptions) {
-        val completedEntry = shareableEntry ?: return
         if (deliveryInProgress || actionInProgress) return
         val resumeAfter = activePlayer?.isPlaying == true
         activePlayer?.pause()
@@ -459,6 +456,21 @@ private fun PlaybackClipSession(
                 val stageContext = coroutineContext
                 val runningJob = stageContext[Job]
                 try {
+                    val completedEntry =
+                        shareableEntry
+                            ?: mediaDeliveryCoordinator
+                                ?.cacheFromCamera(
+                                    destination = MediaDeliveryKind.FRAMEIO,
+                                    selection = listOf(MediaDeliverySelection(cameraID, clip)),
+                                    cameraTransferAvailable = cameraTransferAvailable,
+                                )
+                                ?.items
+                                ?.firstOrNull()
+                                ?.entry
+                    if (completedEntry == null) {
+                        deliveryMessage = "Couldn't cache this clip from the camera."
+                        return@launch
+                    }
                     val staged =
                         withContext(Dispatchers.IO) {
                             MediaShareStager(shareCacheDirectory).stage(completedEntry, clip) {
@@ -584,7 +596,12 @@ private fun PlaybackClipSession(
                     ratingShadeOpen = ratingShadeOpen,
                     onRatingShadeOpenChanged = { ratingShadeOpen = it },
                     onPlayerChanged = { activePlayer = it },
-                    shareReady = shareState == PlaybackShareState.READY,
+                    shareReady =
+                        canDeliverMedia(
+                            readyCount = if (shareState == PlaybackShareState.READY) 1 else 0,
+                            clipCount = 1,
+                            cameraConnected = cameraTransferAvailable,
+                        ),
                     deliveryInProgress = deliveryInProgress,
                     onShare = { deliveryChooserPresented = true },
                     ratingStars = ratingStars,
@@ -661,7 +678,11 @@ private fun PlaybackClipSession(
                 when (shareState) {
                     PlaybackShareState.BUFFERING ->
                         Text(
-                            "Buffering camera proxy. Delivery unlocks after the private cache completes.",
+                            if (cameraTransferAvailable) {
+                                "Still caching from the camera. Share will finish the copy first."
+                            } else {
+                                "Buffering camera proxy. Delivery unlocks after the private cache completes."
+                            },
                             modifier = Modifier.padding(start = 44.dp, top = 5.dp, end = 8.dp),
                             style = chromeStyle(10.5f, FontWeight.Medium),
                             color = LiveDesign.muted,
@@ -689,7 +710,7 @@ private fun PlaybackClipSession(
             MediaDeliveryPopup(
                 clipCount = 1,
                 readyCount = if (shareState == PlaybackShareState.READY) 1 else 0,
-                cameraConnected = true,
+                cameraConnected = cameraTransferAvailable,
                 selectedLut = deliveryLut.takeIf { deliveryLutLabel != null },
                 selectedLutLabel = deliveryLutLabel,
                 frameioController = frameioController,

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackState.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/PlaybackState.kt
@@ -55,9 +55,9 @@ internal enum class PlaybackAudioMode(val volume: Float) {
         if (this == AUDIBLE) MUTED else AUDIBLE
 }
 
-/** Complete-cache-only delivery state shown by playback chrome. */
+/** Cache completeness shown by playback chrome; delivery itself can still cache from the camera. */
 internal enum class PlaybackShareState {
-    /** The cache is still growing, so no external URI can be exposed. */
+    /** The cache is still growing. Share remains available when the camera can finish the copy. */
     BUFFERING,
 
     /** A validated final cache artifact may be staged into FileProvider storage. */
@@ -67,7 +67,7 @@ internal enum class PlaybackShareState {
     UNAVAILABLE,
 }
 
-/** Derives safe share eligibility solely from the cache entry's validated state. */
+/** Derives cache completeness from the entry's validated state. */
 internal fun playbackShareState(
     state: MediaCacheState,
     downloadedBytes: Long,
@@ -78,6 +78,18 @@ internal fun playbackShareState(
         state == MediaCacheState.ACTIVE -> PlaybackShareState.BUFFERING
         else -> PlaybackShareState.UNAVAILABLE
     }
+
+/**
+ * Native share / save (and Frame.io after a cache pre-pass) can start when a complete local
+ * copy exists, or the camera is connected so the delivery run can pull the file first.
+ *
+ * Mirrors iOS `MediaDeliveryEligibility`.
+ */
+internal fun canDeliverMedia(
+    readyCount: Int,
+    clipCount: Int,
+    cameraConnected: Boolean,
+): Boolean = clipCount > 0 && (readyCount > 0 || cameraConnected)
 
 /** Projects Media3's current state into the replay affordance without latching old end events. */
 internal fun requiresPlaybackReplay(playbackState: Int): Boolean =

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/media/PlaybackStateTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/media/PlaybackStateTest.kt
@@ -45,7 +45,7 @@ class PlaybackStateTest {
     }
 
     @Test
-    fun `mute is player local and complete cache is the only shareable state`() {
+    fun `mute is player local and cache completeness is independent of delivery`() {
         assertEquals(PlaybackAudioMode.MUTED, PlaybackAudioMode.AUDIBLE.toggled())
         assertEquals(0f, PlaybackAudioMode.MUTED.volume)
         assertEquals(PlaybackAudioMode.AUDIBLE, PlaybackAudioMode.MUTED.toggled())
@@ -65,6 +65,14 @@ class PlaybackStateTest {
             PlaybackShareState.UNAVAILABLE,
             playbackShareState(MediaCacheState.FAILED, downloadedBytes = 10L, expectedLength = 10L),
         )
+    }
+
+    @Test
+    fun `connected camera can start delivery before the cache completes`() {
+        assertEquals(true, canDeliverMedia(readyCount = 0, clipCount = 1, cameraConnected = true))
+        assertEquals(true, canDeliverMedia(readyCount = 1, clipCount = 1, cameraConnected = false))
+        assertEquals(false, canDeliverMedia(readyCount = 0, clipCount = 1, cameraConnected = false))
+        assertEquals(false, canDeliverMedia(readyCount = 0, clipCount = 0, cameraConnected = true))
     }
 
     @Test

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,5 +1,5 @@
+- Fixed: Share and Save to Photos work on clips from the camera.
+- Fixed: Share in playback is available while the camera is still connected.
 - New: Settings > Controls has Auto-Rotate Feed. Turn it off if you want the picture to stay put when the camera is on its side.
 - Fixed: in photo mode on a tablet, the battery gauges sit beside the lock instead of covering PLAY.
 - Fixed: joining the camera's own Wi-Fi finds the camera instead of failing with an address error.
-- Fixed: stills focus settings no longer change how video focus taps behave.
-- New: your camera's clock syncs to the phone on connect - never while recording.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,13 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- Native Share and Save to Photos no longer fail with AVFoundation `Invalid sample cursor` on
+  Nikon proxy clips. Export now strips the camera timecode track before the session, uses the
+  stable export path, and restores timecode afterwards (iOS).
+- Playback Share is available while the camera is connected. The delivery run caches the clip
+  from the camera first; disconnecting and opening Operator Setup media is no longer required
+  (iOS and Android).
+
 - A stills-side focus-mode event no longer repaints the movie FOCUS readout or makes feed taps
   fire a one-shot AF drive on a body running continuous AF — the two modes were decoding into
   one field, last writer wins (both platforms).

--- a/docs/flows/media-delivery-frameio.md
+++ b/docs/flows/media-delivery-frameio.md
@@ -71,11 +71,14 @@ flowchart TD
 
 - **Status:** shipped
 - **Screen:** Media grid: enter selection mode → **Share** (paperplane). Media player: transport
-  bar **Share** button (disabled until clip is cached locally).
+  bar **Share** button (enabled when the clip is cached, or when the camera is connected so the
+  run can cache it first).
 - **Code:** `MediaBrowser.swift` (`MediaBrowserView`, `MediaPlayerView`), `MediaDeliveryPopup.swift`
   (`MediaDeliveryRequest`, `MediaDeliveryPresentation`, `MediaDeliveryPopupOverlay`).
 - **Detail:** Popup anchors below the grid Share button or above the player share button (420pt
-  glass panel, dimmed backdrop). Player pauses playback while the popup is open.
+  glass panel, dimmed backdrop). Player pauses playback while the popup is open. Playback Share
+  is enabled when the clip is already cached **or** the camera is connected (the runner caches
+  on-camera files first). Disconnected uncached clips stay disabled.
 - 📝 Notes:
 
 ### DELIVERY-02 — Pick destination

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		TEST00000000000000000090 /* ConnectionLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00000000000000000091 /* ConnectionLifecycleTests.swift */; };
 		TEST00000000000000000092 /* RelayRecordControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00000000000000000093 /* RelayRecordControlTests.swift */; };
 		TEST00000000000000000094 /* LiveFeedNoiseFilterWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00000000000000000095 /* LiveFeedNoiseFilterWindowTests.swift */; };
+		TEST00000000000000000100 /* MediaDeliveryEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00000000000000000101 /* MediaDeliveryEligibilityTests.swift */; };
 		USBC00000000000000000002 /* PTPUSBContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = USBC00000000000000000001 /* PTPUSBContainer.swift */; };
 		USBT00000000000000000002 /* USBCameraTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = USBT00000000000000000001 /* USBCameraTransport.swift */; };
 		RLNK00000000000000000002 /* MonitorRelayLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = RLNK00000000000000000001 /* MonitorRelayLink.swift */; };
@@ -351,6 +352,7 @@
 		TEST00000000000000000091 /* ConnectionLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionLifecycleTests.swift; sourceTree = "<group>"; };
 		TEST00000000000000000093 /* RelayRecordControlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayRecordControlTests.swift; sourceTree = "<group>"; };
 		TEST00000000000000000095 /* LiveFeedNoiseFilterWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveFeedNoiseFilterWindowTests.swift; sourceTree = "<group>"; };
+		TEST00000000000000000101 /* MediaDeliveryEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDeliveryEligibilityTests.swift; sourceTree = "<group>"; };
 		USBC00000000000000000001 /* PTPUSBContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PTPUSBContainer.swift; path = ../Sources/OpenZCineCore/PTPUSBContainer.swift; sourceTree = SOURCE_ROOT; };
 		USBT00000000000000000001 /* USBCameraTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = USBCameraTransport.swift; sourceTree = "<group>"; };
 		RLNK00000000000000000001 /* MonitorRelayLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorRelayLink.swift; sourceTree = "<group>"; };
@@ -410,6 +412,7 @@
 				TEST00000000000000000091 /* ConnectionLifecycleTests.swift */,
 				TEST00000000000000000093 /* RelayRecordControlTests.swift */,
 				TEST00000000000000000095 /* LiveFeedNoiseFilterWindowTests.swift */,
+				TEST00000000000000000101 /* MediaDeliveryEligibilityTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -758,6 +761,7 @@
 				TEST00000000000000000090 /* ConnectionLifecycleTests.swift in Sources */,
 				TEST00000000000000000092 /* RelayRecordControlTests.swift in Sources */,
 				TEST00000000000000000094 /* LiveFeedNoiseFilterWindowTests.swift in Sources */,
+				TEST00000000000000000100 /* MediaDeliveryEligibilityTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/MediaBrowser.swift
+++ b/ios/Runner/MediaBrowser.swift
@@ -4005,7 +4005,7 @@ struct MediaPlayerView: View {
             )
             .font(.system(size: PlaybackChrome.actionIconSize, weight: .medium))
             .foregroundStyle(
-                model.isClipDownloaded(activeClip) ? LiveDesign.text : LiveDesign.faint
+                canShareActiveClip ? LiveDesign.text : LiveDesign.faint
             )
             .frame(
                 width: PlaybackChrome.actionButtonSize.width,
@@ -4019,7 +4019,8 @@ struct MediaPlayerView: View {
                 interactive: true)
         }
         .buttonStyle(.zcTapTarget)
-        .disabled(!model.isClipDownloaded(activeClip))
+        .disabled(!canShareActiveClip)
+        .accessibilityLabel("Share")
         .background {
             GeometryReader { proxy in
                 Color.clear
@@ -4029,6 +4030,13 @@ struct MediaPlayerView: View {
                     }
             }
         }
+    }
+
+    /// Cached clips are ready now; on-camera clips are ready once the camera can cache them.
+    private var canShareActiveClip: Bool {
+        MediaDeliveryEligibility.canDeliver(
+            clipIsLocal: model.isClipDownloaded(activeClip),
+            cameraConnected: model.isConnected)
     }
 
     private func transportButton(

--- a/ios/Runner/MediaDelivery.swift
+++ b/ios/Runner/MediaDelivery.swift
@@ -85,6 +85,23 @@ enum MediaDeliveryDestination: String, CaseIterable, Identifiable, Sendable {
     }
 }
 
+/// Whether native share / save (and Frame.io after a cache pre-pass) can start.
+///
+/// The player used to require a complete local file, which greyed Share out for every on-camera
+/// clip even though `MediaDeliveryRunner` already pulls those files before export. Cached clips
+/// stay deliverable offline; uncached clips need the camera.
+enum MediaDeliveryEligibility {
+    /// One clip, as the playback transport Share button sees it.
+    static func canDeliver(clipIsLocal: Bool, cameraConnected: Bool) -> Bool {
+        clipIsLocal || cameraConnected
+    }
+
+    /// A selection of clips, as the destination popup sees it.
+    static func canDeliver(localCount: Int, totalCount: Int, cameraConnected: Bool) -> Bool {
+        totalCount > 0 && (localCount > 0 || cameraConnected)
+    }
+}
+
 /// Options shared by native share and Frame.io delivery.
 struct MediaDeliveryConfiguration: Sendable {
     var bakeLUT: Bool = true

--- a/ios/Runner/MediaDeliveryPopup.swift
+++ b/ios/Runner/MediaDeliveryPopup.swift
@@ -355,9 +355,10 @@ struct MediaDeliveryPopup: View {
 
     private var canContinue: Bool {
         destination != nil
-            // On-camera clips cache automatically when the camera is connected, so a selection
-            // with nothing local yet is still deliverable.
-            && (!downloadableClips.isEmpty || (model.isConnected && !clips.isEmpty))
+            && MediaDeliveryEligibility.canDeliver(
+                localCount: downloadableClips.count,
+                totalCount: clips.count,
+                cameraConnected: model.isConnected)
             && !(configuration.bakeLUT && !lutAvailable)
             && !(destination == .frameio && !frameioProjectReady)
     }
@@ -470,9 +471,10 @@ struct MediaDeliveryPopup: View {
     }
 
     private func isDestinationEnabled(_ candidate: MediaDeliveryDestination) -> Bool {
-        // On-camera clips cache automatically when the camera is connected.
-        let hasDeliverableClips =
-            !downloadableClips.isEmpty || (model.isConnected && !clips.isEmpty)
+        let hasDeliverableClips = MediaDeliveryEligibility.canDeliver(
+            localCount: downloadableClips.count,
+            totalCount: clips.count,
+            cameraConnected: model.isConnected)
         switch candidate {
         case .nativeShare:
             return hasDeliverableClips
@@ -896,9 +898,12 @@ struct MediaDeliveryPopup: View {
 
     private func beginDelivery(postExportAction: MediaDeliveryPostExportAction = .systemShare) {
         guard let destination else { return }
-        // On-camera clips cache automatically when the camera is connected, so an all-on-camera
-        // selection is still deliverable.
-        guard !downloadableClips.isEmpty || (model.isConnected && !clips.isEmpty) else {
+        guard
+            MediaDeliveryEligibility.canDeliver(
+                localCount: downloadableClips.count,
+                totalCount: clips.count,
+                cameraConnected: model.isConnected)
+        else {
             statusMessage = MediaDeliveryError.emptySelection.localizedDescription
             return
         }

--- a/ios/Runner/MediaLUTExport.swift
+++ b/ios/Runner/MediaLUTExport.swift
@@ -1,5 +1,7 @@
 import AVFoundation
 import CoreImage
+import CoreMedia
+import CoreVideo
 import Foundation
 import UIKit
 import os
@@ -282,6 +284,65 @@ enum MediaLUT {
         return sourceURL.standardizedFileURL != outputURL.standardizedFileURL
     }
 
+    /// Video+audio composition of `asset`, dropping `tmcd` and other data tracks.
+    ///
+    /// Nikon ZR proxies attach a per-frame QuickTime timecode track. Feeding that original asset
+    /// to `AVAssetExportSession` fails on iOS with `AVErrorInvalidSampleCursor` (−11880), which
+    /// is why native Share and Save to Photos both died on the same export path.
+    static func audioVisualExportAsset(from asset: AVAsset) async throws -> AVMutableComposition {
+        let composition = AVMutableComposition()
+        let duration = try await asset.load(.duration)
+        let videoTracks = try await asset.loadTracks(withMediaType: .video)
+        guard !videoTracks.isEmpty else { throw ExportError.sessionSetupFailed }
+
+        for track in videoTracks {
+            guard
+                let dest = composition.addMutableTrack(
+                    withMediaType: .video, preferredTrackID: kCMPersistentTrackID_Invalid)
+            else { continue }
+            do {
+                try insert(
+                    track, timeRange: try await track.load(.timeRange), into: dest,
+                    fallbackDuration: duration)
+                dest.preferredTransform = try await track.load(.preferredTransform)
+            } catch {
+                composition.removeTrack(dest)
+            }
+        }
+        guard !(try await composition.loadTracks(withMediaType: .video)).isEmpty else {
+            throw ExportError.sessionSetupFailed
+        }
+
+        for track in try await asset.loadTracks(withMediaType: .audio) {
+            guard
+                let dest = composition.addMutableTrack(
+                    withMediaType: .audio, preferredTrackID: kCMPersistentTrackID_Invalid)
+            else { continue }
+            do {
+                try insert(
+                    track, timeRange: try await track.load(.timeRange), into: dest,
+                    fallbackDuration: duration)
+            } catch {
+                composition.removeTrack(dest)
+            }
+        }
+        return composition
+    }
+
+    private static func insert(
+        _ source: AVAssetTrack,
+        timeRange: CMTimeRange,
+        into dest: AVMutableCompositionTrack,
+        fallbackDuration: CMTime
+    ) throws {
+        do {
+            try dest.insertTimeRange(timeRange, of: source, at: .zero)
+        } catch {
+            try dest.insertTimeRange(
+                CMTimeRange(start: .zero, duration: fallbackDuration), of: source, at: .zero)
+        }
+    }
+
     private static func transcode(
         sourceURL: URL,
         outputURL: URL,
@@ -289,14 +350,23 @@ enum MediaLUT {
         cube: CubeLUT?,
         progress: @escaping @Sendable (Double) -> Void
     ) async throws {
-        let asset = AVURLAsset(url: sourceURL)
+        let asset = AVURLAsset(
+            url: sourceURL, options: [AVURLAssetPreferPreciseDurationAndTimingKey: true])
+        _ = try await asset.load(.tracks)
+        let exportAsset: AVAsset
+        do {
+            exportAsset = try await audioVisualExportAsset(from: asset)
+        } catch {
+            exportAsset = asset
+        }
+        let fileType = format.avFileType
         guard
             let session = AVAssetExportSession(
-                asset: asset, presetName: AVAssetExportPresetHighestQuality)
+                asset: exportAsset, presetName: AVAssetExportPresetHighestQuality)
         else { throw ExportError.sessionSetupFailed }
 
         if let cube {
-            session.videoComposition = videoComposition(for: asset, cube: cube)
+            session.videoComposition = videoComposition(for: exportAsset, cube: cube)
         }
         progress(0.05)
 
@@ -304,23 +374,246 @@ enum MediaLUT {
         let progressTask = Task { await reporter.poll() }
         defer { progressTask.cancel() }
 
-        if #available(iOS 18, *) {
-            try await session.export(to: outputURL, as: format.avFileType)
-        } else {
-            session.outputURL = outputURL
-            session.outputFileType = format.avFileType
-            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-                nonisolated(unsafe) let exportSession = session
-                exportSession.exportAsynchronously {
-                    if exportSession.status == .completed {
-                        cont.resume()
-                    } else {
-                        cont.resume(throwing: exportSession.error ?? ExportError.failed("export"))
-                    }
+        do {
+            try await runExportSession(session, to: outputURL, as: fileType)
+        } catch {
+            guard isInvalidSampleCursor(error) else { throw error }
+            try? FileManager.default.removeItem(at: outputURL)
+            try await transcodeWithReaderWriter(
+                sourceURL: sourceURL, outputURL: outputURL, format: format, cube: cube,
+                progress: progress)
+        }
+        progress(0.95)
+    }
+
+    private static func runExportSession(
+        _ session: AVAssetExportSession, to outputURL: URL, as fileType: AVFileType
+    ) async throws {
+        // The iOS 18 `export(to:as:)` async API crashes with `_resumeCheckedContinuation`
+        // when the session's asset is an `AVMutableComposition` (the video+audio wrapper
+        // that drops Nikon `tmcd`). `exportAsynchronously` is the stable path.
+        session.outputURL = outputURL
+        session.outputFileType = fileType
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            nonisolated(unsafe) let exportSession = session
+            exportSession.exportAsynchronously {
+                if exportSession.status == .completed {
+                    cont.resume()
+                } else {
+                    cont.resume(throwing: exportSession.error ?? ExportError.failed("export"))
                 }
             }
         }
-        progress(0.95)
+    }
+
+    private static func isInvalidSampleCursor(_ error: Error) -> Bool {
+        let ns = error as NSError
+        return ns.domain == AVFoundationErrorDomain
+            && ns.code == AVError.Code.invalidSampleCursor.rawValue
+    }
+
+    private static func transcodeWithReaderWriter(
+        sourceURL: URL,
+        outputURL: URL,
+        format: MediaExportFormat,
+        cube: CubeLUT?,
+        progress: @escaping @Sendable (Double) -> Void
+    ) async throws {
+        let asset = AVURLAsset(
+            url: sourceURL, options: [AVURLAssetPreferPreciseDurationAndTimingKey: true])
+        guard let videoTrack = try await asset.loadTracks(withMediaType: .video).first else {
+            throw ExportError.sessionSetupFailed
+        }
+        let audioTrack = try await asset.loadTracks(withMediaType: .audio).first
+        let naturalSize = try await videoTrack.load(.naturalSize)
+        let transform = try await videoTrack.load(.preferredTransform)
+        let displayed = naturalSize.applying(transform)
+        let width = max(16, Int(abs(displayed.width).rounded()))
+        let height = max(16, Int(abs(displayed.height).rounded()))
+        let duration = try await asset.load(.duration)
+
+        let reader = try AVAssetReader(asset: asset)
+        let videoOutput = AVAssetReaderTrackOutput(
+            track: videoTrack,
+            outputSettings: [
+                kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
+            ])
+        videoOutput.alwaysCopiesSampleData = false
+        guard reader.canAdd(videoOutput) else { throw ExportError.sessionSetupFailed }
+        reader.add(videoOutput)
+
+        var audioOutput: AVAssetReaderTrackOutput?
+        if let audioTrack {
+            let output = AVAssetReaderTrackOutput(track: audioTrack, outputSettings: nil)
+            output.alwaysCopiesSampleData = false
+            if reader.canAdd(output) {
+                reader.add(output)
+                audioOutput = output
+            }
+        }
+
+        let writer = try AVAssetWriter(outputURL: outputURL, fileType: format.avFileType)
+        let videoInput = AVAssetWriterInput(
+            mediaType: .video,
+            outputSettings: [
+                AVVideoCodecKey: AVVideoCodecType.h264,
+                AVVideoWidthKey: width,
+                AVVideoHeightKey: height,
+            ])
+        videoInput.expectsMediaDataInRealTime = false
+        videoInput.transform = transform
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: videoInput,
+            sourcePixelBufferAttributes: [
+                kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+                kCVPixelBufferWidthKey as String: width,
+                kCVPixelBufferHeightKey as String: height,
+            ])
+        guard writer.canAdd(videoInput) else { throw ExportError.sessionSetupFailed }
+        writer.add(videoInput)
+
+        var audioInput: AVAssetWriterInput?
+        if audioOutput != nil, let audioTrack {
+            let formats = try await audioTrack.load(.formatDescriptions)
+            let input = AVAssetWriterInput(
+                mediaType: .audio, outputSettings: nil, sourceFormatHint: formats.first)
+            input.expectsMediaDataInRealTime = false
+            if writer.canAdd(input) {
+                writer.add(input)
+                audioInput = input
+            }
+        }
+
+        guard writer.startWriting() else {
+            throw writer.error ?? ExportError.sessionSetupFailed
+        }
+        guard reader.startReading() else {
+            throw reader.error ?? ExportError.sessionSetupFailed
+        }
+        writer.startSession(atSourceTime: .zero)
+
+        let filter = cube.flatMap(colorCubeFilter(for:))
+        try await appendReaderWriterSamples(
+            reader: reader,
+            writer: writer,
+            videoOutput: videoOutput,
+            videoInput: videoInput,
+            adaptor: adaptor,
+            audioOutput: audioOutput,
+            audioInput: audioInput,
+            filter: filter,
+            duration: duration,
+            progress: progress)
+
+        videoInput.markAsFinished()
+        audioInput?.markAsFinished()
+        await writer.finishWriting()
+        guard writer.status == .completed else {
+            throw writer.error ?? reader.error ?? ExportError.failed("export")
+        }
+    }
+
+    private static func colorCubeFilter(for cube: CubeLUT) -> CIFilter? {
+        let prepared = cube.preparedForRenderer()
+        let cubeData = prepared.rgbaComponents.withUnsafeBytes { Data($0) }
+        return CIFilter(
+            name: "CIColorCube",
+            parameters: [
+                "inputCubeDimension": prepared.size,
+                "inputCubeData": cubeData,
+            ])
+    }
+
+    private static func appendReaderWriterSamples(
+        reader: AVAssetReader,
+        writer: AVAssetWriter,
+        videoOutput: AVAssetReaderTrackOutput,
+        videoInput: AVAssetWriterInput,
+        adaptor: AVAssetWriterInputPixelBufferAdaptor,
+        audioOutput: AVAssetReaderTrackOutput?,
+        audioInput: AVAssetWriterInput?,
+        filter: CIFilter?,
+        duration: CMTime,
+        progress: @escaping @Sendable (Double) -> Void
+    ) async throws {
+        var videoDone = false
+        var audioDone = audioOutput == nil || audioInput == nil
+        while !videoDone || !audioDone {
+            if Task.isCancelled {
+                reader.cancelReading()
+                writer.cancelWriting()
+                throw CancellationError()
+            }
+            var progressed = false
+            if !videoDone, videoInput.isReadyForMoreMediaData {
+                if let sample = videoOutput.copyNextSampleBuffer() {
+                    try appendVideoSample(sample, adaptor: adaptor, filter: filter)
+                    let pts = CMSampleBufferGetPresentationTimeStamp(sample)
+                    if duration.seconds > 0, pts.seconds > 0 {
+                        progress(min(0.9, 0.05 + 0.85 * (pts.seconds / duration.seconds)))
+                    }
+                    progressed = true
+                } else {
+                    videoDone = true
+                    progressed = true
+                }
+            }
+            if !audioDone, let audioOutput, let audioInput, audioInput.isReadyForMoreMediaData {
+                if let sample = audioOutput.copyNextSampleBuffer() {
+                    if !audioInput.append(sample) {
+                        throw writer.error ?? ExportError.failed("audio")
+                    }
+                    progressed = true
+                } else {
+                    audioDone = true
+                    progressed = true
+                }
+            }
+            if !progressed {
+                try await Task.sleep(for: .milliseconds(10))
+            }
+            if reader.status == .failed {
+                throw reader.error ?? ExportError.failed("export")
+            }
+            if writer.status == .failed {
+                throw writer.error ?? ExportError.failed("export")
+            }
+        }
+    }
+
+    private static func appendVideoSample(
+        _ sample: CMSampleBuffer,
+        adaptor: AVAssetWriterInputPixelBufferAdaptor,
+        filter: CIFilter?
+    ) throws {
+        let timestamp = CMSampleBufferGetPresentationTimeStamp(sample)
+        guard let pixelBuffer = CMSampleBufferGetImageBuffer(sample) else {
+            throw ExportError.failed("video")
+        }
+        if let filter {
+            let source = CIImage(cvPixelBuffer: pixelBuffer)
+            filter.setValue(source.clampedToExtent(), forKey: kCIInputImageKey)
+            let output = (filter.outputImage ?? source).cropped(to: source.extent)
+            var rendered: CVPixelBuffer?
+            if let pool = adaptor.pixelBufferPool {
+                CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pool, &rendered)
+            }
+            if rendered == nil {
+                let width = CVPixelBufferGetWidth(pixelBuffer)
+                let height = CVPixelBufferGetHeight(pixelBuffer)
+                CVPixelBufferCreate(
+                    kCFAllocatorDefault, width, height, kCVPixelFormatType_32BGRA, nil, &rendered)
+            }
+            guard let rendered else { throw ExportError.failed("pixel buffer") }
+            renderContext.render(output, to: rendered)
+            if !adaptor.append(rendered, withPresentationTime: timestamp) {
+                throw ExportError.failed("video")
+            }
+            return
+        }
+        if !adaptor.append(pixelBuffer, withPresentationTime: timestamp) {
+            throw ExportError.failed("video")
+        }
     }
 
     /// Polls `AVAssetExportSession.progress` during transcode without crossing Swift 6 sendability.

--- a/ios/Runner/MediaTimecode.swift
+++ b/ios/Runner/MediaTimecode.swift
@@ -18,16 +18,25 @@ enum MediaTimecode {
     static func copySourceTimecodeTrack(
         from sourceURL: URL, to outputURL: URL, as fileType: AVFileType
     ) async {
-        // Precise timing is required for cross-asset track inserts (AVFoundation -11838).
+        // Precise timing is required for cross-asset track inserts (AVFoundation -11838 / -11880).
         let source = AVURLAsset(
             url: sourceURL, options: [AVURLAssetPreferPreciseDurationAndTimingKey: true])
+        let stagedURL = outputURL.deletingLastPathComponent()
+            .appendingPathComponent(
+                ".\(outputURL.deletingPathExtension().lastPathComponent).tmcd"
+            )
+            .appendingPathExtension(outputURL.pathExtension)
         do {
             guard let sourceTrack = try await source.loadTracks(withMediaType: .timecode).first
             else { return }
             let timeRange = try await sourceTrack.load(.timeRange)
 
-            let movie = AVMutableMovie(url: outputURL, options: nil)
-            movie.defaultMediaDataStorage = AVMediaDataStorage(url: outputURL, options: nil)
+            try? FileManager.default.removeItem(at: stagedURL)
+            try FileManager.default.copyItem(at: outputURL, to: stagedURL)
+            defer { try? FileManager.default.removeItem(at: stagedURL) }
+
+            let movie = AVMutableMovie(url: stagedURL, options: nil)
+            movie.defaultMediaDataStorage = AVMediaDataStorage(url: stagedURL, options: nil)
             guard
                 let timecodeTrack = movie.addMutableTrack(
                     withMediaType: .timecode, copySettingsFrom: nil)
@@ -41,10 +50,31 @@ enum MediaTimecode {
                 video.addTrackAssociation(to: timecodeTrack, type: .timecode)
             }
             try movie.writeHeader(
-                to: outputURL, fileType: fileType, options: .addMovieHeaderToDestination)
+                to: stagedURL, fileType: fileType, options: .addMovieHeaderToDestination)
+            guard await hasReadableVideoTrack(at: stagedURL) else {
+                logger.error("timecode embed produced an unreadable movie; keeping the export")
+                return
+            }
+            try FileManager.default.removeItem(at: outputURL)
+            try FileManager.default.copyItem(at: stagedURL, to: outputURL)
         } catch {
             logger.error(
                 "timecode embed failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// True when the file still has a video track AVFoundation can cursor — a failed tmcd rewrite
+    /// must not replace a good export with a Photos-rejected file.
+    private static func hasReadableVideoTrack(at url: URL) async -> Bool {
+        let asset = AVURLAsset(
+            url: url, options: [AVURLAssetPreferPreciseDurationAndTimingKey: true])
+        do {
+            guard let track = try await asset.loadTracks(withMediaType: .video).first else {
+                return false
+            }
+            return try await track.load(.isPlayable)
+        } catch {
+            return false
         }
     }
 }

--- a/ios/RunnerTests/MediaDeliveryEligibilityTests.swift
+++ b/ios/RunnerTests/MediaDeliveryEligibilityTests.swift
@@ -1,0 +1,39 @@
+import Testing
+
+@testable import Runner
+
+@Suite("Media delivery eligibility")
+struct MediaDeliveryEligibilityTests {
+    @Test("Share stays available while the camera can cache an uncached clip")
+    func connectedCameraUnlocksUncachedClip() {
+        #expect(MediaDeliveryEligibility.canDeliver(clipIsLocal: false, cameraConnected: true))
+        #expect(
+            MediaDeliveryEligibility.canDeliver(localCount: 0, totalCount: 1, cameraConnected: true)
+        )
+    }
+
+    @Test("A cached clip stays deliverable after disconnect")
+    func cachedClipWorksOffline() {
+        #expect(MediaDeliveryEligibility.canDeliver(clipIsLocal: true, cameraConnected: false))
+        #expect(
+            MediaDeliveryEligibility.canDeliver(
+                localCount: 1, totalCount: 1, cameraConnected: false)
+        )
+    }
+
+    @Test("Uncached clips are not deliverable without the camera")
+    func uncachedClipNeedsCamera() {
+        #expect(!MediaDeliveryEligibility.canDeliver(clipIsLocal: false, cameraConnected: false))
+        #expect(
+            !MediaDeliveryEligibility.canDeliver(
+                localCount: 0, totalCount: 2, cameraConnected: false))
+    }
+
+    @Test("An empty selection is never deliverable")
+    func emptySelectionIsNotDeliverable() {
+        #expect(
+            !MediaDeliveryEligibility.canDeliver(
+                localCount: 0, totalCount: 0, cameraConnected: true)
+        )
+    }
+}

--- a/ios/RunnerTests/MediaTimecodeTests.swift
+++ b/ios/RunnerTests/MediaTimecodeTests.swift
@@ -40,6 +40,109 @@ final class MediaTimecodeTests: XCTestCase {
         XCTAssertEqual(start?.frameQuanta, UInt32(Self.fps))
     }
 
+    func testCompositionExportSessionCompletes() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let sourceURL = dir.appendingPathComponent("source.mov")
+        try await Self.writeMovieWithTimecode(to: sourceURL)
+        let source = AVURLAsset(
+            url: sourceURL, options: [AVURLAssetPreferPreciseDurationAndTimingKey: true])
+        let exportable = try await MediaLUT.audioVisualExportAsset(from: source)
+        let output = dir.appendingPathComponent("out.mp4")
+        guard
+            let session = AVAssetExportSession(
+                asset: exportable, presetName: AVAssetExportPresetHighestQuality)
+        else {
+            XCTFail("no export session")
+            return
+        }
+        session.outputURL = output
+        session.outputFileType = .mp4
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            nonisolated(unsafe) let exportSession = session
+            exportSession.exportAsynchronously {
+                if exportSession.status == .completed {
+                    cont.resume()
+                } else {
+                    cont.resume(
+                        throwing: exportSession.error ?? NSError(domain: "export", code: -1))
+                }
+            }
+        }
+        let size =
+            (try FileManager.default.attributesOfItem(atPath: output.path)[.size] as? UInt64) ?? 0
+        XCTAssertGreaterThan(size, 0)
+    }
+
+    func testExportCompositionDropsTimecodeTrack() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let sourceURL = dir.appendingPathComponent("source.mov")
+        try await Self.writeMovieWithTimecode(to: sourceURL)
+        let source = AVURLAsset(
+            url: sourceURL, options: [AVURLAssetPreferPreciseDurationAndTimingKey: true])
+        let sourceTimecode = try await source.loadTracks(withMediaType: .timecode)
+        XCTAssertFalse(sourceTimecode.isEmpty)
+
+        let exportable = try await MediaLUT.audioVisualExportAsset(from: source)
+        let exportTimecode = try await exportable.loadTracks(withMediaType: .timecode)
+        let exportVideo = try await exportable.loadTracks(withMediaType: .video)
+        XCTAssertTrue(exportTimecode.isEmpty)
+        XCTAssertFalse(exportVideo.isEmpty)
+    }
+
+    func testLUTBakeExportSucceedsForTimecodeSource() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let sourceURL = dir.appendingPathComponent("source.mov")
+        try await Self.writeMovieWithTimecode(to: sourceURL)
+
+        let result = try await MediaLUT.export(
+            sourceURL: sourceURL,
+            outputFilename: "lut-bake-\(UUID().uuidString).mov",
+            format: .mov,
+            cube: Self.identityCube(),
+            metadata: nil
+        ) { _ in }
+        defer { try? FileManager.default.removeItem(at: result.videoURL) }
+
+        let size =
+            (try FileManager.default.attributesOfItem(atPath: result.videoURL.path)[.size]
+                as? UInt64) ?? 0
+        XCTAssertGreaterThan(size, 0)
+        let start = try await Self.readStartTimecode(of: result.videoURL)
+        XCTAssertEqual(start?.frame, Self.startFrame)
+    }
+
+    func testExportReferenceProxyIfPresent() async throws {
+        let sample = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("samples")
+            .appendingPathComponent("A002_C057_0704BT.MP4")
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: sample.path),
+            "reference proxy sample is not on this machine")
+
+        let source = AVURLAsset(
+            url: sample, options: [AVURLAssetPreferPreciseDurationAndTimingKey: true])
+        let exportable = try await MediaLUT.audioVisualExportAsset(from: source)
+        let exportTimecode = try await exportable.loadTracks(withMediaType: .timecode)
+        let exportVideo = try await exportable.loadTracks(withMediaType: .video)
+        XCTAssertTrue(exportTimecode.isEmpty)
+        XCTAssertFalse(exportVideo.isEmpty)
+    }
+
     // MARK: - Synthesis
 
     /// Writes a tiny H.264 movie with a `tmcd` track starting at `startFrame`.
@@ -117,6 +220,22 @@ final class MediaTimecodeTests: XCTestCase {
         guard writer.status == .completed else {
             throw writer.error ?? NSError(domain: "MediaTimecodeTests", code: -4)
         }
+    }
+
+    private static func identityCube(size: Int = 2) -> CubeLUT {
+        var rgb: [Float] = []
+        rgb.reserveCapacity(size * size * size * 3)
+        let denominator = Float(size - 1)
+        for b in 0..<size {
+            for g in 0..<size {
+                for r in 0..<size {
+                    rgb.append(Float(r) / denominator)
+                    rgb.append(Float(g) / denominator)
+                    rgb.append(Float(b) / denominator)
+                }
+            }
+        }
+        return CubeLUT(size: size, rgb: rgb)
     }
 
     private static func makePixelBuffer(

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -9,6 +9,8 @@ New and changed
 
 Fixes
 
+- Share and Save to Photos work on clips from the camera. They used to fail with "Invalid sample cursor".
+- Share on the player is available while the camera is connected. You no longer have to disconnect and go through Operator Setup to reach it.
 - On iPad in photo mode, the battery gauges sit beside the lock instead of covering PLAY.
 - A camera whose clock has drifted is set to your phone's time on connect - automatically, never while recording.
 - Changing stills focus settings no longer flips the video FOCUS readout or makes taps refocus single-shot on a camera set to full-time AF.
@@ -20,6 +22,7 @@ Fixes
 
 What to test
 
+- Connect to the camera, play a clip, tap Share, then Share and Save to Photos. Both should finish. You should not have to disconnect first.
 - Save the same body on two different Wi-Fi networks. Each should stay its own setup with its own Stream Preset and Quality Bias, and renaming one should not touch the other.
 - Turn the camera on its side, then turn Auto-Rotate Feed off in Settings > Controls: the picture should stay put. Turn it back on and the picture should stand up. Then flip the iPhone to the opposite landscape: picture and controls swap sides, nothing under the island.
 - Turn on Share This Feed, ask for control from the second device, and start a take from it. Then screen-record on the sharing device and check the watcher stays with the action.


### PR DESCRIPTION
## What & why

Closes #342 (Kaneo **OPE-166**).

Two operator-facing delivery bugs:

1. **Native Share and Save to Photos failed** with AVFoundation `Invalid sample cursor` (−11880) on Nikon proxy clips. Those files carry a per-frame `tmcd` track plus an edit list. `MediaLUT.export` fed the whole asset into `AVAssetExportSession`, and the iOS 18 `export(to:as:)` API also crashed (`_resumeCheckedContinuation`) once the session's asset was a video+audio composition.
2. **Playback Share was greyed out while the camera was connected.** The button required a complete local cache, even though the delivery runner already caches on-camera clips first. Testers could only reach Share after disconnecting and opening media from Operator Setup.

### Export

- Load with precise timing and wrap **video+audio only** (drop `tmcd`) before the export session.
- Use `exportAsynchronously` instead of the crashing iOS 18 async export.
- Re-embed timecode onto a copy afterwards; keep the original export if that rewrite is unreadable.
- Fall back to a reader/writer re-encode if −11880 is still thrown.

### Share enablement (iOS + Android)

Share is available when the clip is cached **or** the camera is connected so the run can cache it first. Disconnected uncached clips stay disabled.

## TestFlight notes

Updated `ios/TestFlight/WhatToTest.en-US.txt`.

## Google Play notes

Updated `Apps/Android/distribution/whatsnew/whatsnew-en-US`.

## Test plan

**iOS**
- [x] `just native-check`
- [x] Eligibility tests: cached / connected / disconnected-uncached
- [x] Export tests: composition drops `tmcd`, LUT bake, mov→mp4 transcode, Nikon proxy composition strip
- [ ] Hardware: connect to the camera, play a clip, tap Share, then Share and Save to Photos. Both should finish without “Invalid sample cursor”. Share should not require disconnecting first.

**Android**
- [x] `just android-check`
- [x] `canDeliverMedia` unit tests
- [ ] Hardware: same operator path — Share on the player while connected, then native Share / Save to Photos.

## Checklist

- [x] Native production changes: `just native-check` passes.
- [x] Android: `just android-check` passes.
- [x] Commits follow Conventional Commits.
- [x] No proprietary assets (`vendor/`, `ref/`) are included.
- [x] Docs/CHANGELOG updated.
- [x] TestFlight notes updated.
- [x] Play notes updated.