### PR TITLE
fix: photo FOCUS and tap-to-focus stop borrowing the movie AF mode

### DIFF
--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/PhotographyPickers.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/PhotographyPickers.kt
@@ -625,6 +625,7 @@ internal fun photographyCaptureSettings(
         tile(
             MonitorPickerKind.FOCUS,
             "FOCUS",
+            // Stills AF mode only — leftover movie AF-F on this tile is #272.
             properties.activeFocusMode(photography = true),
             "Wide-L",
             focusPicker,

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/PhotographyPickersTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/PhotographyPickersTest.kt
@@ -318,6 +318,22 @@ class PhotographyPickersTest {
     }
 
     @Test
+    fun `focus tile and mode tab read the stills side not leftover movie AF-F`() {
+        // iOS `photographyCaptureValues` used the movie `focusMode` field, so the
+        // photo strip showed AF-F or "—" while the Focus panel confirmed AF-S (#272).
+        val split =
+            snapshot.copy(focusMode = "AF-F", stillFocusMode = "AF-S")
+        val tiles = settings(split)
+        val focus = tiles.first { it.kind == MonitorPickerKind.FOCUS }
+        assertEquals("AF-S", focus.value)
+        assertEquals("AF-S", focus.picker?.modes?.get(0)?.request?.currentValue)
+
+        val movieOnly = snapshot.copy(focusMode = "AF-F", stillFocusMode = null)
+        val blank = settings(movieOnly).first { it.kind == MonitorPickerKind.FOCUS }
+        assertEquals("—", blank.value)
+    }
+
+    @Test
     fun `focus picker routes three independent stills controls`() {
         val picker = settings().first { it.kind == MonitorPickerKind.FOCUS }.picker
         assertNotNull(picker)

--- a/Apps/Android/core-api/src/main/kotlin/com/opencapture/openzcine/core/CameraSession.kt
+++ b/Apps/Android/core-api/src/main/kotlin/com/opencapture/openzcine/core/CameraSession.kt
@@ -604,16 +604,15 @@ public data class CameraPropertySnapshot(
         }
 
     /**
-     * The focus mode belonging to the side of the camera currently on screen, with the same
-     * fallback rule as [activeWhiteBalanceMode]. Mirrors shared-core `activeFocusMode(photography:)`
-     * — a stills AF-S must never repaint (or drive) the movie AF-F.
+     * The focus mode belonging to the side of the camera currently on screen.
+     *
+     * Unlike [activeWhiteBalanceMode], this does not fall back to the other side. Movie AF-F is
+     * not a stills mode; borrowing it is how the photo strip showed AF-F (or "—") while the
+     * Focus panel confirmed AF-S, and how a video tap fired a one-shot drive into AF-F (#272).
+     * Mirrors shared-core `activeFocusMode(photography:)`.
      */
     public fun activeFocusMode(photography: Boolean): String? =
-        if (photography) {
-            stillFocusMode ?: focusMode
-        } else {
-            focusMode ?: stillFocusMode
-        }
+        if (photography) stillFocusMode else focusMode
 }
 
 /** The non-terminal reason an Android property refresh could not update the snapshot. */

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,6 +1,6 @@
+- Fixed: photo FOCUS and taps follow stills AF, not leftover video AF-F.
 - New: Media has REFRESH. After a format it follows the card, not old names; Clear Cache reloads Media from the camera.
 - Fixed: Share and Save to Photos work on clips from the camera.
 - Fixed: Share in playback is available while the camera is still connected.
 - New: Settings > Controls has Auto-Rotate Feed. Turn it off if you want the picture to stay put when the camera is on its side.
 - Fixed: in photo mode on a tablet, the battery gauges sit beside the lock instead of covering PLAY.
-- Fixed: joining the camera's own Wi-Fi finds the camera instead of failing with an address error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,15 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- **Photo-mode FOCUS and tap-to-focus no longer borrow the movie AF mode.** The capture strip
+  was reading the movie leftover, so it showed AF-F or an em dash while the Focus panel — which
+  already used the stills setting — confirmed AF-S. A video tap could then fire the one-shot
+  AF drive that AF-S needs against a body still in AF-F. Each chrome now reads and drives only
+  its own side; a missing readout stays "—" instead of a synthetic AF-F. Both platforms.
+- **A focus-dial pull that overruns the readiness poll no longer wedges tap-to-focus.** The poll
+  ceiling used to count as success while a native Z STM lens was still moving, so the next
+  AF-area change answered busy until a half-press on the body. The in-flight drive is now
+  aborted and the channel is freed. Both platforms.
 - Native Share and Save to Photos no longer fail with AVFoundation `Invalid sample cursor` on
   Nikon proxy clips. Export now strips the camera timecode track before the session, uses the
   stable export path, and restores timecode afterwards (iOS).

--- a/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
+++ b/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
@@ -3221,9 +3221,9 @@ public final class PTPIPClientSession: @unchecked Sendable {
         guard start.operationResponse.responseCode == .ok else {
             return .refused(start.operationResponse.responseCode)
         }
-        // Bounded by `MFDriveChannelBudget`: this whole loop runs under `commandLifecycleLock`,
-        // which `changeAfArea` also needs — waiting out a long pull here is what left tap-to-focus
-        // blocked. Past the ceiling the lens keeps moving on the body; the app just stops watching.
+        // Bounded by `MFDriveChannelBudget`. Exhausting the ceiling used to return `.complete`
+        // while the lens was still moving, so `changeAfArea` (same lock) answered busy until a
+        // half-press. Abort the body-side drive and refuse so the next command is not blocked.
         for _ in 0..<MFDriveChannelBudget.readinessPollLimit {
             guard let ready = try? executeTransaction(.deviceReady) else {
                 return .refused(.deviceBusy)
@@ -3237,7 +3237,8 @@ public final class PTPIPClientSession: @unchecked Sendable {
             case let other: return .refused(other)
             }
         }
-        return .complete
+        _ = try? executeTransaction(.afDriveCancel)
+        return .refused(.deviceBusy)
     }
 
     // MARK: - Autofocus area

--- a/Sources/OpenZCineCore/PTPCameraProperties.swift
+++ b/Sources/OpenZCineCore/PTPCameraProperties.swift
@@ -1935,13 +1935,13 @@ public struct PTPCameraPropertySnapshot: Equatable, Sendable {
 
     /// The focus mode that belongs to the side of the camera currently on screen.
     ///
-    /// Falls back to the other one only when its own has never been reported, so a body that has
-    /// only ever pushed one of the two still reads out — but a value from the wrong side never
-    /// overwrites a value from the right one. (Field report: a stills AF-S announcement during
-    /// video repainted the FOCUS readout while the body stayed AF-F, and taps then fired the
-    /// single-servo AF drive against the operator's continuous mode.)
+    /// Unlike white balance, this does **not** fall back to the other side. Movie AF-F is not a
+    /// stills mode, and stills AF-S is not the movie setting: borrowing either is how the photo
+    /// strip showed a leftover AF-F (or "—") while the Focus panel confirmed AF-S, and how a
+    /// video tap fired the one-shot AF drive against a body still in AF-F (#272). Unavailable
+    /// stays explicit until that chrome's own property arrives.
     public func activeFocusMode(photography: Bool) -> String? {
-        photography ? (stillFocusMode ?? focusMode) : (focusMode ?? stillFocusMode)
+        photography ? stillFocusMode : focusMode
     }
 
     // Audio.

--- a/Sources/OpenZCineCore/PTPOperation.swift
+++ b/Sources/OpenZCineCore/PTPOperation.swift
@@ -313,8 +313,9 @@ public enum MFDriveEligibility: Equatable, Sendable {
 ///
 /// Mirrored in Kotlin by `MFDriveController` (same numbers, same rule).
 public enum MFDriveChannelBudget: Sendable {
-    /// Readiness polls inside ONE drive before it stops waiting and frees the channel. The lens
-    /// keeps moving on the body; the app just stops owning the transaction gate to watch it.
+    /// Readiness polls inside ONE drive before it stops waiting and frees the channel.
+    /// Exhausting this is not success: the body may still be driving, and callers abort that
+    /// in-flight move so `ChangeAfArea` is not left answering busy until a half-press (#272).
     public static let readinessPollLimit = 12
     public static let readinessPollIntervalSeconds = 0.12
 

--- a/Sources/OpenZCineCore/StillCapture.swift
+++ b/Sources/OpenZCineCore/StillCapture.swift
@@ -391,7 +391,10 @@ extension PTPCameraPropertySnapshot {
             CameraValue(label: "SHUTTER", value: shutterSpeed ?? "—"),
             CameraValue(label: "IRIS", value: fNumber ?? "—"),
             CameraValue(label: "DRIVE", value: compactDriveLabel ?? "—"),
-            CameraValue(label: "FOCUS", value: focusMode ?? "—"),
+            // Stills AF mode (`StillFocusMode` / `FocusMode`), never the movie leftover.
+            // The movie field here is how the capture bar showed AF-F or "—" while the
+            // Focus panel — which already reads `stillFocusMode` — confirmed AF-S (#272).
+            CameraValue(label: "FOCUS", value: stillFocusMode ?? "—"),
             CameraValue(label: "WB", value: stillWhiteBalanceValue),
             CameraValue(label: "METER", value: meteringMode ?? "—"),
             CameraValue(label: "PROFILE", value: compactPictureControlLabel ?? "—"),

--- a/Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift
@@ -155,6 +155,10 @@ final class FakeZRServer: @unchecked Sendable {
         var endTrackingResponseCode: UInt16 = 0x2001
         /// Response sent for Nikon `AfDriveCancel`.
         var afDriveCancelResponseCode: UInt16 = 0x2001
+        /// How many `DeviceReady` polls after `MfDrive` report busy before OK. A value
+        /// at or above `MFDriveChannelBudget.readinessPollLimit` keeps the drive in
+        /// flight for the whole poll ceiling so tests can assert the abort path.
+        var mfDriveReadinessBusyPolls: Int = 0
         /// Whether synthesized live-view headers contain authoritative focus data.
         var focusMetadataEnabled = true
         var focusCoordinateWidth: UInt16 = 6_048
@@ -216,6 +220,7 @@ final class FakeZRServer: @unchecked Sendable {
     private var propertyReadCounts: [UInt32: Int] = [:]
     private var stillCaptureRequests: [[UInt32]] = []
     private var stillReleaseBusyPollsRemaining = 0
+    private var mfDriveBusyPollsRemaining = 0
     private var terminateCaptureCount = 0
     private var descriptorReadCounts: [UInt32: Int] = [:]
     private var propertyValueOverrides: [UInt32: Data] = [:]
@@ -646,7 +651,10 @@ final class FakeZRServer: @unchecked Sendable {
         case .deviceReady:
             lock.lock()
             let busyCode: UInt16?
-            if stillReleaseBusyPollsRemaining > 0 {
+            if mfDriveBusyPollsRemaining > 0 {
+                mfDriveBusyPollsRemaining -= 1
+                busyCode = PTPResponseCode.deviceBusy.rawValue
+            } else if stillReleaseBusyPollsRemaining > 0 {
                 stillReleaseBusyPollsRemaining -= 1
                 busyCode = options.stillReleaseBusyResponseCode
             } else {
@@ -654,6 +662,11 @@ final class FakeZRServer: @unchecked Sendable {
             }
             lock.unlock()
             sendResponse(connection, code: busyCode ?? 0x2001, transactionID: transactionID)
+        case .mfDrive:
+            lock.lock()
+            mfDriveBusyPollsRemaining = options.mfDriveReadinessBusyPolls
+            lock.unlock()
+            sendResponse(connection, code: 0x2001, transactionID: transactionID)
         case .initiateCaptureRecInMedia:
             lock.lock()
             let captureResponse = options.stillCaptureResponseCode

--- a/Tests/OpenZCineAndroidFacadeTests/PTPIPClientSessionTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/PTPIPClientSessionTests.swift
@@ -1510,6 +1510,35 @@ struct PTPIPClientSessionTests {
         #expect(!server.isRecording())
     }
 
+    @Test func mfDriveCompletesWhenTheBodyBecomesReady() throws {
+        let server = try FakeZRServer()
+        defer { server.stop() }
+        let session = try connect(to: server)
+        defer { session.disconnect() }
+
+        #expect(session.mfDrive(towardNear: false, pulses: 40) == .complete)
+        #expect(server.receivedOperations().contains(.mfDrive))
+        #expect(!server.receivedOperations().contains(.afDriveCancel))
+    }
+
+    @Test func mfDrivePollCeilingAbortsTheBodySoTouchAFIsNotLeftBusy() throws {
+        // #272: a native Z STM lens can still be moving when the poll ceiling hits.
+        // Returning `.complete` there left ChangeAfArea answering busy until a
+        // half-press. Abort the in-flight drive and refuse so the channel is free.
+        var options = FakeZRServer.Options()
+        options.mfDriveReadinessBusyPolls = MFDriveChannelBudget.readinessPollLimit + 4
+        let server = try FakeZRServer(options: options)
+        defer { server.stop() }
+        let session = try connect(to: server)
+        defer { session.disconnect() }
+
+        #expect(session.mfDrive(towardNear: true, pulses: 80) == .refused(.deviceBusy))
+        let operations = server.receivedOperations()
+        #expect(operations.contains(.mfDrive))
+        #expect(operations.contains(.afDriveCancel))
+        #expect(operations.last == .afDriveCancel)
+    }
+
     @Test func changeAfAreaUsesExactParametersWithoutADataOutPhase() throws {
         let server = try FakeZRServer()
         defer { server.stop() }

--- a/Tests/OpenZCineCoreTests/CameraPropertyTests.swift
+++ b/Tests/OpenZCineCoreTests/CameraPropertyTests.swift
@@ -294,17 +294,36 @@ import Testing
     #expect(
         !StillCapturePolicy.focusPointNeedsAutofocusDrive(
             focusMode: snapshot.activeFocusMode(photography: false), photography: false))
+    // The photography strip must use the stills side too — it used to render `focusMode`
+    // (movie AF-F here), so the capture bar showed AF-F or "—" while the Focus panel,
+    // which reads `stillFocusMode`, confirmed AF-S (#272).
+    #expect(
+        snapshot.photographyCaptureValues.first { $0.label == "FOCUS" }?.value == "AF-S")
 }
 
-/// A body that has only ever reported one side still reads out — the split must not blank the
-/// readout on a camera that pushes just one of the two properties.
-@Test func aFocusModeFromEitherSideStillShowsWhenItIsTheOnlyOne() {
+/// Borrowing the other chrome's focus mode is how photo showed a leftover movie AF-F (or
+/// an em dash, when movie had never been polled) and how a video tap fired the AF-S
+/// one-shot drive against a body still in AF-F. Unavailable stays explicit.
+@Test func aMissingFocusModeOnTheActiveSideDoesNotBorrowTheOtherChrome() {
     let stillsOnly = PTPCameraPropertySnapshot()
         .applying(property: .stillFocusMode, data: Data([0x01]))  // stills AF-C
-    #expect(stillsOnly.activeFocusMode(photography: false) == "AF-C")
+    #expect(stillsOnly.activeFocusMode(photography: true) == "AF-C")
+    #expect(stillsOnly.activeFocusMode(photography: false) == nil)
+    #expect(
+        stillsOnly.photographyCaptureValues.first { $0.label == "FOCUS" }?.value == "AF-C")
+
     let movieOnly = PTPCameraPropertySnapshot()
-        .applying(property: .movieFocusMode, data: Data([0x00]))  // movie AF-S
-    #expect(movieOnly.activeFocusMode(photography: true) == "AF-S")
+        .applying(property: .movieFocusMode, data: Data([0x02]))  // movie AF-F
+    #expect(movieOnly.activeFocusMode(photography: false) == "AF-F")
+    #expect(movieOnly.activeFocusMode(photography: true) == nil)
+    // Not AF-F: that movie leftover is the false photo readout in the field report.
+    #expect(
+        movieOnly.photographyCaptureValues.first { $0.label == "FOCUS" }?.value == "—")
+    // A video body whose movie mode is not in yet must not inherit stills AF-S and
+    // fire a one-shot drive into continuous AF.
+    #expect(
+        !StillCapturePolicy.focusPointNeedsAutofocusDrive(
+            focusMode: stillsOnly.activeFocusMode(photography: false), photography: false))
 }
 
 @Test func cameraPropertyWriteRequestsEncodePickerValues() {

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -7779,8 +7779,7 @@ final class NativeAppModel {
                 let photography = StillCapturePolicy.prefersPhotographyChrome(
                     selector: cameraPropertySnapshot.captureSelector)
                 if StillCapturePolicy.focusPointNeedsAutofocusDrive(
-                    focusMode: cameraPropertySnapshot.activeFocusMode(photography: photography)
-                        ?? cameraValue(for: .focus),
+                    focusMode: cameraPropertySnapshot.activeFocusMode(photography: photography),
                     photography: photography)
                 {
                     try await session.afDrive()

--- a/ios/Runner/NativeCameraSession.swift
+++ b/ios/Runner/NativeCameraSession.swift
@@ -845,10 +845,15 @@ final class NativeCameraSession: @unchecked Sendable {
         guard start.operationResponse.responseCode == .ok else {
             return .refused(start.operationResponse.responseCode)
         }
-        // Bounded by `MFDriveChannelBudget`: past the ceiling the lens keeps moving on the body
-        // and the app stops owning the transaction gate to watch it — holding it longer is what
-        // starved `ChangeAfArea` and made tap-to-focus look dead.
+        // Bounded by `MFDriveChannelBudget`. Exhausting the ceiling used to return `.complete`
+        // while the STM lens was still moving — native Z glass especially — so the next
+        // `ChangeAfArea` answered busy until a body half-press (#272). Abort and refuse so a
+        // tap can own the channel, and so a cancelled Task does not keep polling.
         for _ in 0..<MFDriveChannelBudget.readinessPollLimit {
+            if Task.isCancelled {
+                try? await afDriveCancel()
+                return .refused(.deviceBusy)
+            }
             guard let ready = try? await transact(operationCode: .deviceReady) else {
                 return .refused(.deviceBusy)
             }
@@ -862,7 +867,8 @@ final class NativeCameraSession: @unchecked Sendable {
             case let other: return .refused(other)
             }
         }
-        return .complete
+        try? await afDriveCancel()
+        return .refused(.deviceBusy)
     }
 
     func afDriveCancel() async throws {

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -14,6 +14,7 @@ Fixes
 - Share on the player is available while the camera is connected. You no longer have to disconnect and go through Operator Setup to reach it.
 - On iPad in photo mode, the battery gauges sit beside the lock instead of covering PLAY.
 - A camera whose clock has drifted is set to your phone's time on connect - automatically, never while recording.
+- Photo FOCUS follows stills AF, not leftover video AF-F. After a focus-dial pull, a tap focuses without a half-press.
 - Changing stills focus settings no longer flips the video FOCUS readout or makes taps refocus single-shot on a camera set to full-time AF.
 - A weak or busy link degrades the picture instead of dropping the session, and screen recording while you share your feed no longer walks the watcher's picture behind the action.
 - A watcher granted camera control can now start and stop the take, and keeps that control through a brief drop-out instead of losing it the moment the link stutters.
@@ -28,4 +29,5 @@ What to test
 - Turn the camera on its side, then turn Auto-Rotate Feed off in Settings > Controls: the picture should stay put. Turn it back on and the picture should stand up. Then flip the iPhone to the opposite landscape: picture and controls swap sides, nothing under the island.
 - Turn on Share This Feed, ask for control from the second device, and start a take from it. Then screen-record on the sharing device and check the watcher stays with the action.
 - Watch a dim high-ISO shot with Feed Noise Reduction on and off, then step the Feed Upscaler through Fast, Quality and AI on the same framing.
+- Set stills AF-S and video full-time AF. Photo FOCUS should match the Focus panel, not leftover AF-F. Pull the focus dial, then tap: it should focus without a half-press. Set the clock a minute off, connect, and check it corrects.
 - On an iPad (especially mini) in landscape photo mode, PLAY and the rest of the left tool column should be fully visible and tappable, with the battery gauges beside the lock — not on top of PLAY.


### PR DESCRIPTION
## Summary

Follow-up to [#272](https://github.com/erik-sutton95/OpenZCine/issues/272) after the first focus-dial stall fix in #281 and the stills/movie split in #331.

Field reports after those ships:

- Photo-mode capture strip showed **AF-F** or an em dash while the Focus panel confirmed **AF-S**
- Video AF-F taps behaved like AF-S (one-shot drive) while the camera rear LCD stayed AF-F
- Native Z 24–120mm focus dial stalled; a body half-press restored tap-to-focus

Two remaining software causes:

1. **The photography FOCUS tile read the movie leftover.** White balance was already side-aware; FOCUS still used `focusMode` (movie). Combined with `activeFocusMode` falling back across chrome, a leftover movie AF-F painted the photo strip and a stills AF-S could fire the one-shot drive against video AF-F.
2. **A focus-dial poll ceiling counted as success** while an STM lens was still moving. The next `ChangeAfArea` answered busy until a half-press. Timeout/cancel now abort the in-flight drive (`AfDriveCancel`) and refuse, so the channel is free.

Each chrome now reads and drives **only its own** focus-mode property. Unavailable stays `---` instead of a synthetic AF-F.

## Test plan

- [x] `just native-check`
- [x] `just android-check` (SDK via `ANDROID_HOME`)
- [ ] **Hardware (Z6III + NIKKOR Z 24–120mm f/4 S, and ZR + 40mm):** photo AF-S strip matches the Focus panel; tap-to-focus acquires without switching to AF-F; video AF-F taps move the box only; focus dial then tap-to-focus without a shutter/half-press recovery; FTZ 24–70 still drives.

Fixes #272
