### PR TITLE
fix: A-mode shutter and ISO follow the camera body

### DIFF
--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/CameraPropertySnapshotWire.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/CameraPropertySnapshotWire.kt
@@ -128,6 +128,7 @@ internal object CameraPropertySnapshotWire {
             pictureControl = value.optionalString("pictureControl"),
             evIndicatorSixths = value.optionalInt("evIndicatorSixths"),
             evIndicatorLit = value.optionalBoolean("evIndicatorLit"),
+            autoExposurePoll = value.optionalBoolean("autoExposurePoll") == true,
             controlCapabilities =
                 CameraControlCapabilities(
                     isoValues = value.options("options.iso"),

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCore.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCore.kt
@@ -549,6 +549,14 @@ object SwiftCore {
      */
     const val PROPERTY_REFRESH_SELECTOR: Int = 4
 
+    /**
+     * One rotating camera-owned auto-exposure readout (working ISO / shutter /
+     * iris) while P/A/S/Auto or Auto ISO owns those values. Never advances the
+     * round-robin. A no-op in the core when the operator owns every exposure
+     * value.
+     */
+    const val PROPERTY_REFRESH_AUTO_EXPOSURE: Int = 5
+
     /** `sessionSetRecording` completed and the camera accepted the command. */
     const val RECORDING_COMMAND_ACCEPTED: Int = 0
 
@@ -667,8 +675,9 @@ object SwiftCore {
      * Refreshes semantic Android camera state through the Swift core and
      * returns a flat semantic record consumed by `SwiftCoreCameraSession`. [request]
      * must be one of [PROPERTY_REFRESH_BOOTSTRAP], [PROPERTY_REFRESH_NEXT],
-     * [PROPERTY_REFRESH_EVENT], [PROPERTY_REFRESH_EV_INDICATOR], or
-     * [PROPERTY_REFRESH_SELECTOR]. [recording] informs the core's shared
+     * [PROPERTY_REFRESH_EVENT], [PROPERTY_REFRESH_EV_INDICATOR],
+     * [PROPERTY_REFRESH_SELECTOR], or [PROPERTY_REFRESH_AUTO_EXPOSURE].
+     * [recording] informs the core's shared
      * low-rate poll policy. [propertyCode] is only a raw value forwarded from
      * an existing `DevicePropChanged` event; Kotlin never creates or decodes a
      * Nikon property identifier. Null is reserved for an unavailable native

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSession.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSession.kt
@@ -1149,6 +1149,7 @@ class SwiftCoreCameraSession internal constructor(
                     }
                 }
                 var fastTick = 0
+                var autoExposureFastTick = 0
                 var selectorElapsedMillis = 0L
                 var lastCaptureSelector = _cameraProperties.value.captureSelector
                 var flipFastTicksRemaining = 0
@@ -1189,11 +1190,30 @@ class SwiftCoreCameraSession internal constructor(
                         // propertyPollIntervalMillis.
                         delay(selectorPollIntervalMillis.coerceAtLeast(1L))
                         if (!isActive || !ownsConnectedAttempt(attempt)) break
-                        refreshCameraProperties(
-                            attempt = attempt,
-                            request = SwiftCore.PROPERTY_REFRESH_SELECTOR,
-                            propertyCode = 0L,
-                        )
+                        // Auto-exposure shutter/ISO often change with no event
+                        // (#268). Alternate those camera-owned reads with the
+                        // selector on the same 750 ms lane so the feed still
+                        // pays one PTP per tick. The core no-ops when M +
+                        // manual ISO owns every exposure value.
+                        val autoExposurePoll =
+                            _cameraProperties.value.autoExposurePoll &&
+                                _recordingState.value != CameraRecordingState.RECORDING
+                        if (autoExposurePoll) {
+                            autoExposureFastTick += 1
+                        }
+                        if (autoExposurePoll && autoExposureFastTick % 2 == 0) {
+                            refreshCameraProperties(
+                                attempt = attempt,
+                                request = SwiftCore.PROPERTY_REFRESH_AUTO_EXPOSURE,
+                                propertyCode = 0L,
+                            )
+                        } else {
+                            refreshCameraProperties(
+                                attempt = attempt,
+                                request = SwiftCore.PROPERTY_REFRESH_SELECTOR,
+                                propertyCode = 0L,
+                            )
+                        }
                         val fastSelector = _cameraProperties.value.captureSelector
                         if (fastSelector != lastCaptureSelector) {
                             lastCaptureSelector = fastSelector

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/CameraPropertySnapshotWireTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/CameraPropertySnapshotWireTest.kt
@@ -167,6 +167,18 @@ class CameraPropertySnapshotWireTest {
         assertNull(bare.snapshot.pictureControl)
         assertNull(bare.snapshot.evIndicatorSixths)
         assertNull(bare.snapshot.evIndicatorLit)
+        assertFalse(bare.snapshot.autoExposurePoll)
+    }
+
+    @Test
+    fun decodesTheAutoExposurePollGate() {
+        val on =
+            CameraPropertySnapshotWire.decode(validPayload() + "\nautoExposurePoll\ttrue")
+        assertTrue(on.snapshot.autoExposurePoll)
+
+        val off =
+            CameraPropertySnapshotWire.decode(validPayload() + "\nautoExposurePoll\tfalse")
+        assertFalse(off.snapshot.autoExposurePoll)
     }
 
     private fun assertRejected(payload: String) {

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSessionTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSessionTest.kt
@@ -884,6 +884,43 @@ class SwiftCoreCameraSessionTest {
     }
 
     @Test
+    fun `auto-exposure fast polling alternates with the selector`() = runTest {
+        val bridge = FakeBridge()
+        bridge.propertyRefreshPayload = propertyPayload() + "\nautoExposurePoll\ttrue"
+        val session =
+            SwiftCoreCameraSession(
+                host = "192.168.1.1",
+                phaseLogger = { _, _ -> },
+                core = bridge,
+                propertyRefreshScope = this,
+                propertyRefreshDispatcher = StandardTestDispatcher(testScheduler),
+                propertyPollIntervalMillis = 3_000,
+                selectorPollIntervalMillis = 750,
+            )
+        val connecting = async { session.connect() }
+        runCurrent()
+        bridge.listeners.single().onConnected("ZR", "NIKON ZR", "6001234")
+        connecting.await()
+        runCurrent()
+        bridge.clearRefreshRequests()
+        advanceTimeBy(3_100)
+        runCurrent()
+
+        assertEquals(
+            listOf(
+                SwiftCore.PROPERTY_REFRESH_SELECTOR,
+                SwiftCore.PROPERTY_REFRESH_AUTO_EXPOSURE,
+                SwiftCore.PROPERTY_REFRESH_SELECTOR,
+                SwiftCore.PROPERTY_REFRESH_AUTO_EXPOSURE,
+                SwiftCore.PROPERTY_REFRESH_NEXT,
+            ),
+            bridge.refreshRequests().map { it.request },
+        )
+
+        session.disconnect()
+    }
+
+    @Test
     fun `property events debounce and coalesce into one semantic refresh`() = runTest {
         val bridge = FakeBridge()
         bridge.propertyRefreshHandler = { request ->

--- a/Apps/Android/core-api/src/main/kotlin/com/opencapture/openzcine/core/CameraSession.kt
+++ b/Apps/Android/core-api/src/main/kotlin/com/opencapture/openzcine/core/CameraSession.kt
@@ -586,6 +586,12 @@ public data class CameraPropertySnapshot(
     val evIndicatorSixths: Int? = null,
     /** Whether the body reports its exposure indicator lit (value undefined while off). */
     val evIndicatorLit: Boolean? = null,
+    /**
+     * True when the shared core wants a bounded auto-exposure re-read (P/A/S/Auto
+     * or Auto ISO owns shutter, iris, and/or working ISO). Kotlin only uses this
+     * as a cadence gate — it never picks the Nikon property.
+     */
+    val autoExposurePoll: Boolean = false,
     /** Current descriptor-dependent camera-control capabilities. */
     val controlCapabilities: CameraControlCapabilities = CameraControlCapabilities(),
 ) {

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,6 +1,6 @@
+- Fixed: Aperture-priority shutter and ISO on the phone follow the camera as it meters.
 - Fixed: photo FOCUS and taps follow stills AF, not leftover video AF-F.
 - New: Media has REFRESH. After a format it follows the card, not old names; Clear Cache reloads Media from the camera.
 - Fixed: Share and Save to Photos work on clips from the camera.
 - Fixed: Share in playback is available while the camera is still connected.
 - New: Settings > Controls has Auto-Rotate Feed. Turn it off if you want the picture to stay put when the camera is on its side.
-- Fixed: in photo mode on a tablet, the battery gauges sit beside the lock instead of covering PLAY.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,12 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- **Aperture-priority (and other auto-exposure) shutter and ISO no longer sit stale.** Nikon
+  often does not announce those camera-owned changes on `DevicePropChanged`, so after the first
+  #268 fix a photo A-mode body could show 1/30 · ISO 1000 while the app still read 1/125 · A900.
+  The shared core now re-reads the camera-owned ISO / shutter / iris set on a bounded cadence —
+  one property per tick, skipped entirely in M + manual ISO — and both shells use it. Operator
+  dials still jump the queue when the body does announce them.
 - **Photo-mode FOCUS and tap-to-focus no longer borrow the movie AF mode.** The capture strip
   was reading the movie leftover, so it showed AF-F or an em dash while the Focus panel — which
   already used the stills setting — confirmed AF-S. A video tap could then fire the one-shot

--- a/Sources/OpenZCineAndroidFacade/AndroidCameraPropertyReadbackWire.swift
+++ b/Sources/OpenZCineAndroidFacade/AndroidCameraPropertyReadbackWire.swift
@@ -20,6 +20,10 @@ public enum AndroidCameraPropertyRefreshRequest: Sendable {
     /// within ~1s of the body's lever (iOS polls it off the frame loop). No
     /// round-robin advance — the heavy property set keeps its slow cadence.
     case selector
+    /// One rotating camera-owned auto-exposure readout (working ISO / shutter /
+    /// iris) while P/A/S/Auto or Auto ISO owns those values. No round-robin
+    /// advance. A no-op when the operator owns every exposure value.
+    case autoExposure
 }
 
 /// Non-terminal result of one Android camera-property refresh.
@@ -320,6 +324,10 @@ public enum AndroidCameraPropertyReadbackWire {
         append(
             "evIndicatorSixths", value: properties.evIndicatorSixths.map(String.init), to: &fields)
         append("evIndicatorLit", value: properties.evIndicatorLit.map(String.init), to: &fields)
+        append(
+            "autoExposurePoll",
+            value: CameraAutoExposureReadouts.needsPoll(from: properties) ? "true" : "false",
+            to: &fields)
         let controls = readback.controls
         append("resolutionFrameRate", value: controls.resolutionFrameRate, to: &fields)
         append("codecSelection", value: controls.codec, to: &fields)

--- a/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
+++ b/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
@@ -644,6 +644,7 @@ public final class PTPIPClientSession: @unchecked Sendable {
     private var androidWhiteBalanceTint: String?
     private var androidPropertyPollIndex = 0
     private var androidEVIndicatorPollTick = 0
+    private var androidAutoExposurePollTick = 0
     private var androidLastStorageRefreshAt: Date?
     private var androidLastDescriptorRefreshAt: Date?
     /// Remaining property reads of a photo↔video flip's value burst, drained
@@ -1562,6 +1563,19 @@ public final class PTPIPClientSession: @unchecked Sendable {
                 androidDescriptorsDueForModeFlip = true
             }
             return androidPropertyReadback(result: result)
+        case .autoExposure:
+            // Nikon often does not announce auto-exposure shutter/ISO (#268 round
+            // three). One rotating camera-owned readout, same cheap-tick shape as
+            // the EV needle. Empty set (M + manual ISO) is a no-op — no PTP.
+            guard
+                let property = CameraAutoExposureReadouts.nextProperty(
+                    pollIndex: androidAutoExposurePollTick,
+                    snapshot: androidPropertySnapshot)
+            else {
+                return androidPropertyReadback(result: .accepted)
+            }
+            androidAutoExposurePollTick &+= 1
+            return androidPropertyReadback(result: refreshAndroidProperty(property))
         case .propertyChanged(let rawCode):
             // Gate on the movie ∪ photo monitor union, not the movie order alone: photo chrome
             // watches `fNumber` / `stillShutterSpeed` / `imageSize`, none of which appear in

--- a/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
+++ b/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
@@ -1334,6 +1334,8 @@
             refreshRequest = .evIndicator
         case 4:
             refreshRequest = .selector
+        case 5:
+            refreshRequest = .autoExposure
         default:
             return javaString(
                 env,

--- a/Sources/OpenZCineCore/CameraAutoExposureReadouts.swift
+++ b/Sources/OpenZCineCore/CameraAutoExposureReadouts.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// Camera-owned exposure readouts that can change without a `DevicePropChanged` (`0x4006`).
+///
+/// Operator dials and lens rings announce themselves; auto-exposure does not. In A/P/S/Auto (and
+/// Auto ISO) the body continuously recomputes shutter, iris, and/or working ISO as the scene
+/// changes, and many Nikon bodies never put those values on the event queue. The original #268
+/// fast path only accelerated announced changes, so A-mode stills could sit on a stale shutter
+/// and ISO for the full ~20 s round-robin (TestFlight: body 1/30 · ISO 1000, app 1/125 · A900,
+/// aperture already matching).
+///
+/// The shells re-read this set on a bounded cadence — one property per tick, rotating — and skip
+/// it entirely in M + manual ISO, where the operator is the only writer and `0x4006` already
+/// covers a dial. Recording keeps the compact health poll; this set is standby / live-view only.
+public enum CameraAutoExposureReadouts: Sendable {
+    /// Properties the body can change on its own for this snapshot, in ISO → shutter → iris order
+    /// so a two-slot rotation hits the values the capture strip shows first.
+    public static func polledProperties(
+        from snapshot: PTPCameraPropertySnapshot
+    ) -> [PTPPropertyCode] {
+        let photography = StillCapturePolicy.prefersPhotographyChrome(
+            selector: snapshot.captureSelector)
+        let mode = effectiveExposureMode(snapshot)
+        var properties: [PTPPropertyCode] = []
+
+        if isoIsCameraOwned(snapshot: snapshot, photography: photography, mode: mode) {
+            properties.append(.isoControlSensitivity)
+        }
+        if shutterIsCameraOwned(
+            mode: mode, locked: snapshot.shutterLocked, photography: photography)
+        {
+            if photography {
+                properties.append(.stillShutterSpeed)
+            } else {
+                switch snapshot.shutterMode {
+                case .angle:
+                    properties.append(.movieShutterAngle)
+                case .speed:
+                    properties.append(.movieShutterSpeed)
+                case nil:
+                    // Until `MovieShutterMode` has been polled, cover both circuits so a
+                    // Z6III-on-angle and a Z5II-on-speed both refresh.
+                    properties.append(.movieShutterSpeed)
+                    properties.append(.movieShutterAngle)
+                }
+            }
+        }
+        if irisIsCameraOwned(mode: mode) {
+            properties.append(photography ? .fNumber : .movieFNumber)
+        }
+        return properties
+    }
+
+    /// True when at least one exposure readout is camera-owned and needs the bounded poll.
+    public static func needsPoll(from snapshot: PTPCameraPropertySnapshot) -> Bool {
+        !polledProperties(from: snapshot).isEmpty
+    }
+
+    /// Next camera-owned property to re-read, or `nil` when the operator owns every exposure
+    /// value (M + manual ISO). `pollIndex` rotates through ``polledProperties(from:)``.
+    public static func nextProperty(
+        pollIndex: Int,
+        snapshot: PTPCameraPropertySnapshot
+    ) -> PTPPropertyCode? {
+        let properties = polledProperties(from: snapshot)
+        guard !properties.isEmpty else { return nil }
+        let wrapped = pollIndex % properties.count
+        let index = wrapped >= 0 ? wrapped : wrapped + properties.count
+        return properties[index]
+    }
+
+    /// U1–U4 follow the bank's stored P/A/S/M program when the body has reported it.
+    private static func effectiveExposureMode(
+        _ snapshot: PTPCameraPropertySnapshot
+    ) -> String? {
+        guard let mode = snapshot.exposureMode else { return nil }
+        if mode.hasPrefix("U") { return snapshot.userModeProgram }
+        return mode
+    }
+
+    /// Stills ISO is a different circuit from movie dual-base: a leftover R3D movie codec must
+    /// not suppress A-mode stills ISO. Movie ISO keeps ``ISOPickerPolicy``.
+    private static func isoIsCameraOwned(
+        snapshot: PTPCameraPropertySnapshot,
+        photography: Bool,
+        mode: String?
+    ) -> Bool {
+        if photography {
+            return snapshot.isoAuto == true || mode != "M"
+        }
+        return ISOPickerPolicy.isISOValueCameraOwned(
+            codec: snapshot.fileType ?? "",
+            isoAuto: snapshot.isoAuto,
+            exposureMode: mode)
+    }
+
+    /// Shutter is operator-owned in S and M. A locked movie TV circuit is operator-owned too.
+    /// Unknown / Auto / P / A (and a U-bank that has not reported its program) stay camera-owned.
+    private static func shutterIsCameraOwned(
+        mode: String?,
+        locked: Bool?,
+        photography: Bool
+    ) -> Bool {
+        if !photography, locked == true { return false }
+        switch mode {
+        case "S", "M": return false
+        default: return true
+        }
+    }
+
+    /// Iris is operator-owned in A and M. Unknown / Auto / P / S stay camera-owned.
+    private static func irisIsCameraOwned(mode: String?) -> Bool {
+        switch mode {
+        case "A", "M": return false
+        default: return true
+        }
+    }
+}

--- a/Tests/OpenZCineAndroidFacadeTests/CameraAuthorityWireTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/CameraAuthorityWireTests.swift
@@ -195,4 +195,51 @@ struct CameraPropertyChangeEventWireTests {
         _ = session.refreshAndroidPropertySnapshot(.propertyChanged(0xDEAD))
         #expect(valueReadCount(server) == baseline)
     }
+
+    @Test func autoExposureIsANoOpWhenTheOperatorOwnsEveryExposureValue() throws {
+        // Default fixture is video M + R3D dual-base: shutter, iris, and ISO are
+        // all operator-owned, so the bounded AE poll must not spend a PTP read.
+        let server = try FakeZRServer()
+        defer { server.stop() }
+        let session = try connect(to: server)
+        defer { session.disconnect() }
+        let bootstrap = session.refreshAndroidPropertySnapshot(.bootstrap)
+        #expect(!CameraAutoExposureReadouts.needsPoll(from: bootstrap.properties))
+
+        let baseline = valueReadCount(server)
+        let readback = session.refreshAndroidPropertySnapshot(.autoExposure)
+        #expect(readback.result == .accepted)
+        #expect(valueReadCount(server) == baseline)
+    }
+
+    @Test func photoAModeAutoExposureReadsStillShutterAndWorkingISO() throws {
+        // The August 2026 regression: photo A-mode, no DevicePropChanged for the
+        // camera-owned shutter/ISO, so the app sat on 1/125 · A900. The bounded
+        // poll has to hit those two properties without waiting out the round-robin.
+        let server = try FakeZRServer()
+        defer { server.stop() }
+        server.setCameraProperty(.liveViewSelector, data: Data([0]))
+        server.setCameraProperty(
+            .exposureProgramMode, data: Data(ByteCoding.uint16LE(0x0003)))
+        server.setCameraProperty(.stillISOAutoControl, data: Data([1]))
+        server.setCameraProperty(
+            .stillShutterSpeed, data: Data(ByteCoding.uint32LE(0x0001_001E)))
+        server.setCameraProperty(
+            .isoControlSensitivity, data: Data(ByteCoding.uint32LE(1000)))
+        let session = try connect(to: server)
+        defer { session.disconnect() }
+        let bootstrap = session.refreshAndroidPropertySnapshot(.bootstrap)
+        #expect(bootstrap.properties.captureSelector == .photo)
+        #expect(bootstrap.properties.exposureMode == "A")
+        #expect(CameraAutoExposureReadouts.needsPoll(from: bootstrap.properties))
+        #expect(bootstrap.properties.shutterSpeed == "1/30")
+        #expect(bootstrap.properties.iso == 1000)
+
+        let isoBefore = server.cameraPropertyReadCount(.isoControlSensitivity)
+        let shutterBefore = server.cameraPropertyReadCount(.stillShutterSpeed)
+        _ = session.refreshAndroidPropertySnapshot(.autoExposure)
+        _ = session.refreshAndroidPropertySnapshot(.autoExposure)
+        #expect(server.cameraPropertyReadCount(.isoControlSensitivity) > isoBefore)
+        #expect(server.cameraPropertyReadCount(.stillShutterSpeed) > shutterBefore)
+    }
 }

--- a/Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/FakeZRServer.swift
@@ -385,6 +385,20 @@ final class FakeZRServer: @unchecked Sendable {
         updateCameraMovieFileTypeLocked(raw)
     }
 
+    /// Overrides a property's GetDevicePropValue payload without recording an app write.
+    func setCameraProperty(_ property: PTPPropertyCode, data: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        propertyValueOverrides[property.rawValue] = data
+    }
+
+    /// How many times the scripted body has served this property.
+    func cameraPropertyReadCount(_ property: PTPPropertyCode) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return propertyReadCounts[property.rawValue] ?? 0
+    }
+
     /// Transaction IDs in arrival order (parallel to `receivedOperations`).
     func receivedTransactionIDs() -> [UInt32] {
         lock.lock()

--- a/Tests/OpenZCineCoreTests/CameraSourceOfTruthTests.swift
+++ b/Tests/OpenZCineCoreTests/CameraSourceOfTruthTests.swift
@@ -228,6 +228,197 @@ struct MonitorPollFallbackTests {
     }
 }
 
+// MARK: - #268 · camera-owned auto-exposure readouts (silent AE, no 0x4006)
+
+struct CameraAutoExposureReadoutTests {
+    /// The August 2026 TestFlight regression: photo A-mode, body 1/30 · ISO 1000,
+    /// app 1/125 · A900, aperture already matching. Nikon often does not announce
+    /// auto-exposure shutter/ISO on `DevicePropChanged`, so those two have to be
+    /// re-read on a bounded cadence instead of waiting out the ~20 s round-robin.
+    private let photoA = PTPCameraPropertySnapshot(
+        iso: 900,
+        isoAuto: true,
+        exposureMode: "A",
+        shutterSpeed: "1/125",
+        fNumber: "f/4",
+        fileType: "JPEG",
+        captureSelector: .photo)
+
+    @Test func photoAModePollsWorkingISOAndStillShutterNotIris() {
+        #expect(
+            CameraAutoExposureReadouts.polledProperties(from: photoA)
+                == [.isoControlSensitivity, .stillShutterSpeed])
+        #expect(CameraAutoExposureReadouts.needsPoll(from: photoA))
+    }
+
+    @Test func photoAModeWithALeftoverR3DMovieCodecStillPollsISO() {
+        // The movie codec is not the stills ISO circuit. Gating photo ISO on R3D
+        // dual-base would leave A-mode stills on a stale A900 forever.
+        let leftover = PTPCameraPropertySnapshot(
+            isoAuto: true,
+            exposureMode: "A",
+            fileType: "R3D NE 12-bit R3D",
+            captureSelector: .photo)
+        #expect(
+            CameraAutoExposureReadouts.polledProperties(from: leftover)
+                .contains(.isoControlSensitivity))
+    }
+
+    @Test func photoMModeManualISOPollsNothing() {
+        let snapshot = PTPCameraPropertySnapshot(
+            isoAuto: false,
+            exposureMode: "M",
+            fileType: "JPEG",
+            captureSelector: .photo)
+        #expect(CameraAutoExposureReadouts.polledProperties(from: snapshot).isEmpty)
+        #expect(!CameraAutoExposureReadouts.needsPoll(from: snapshot))
+        #expect(
+            CameraAutoExposureReadouts.nextProperty(pollIndex: 0, snapshot: snapshot) == nil)
+    }
+
+    @Test func photoMModeAutoISOPollsOnlyWorkingISO() {
+        let snapshot = PTPCameraPropertySnapshot(
+            isoAuto: true,
+            exposureMode: "M",
+            fileType: "JPEG",
+            captureSelector: .photo)
+        #expect(
+            CameraAutoExposureReadouts.polledProperties(from: snapshot)
+                == [.isoControlSensitivity])
+    }
+
+    @Test func photoSModePollsIrisAndWorkingISONotShutter() {
+        let snapshot = PTPCameraPropertySnapshot(
+            isoAuto: false,
+            exposureMode: "S",
+            fileType: "JPEG",
+            captureSelector: .photo)
+        #expect(
+            CameraAutoExposureReadouts.polledProperties(from: snapshot)
+                == [.isoControlSensitivity, .fNumber])
+    }
+
+    @Test func videoAModePollsTheMovieShutterFamily() {
+        let speed = PTPCameraPropertySnapshot(
+            isoAuto: true,
+            exposureMode: "A",
+            shutterMode: .speed,
+            fileType: "ProRes 422 HQ",
+            captureSelector: .video)
+        #expect(
+            CameraAutoExposureReadouts.polledProperties(from: speed)
+                == [.isoControlSensitivity, .movieShutterSpeed])
+
+        let angle = PTPCameraPropertySnapshot(
+            isoAuto: false,
+            exposureMode: "A",
+            shutterMode: .angle,
+            fileType: "ProRes 422 HQ",
+            captureSelector: .video)
+        #expect(
+            CameraAutoExposureReadouts.polledProperties(from: angle)
+                == [.isoControlSensitivity, .movieShutterAngle])
+    }
+
+    @Test func r3dManualISODoesNotPollWorkingISO() {
+        let snapshot = PTPCameraPropertySnapshot(
+            isoAuto: true,
+            exposureMode: "A",
+            shutterMode: .angle,
+            fileType: "R3D NE 12-bit R3D",
+            captureSelector: .video)
+        #expect(
+            CameraAutoExposureReadouts.polledProperties(from: snapshot)
+                == [.movieShutterAngle])
+    }
+
+    @Test func aLockedMovieShutterIsNotPolled() {
+        let snapshot = PTPCameraPropertySnapshot(
+            isoAuto: false,
+            exposureMode: "A",
+            shutterMode: .speed,
+            shutterLocked: true,
+            fileType: "H.265",
+            captureSelector: .video)
+        // A-mode still owns ISO; only the locked TV circuit drops out.
+        #expect(
+            CameraAutoExposureReadouts.polledProperties(from: snapshot)
+                == [.isoControlSensitivity])
+    }
+
+    @Test func userBankFollowsTheStoredProgram() {
+        let u1AsAperture = PTPCameraPropertySnapshot(
+            isoAuto: true,
+            exposureMode: "U1",
+            fileType: "JPEG",
+            captureSelector: .photo,
+            userModeProgram: "A")
+        #expect(
+            CameraAutoExposureReadouts.polledProperties(from: u1AsAperture)
+                == [.isoControlSensitivity, .stillShutterSpeed])
+
+        let u1AsManual = PTPCameraPropertySnapshot(
+            isoAuto: false,
+            exposureMode: "U1",
+            fileType: "JPEG",
+            captureSelector: .photo,
+            userModeProgram: "M")
+        #expect(CameraAutoExposureReadouts.polledProperties(from: u1AsManual).isEmpty)
+    }
+
+    @Test func rotationWalksTheCameraOwnedSet() {
+        #expect(
+            CameraAutoExposureReadouts.nextProperty(pollIndex: 0, snapshot: photoA)
+                == .isoControlSensitivity)
+        #expect(
+            CameraAutoExposureReadouts.nextProperty(pollIndex: 1, snapshot: photoA)
+                == .stillShutterSpeed)
+        #expect(
+            CameraAutoExposureReadouts.nextProperty(pollIndex: 2, snapshot: photoA)
+                == .isoControlSensitivity)
+    }
+
+    @Test func photoRoundRobinStillLeavesStillShutterStaleForSeconds() throws {
+        // Documents WHY the auto-exposure path exists: `stillShutterSpeed` in the
+        // photo order is visited about as rarely as movie aperture was in #268.
+        let order = StillCapturePolicy.photoMonitorPollOrder
+        var visits: [Int] = []
+        for tick in 0..<(order.count * 6)
+        where
+            CameraMonitorPollPolicy.nextProperty(
+                pollIndex: tick, isRecording: false, captureSelector: .photo)
+            == .stillShutterSpeed
+        {
+            visits.append(tick)
+        }
+        let first = try #require(visits.first)
+        let second = try #require(visits.dropFirst().first)
+        #expect(second - first > order.count)
+    }
+
+    @Test func displayTilesFollowACameraOwnedStillShutterAndWorkingISO() {
+        let stale = CameraDisplayState.preview.applyingCameraProperties(
+            photoA, photography: true)
+        #expect(stale.values.first { $0.label == "SHUTTER" }?.value == "1/125")
+        #expect(stale.values.first { $0.label == "ISO" }?.value == "A900")
+        #expect(stale.values.first { $0.label == "IRIS" }?.value == "f/4")
+
+        let live = stale.applyingCameraProperties(
+            PTPCameraPropertySnapshot(
+                iso: 1000,
+                isoAuto: true,
+                exposureMode: "A",
+                shutterSpeed: "1/30",
+                fNumber: "f/4",
+                fileType: "JPEG",
+                captureSelector: .photo),
+            photography: true)
+        #expect(live.values.first { $0.label == "SHUTTER" }?.value == "1/30")
+        #expect(live.values.first { $0.label == "ISO" }?.value == "A1000")
+        #expect(live.values.first { $0.label == "IRIS" }?.value == "f/4")
+    }
+}
+
 // MARK: - #257 · shutter mode and value are one camera-supported state
 
 struct ShutterModeAtomicityTests {

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		FEEDC0DEC0FFEE00BAADF002 /* ThermalLoadPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDC0DEC0FFEE00BAADF001 /* ThermalLoadPolicy.swift */; };
 		FTUE00000000000000000002 /* LiveViewOnboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = FTUE00000000000000000001 /* LiveViewOnboarding.swift */; };
 		ISO00000000000000000002 /* ISOPickerPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = ISO00000000000000000003 /* ISOPickerPolicy.swift */; };
+		CAER00000000000000000002 /* CameraAutoExposureReadouts.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAER00000000000000000001 /* CameraAutoExposureReadouts.swift */; };
 		LVSP00000000000000000002 /* LiveViewSignposts.swift in Sources */ = {isa = PBXBuildFile; fileRef = LVSP00000000000000000001 /* LiveViewSignposts.swift */; };
 		MFFB00000000000000000002 /* MetalFeedFrameBaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = MFFB00000000000000000001 /* MetalFeedFrameBaker.swift */; };
 		PTPT00000000000000000002 /* PTPIPTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = PTPT00000000000000000001 /* PTPIPTransport.swift */; };
@@ -340,6 +341,7 @@
 		FEEDC0DEC0FFEE00BAADF001 /* ThermalLoadPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThermalLoadPolicy.swift; path = ../Sources/OpenZCineCore/ThermalLoadPolicy.swift; sourceTree = SOURCE_ROOT; };
 		FTUE00000000000000000001 /* LiveViewOnboarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveViewOnboarding.swift; sourceTree = "<group>"; };
 		ISO00000000000000000003 /* ISOPickerPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ISOPickerPolicy.swift; path = ../Sources/OpenZCineCore/ISOPickerPolicy.swift; sourceTree = SOURCE_ROOT; };
+		CAER00000000000000000001 /* CameraAutoExposureReadouts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CameraAutoExposureReadouts.swift; path = ../Sources/OpenZCineCore/CameraAutoExposureReadouts.swift; sourceTree = SOURCE_ROOT; };
 		LVSP00000000000000000001 /* LiveViewSignposts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveViewSignposts.swift; sourceTree = "<group>"; };
 		MFFB00000000000000000001 /* MetalFeedFrameBaker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MetalFeedFrameBaker.swift; sourceTree = "<group>"; };
 		PTPT00000000000000000001 /* PTPIPTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PTPIPTransport.swift; sourceTree = "<group>"; };
@@ -532,6 +534,7 @@
 				C0DE00000000000000000015 /* PTPDeviceInfo.swift */,
 				C0DE0000000000000000001B /* CameraDiscovery.swift */,
 				ISO00000000000000000003 /* ISOPickerPolicy.swift */,
+				CAER00000000000000000001 /* CameraAutoExposureReadouts.swift */,
 				WBKL00000000000000000003 /* WhiteBalanceKelvinPolicy.swift */,
 				R3D00000000000000000007 /* MediaClipFilename.swift */,
 				DELTA00000000000000000002 /* MediaClipDiscoveryDelta.swift */,
@@ -820,6 +823,7 @@
 				C0DE000000000000000000A2 /* MonitorPortraitLayout.swift in Sources */,
 				C0DE000000000000000000C2 /* MonitorZoneLayout.swift in Sources */,
 				ISO00000000000000000002 /* ISOPickerPolicy.swift in Sources */,
+				CAER00000000000000000002 /* CameraAutoExposureReadouts.swift in Sources */,
 				WBKL00000000000000000002 /* WhiteBalanceKelvinPolicy.swift in Sources */,
 				R3D00000000000000000006 /* MediaClipFilename.swift in Sources */,
 				DELTA00000000000000000001 /* MediaClipDiscoveryDelta.swift in Sources */,

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -8684,6 +8684,21 @@ final class NativeAppModel {
                     ? .exposureIndicateLightup : .exposureIndicateStatus)
             guard !Task.isCancelled, cameraSession === session else { return }
         }
+        // Auto-exposure shutter/ISO/iris often change with no DevicePropChanged (#268
+        // round three: photo A-mode left 1/125 · A900 on screen while the body showed
+        // 1/30 · 1000). One rotating camera-owned readout per idle tick; M + manual
+        // ISO is a no-op. Recording keeps the compact health poll.
+        if !isRecording,
+            let autoExposure = CameraAutoExposureReadouts.nextProperty(
+                pollIndex: autoExposurePollTick,
+                snapshot: cameraPropertySnapshot)
+        {
+            autoExposurePollTick &+= 1
+            if session.supportsProperty(autoExposure) {
+                await readAndApplyCameraProperty(session: session, property: autoExposure)
+                guard !Task.isCancelled, cameraSession === session else { return }
+            }
+        }
         // Properties the CAMERA announced as changed jump the queue: they are the operator's own
         // edit on the body, and the round-robin would otherwise take a full cycle to notice. The
         // WHOLE pending burst drains on the tick that sees it, oldest first and capped
@@ -9761,6 +9776,8 @@ final class NativeAppModel {
     @ObservationIgnored private var stillTimerTask: Task<Void, Never>?
     /// Tick counter for the EV meter's per-tick indicator read (see `pollNextCameraProperty`).
     @ObservationIgnored private var evFastPollTick = 0
+    /// Rotates camera-owned auto-exposure readouts (see `pollNextCameraProperty`).
+    @ObservationIgnored private var autoExposurePollTick = 0
 
     /// The Timer tab's display value ("Off" / "5s").
     var photoTimerLabel: String {

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -18,7 +18,7 @@ Fixes
 - Changing stills focus settings no longer flips the video FOCUS readout or makes taps refocus single-shot on a camera set to full-time AF.
 - A weak or busy link degrades the picture instead of dropping the session, and screen recording while you share your feed no longer walks the watcher's picture behind the action.
 - A watcher granted camera control can now start and stop the take, and keeps that control through a brief drop-out instead of losing it the moment the link stutters.
-- Changes made on the camera reach the app quickly again - the aperture ring, ISO or shutter used to take twenty seconds, or in video never.
+- Aperture-priority shutter and ISO follow the camera as it meters - they used to sit stale, take twenty seconds, or in video never.
 - Unplugging the cable or power-cycling the camera used to wedge the app. Both recover on their own, or offer Retry connection.
 
 What to test
@@ -29,5 +29,6 @@ What to test
 - Turn the camera on its side, then turn Auto-Rotate Feed off in Settings > Controls: the picture should stay put. Turn it back on and the picture should stand up. Then flip the iPhone to the opposite landscape: picture and controls swap sides, nothing under the island.
 - Turn on Share This Feed, ask for control from the second device, and start a take from it. Then screen-record on the sharing device and check the watcher stays with the action.
 - Watch a dim high-ISO shot with Feed Noise Reduction on and off, then step the Feed Upscaler through Fast, Quality and AI on the same framing.
+- Put the body in Aperture-priority photo, change the light, and check shutter and ISO on the phone match the camera. With full-time AF for video, change stills focus settings and tap the feed: FOCUS should hold.
 - Set stills AF-S and video full-time AF. Photo FOCUS should match the Focus panel, not leftover AF-F. Pull the focus dial, then tap: it should focus without a half-press. Set the clock a minute off, connect, and check it corrects.
 - On an iPad (especially mini) in landscape photo mode, PLAY and the rest of the left tool column should be fully visible and tappable, with the battery gauges beside the lock — not on top of PLAY.


### PR DESCRIPTION
## Summary

[#268](https://github.com/erik-sutton95/OpenZCine/issues/268) came back after the first event-path fix: in photo **A** mode a Nikon body can show **1/30 · ISO 1000** while OpenZCine still reads **1/125 · A900**, with aperture already matching.

The first fix accelerated `DevicePropChanged` (`0x4006`). Operator dials announce themselves; auto-exposure often does not. Camera-owned shutter and working ISO then waited on the ~20 s round-robin.

## What changed

Shared-core `CameraAutoExposureReadouts` names the properties the body can change on its own:

- Photo A: working ISO + still shutter (not iris)
- Photo S: working ISO + iris (not shutter)
- M + Auto ISO: working ISO only
- M + manual ISO: nothing extra
- Movie uses the speed/angle family; a leftover R3D movie codec does not suppress stills ISO

Both shells re-read that set on a bounded cadence (one property per tick). Recording keeps the compact health poll. Operator-announced changes still jump the queue.

## Test plan

- [x] `just native-check`
- [x] `just android-check`
- [x] Core tests for A/S/M/U-bank ownership, leftover R3D codec, rotation, and display tiles
- [x] Android facade wire: no-op in M + R3D; photo A reads still shutter + working ISO
- [x] Android JVM: `autoExposurePoll` gate and selector/AE cadence
- [ ] On a Z body in photo A over Wi-Fi: change lighting / EC and confirm ISO + shutter track the body without reconnecting (iOS + Android)
- [ ] Same in P/S/Auto and with Auto ISO in M; confirm M + manual ISO does not add extra PTP traffic

Closes #268
