### PR TITLE
fix: the gallery follows the card after format, refresh, and cache clear

### DIFF
--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
@@ -679,7 +679,10 @@ class MainActivity : ComponentActivity() {
                                 liveViewGuideController = liveViewGuide,
                                 onShowGuideOnNextRealFrame =
                                     liveViewGuide::replayOnNextRealFrame,
-                                onCompletedMediaCacheCleared = { mediaCacheRevision += 1 },
+                                onCompletedMediaCacheCleared = {
+                                    mediaLibraryIndex.clearCameraCatalogs()
+                                    mediaCacheRevision += 1
+                                },
                                 // The watcher leaves from the session controls, exactly like
                                 // iOS (`model.disconnect()` routes a relay viewer through
                                 // leaveRelay).
@@ -705,6 +708,7 @@ class MainActivity : ComponentActivity() {
                         cameraID = primary?.cameraID ?: "offline-all-cameras",
                         cameraConnected = false,
                         cameraSessionAvailable = false,
+                        cacheRevision = mediaCacheRevision,
                         savedCameraID = primary?.savedCameraID,
                         cameraDisplayName =
                             when {
@@ -934,7 +938,10 @@ class MainActivity : ComponentActivity() {
                                 liveViewGuideController = liveViewGuide,
                                 onShowGuideOnNextRealFrame =
                                     liveViewGuide::replayOnNextRealFrame,
-                                onCompletedMediaCacheCleared = { mediaCacheRevision += 1 },
+                                onCompletedMediaCacheCleared = {
+                                    mediaLibraryIndex.clearCameraCatalogs()
+                                    mediaCacheRevision += 1
+                                },
                                 onClose = { standaloneSettingsPresented = false },
                             )
                         }
@@ -1310,6 +1317,10 @@ class MainActivity : ComponentActivity() {
                                             liveViewGuide.replayOnNextRealFrame()
                                             overlay = MonitorOverlay.NONE
                                         },
+                                        onCompletedMediaCacheCleared = {
+                                            mediaLibraryIndex.clearCameraCatalogs()
+                                            mediaCacheRevision += 1
+                                        },
                                         onClose = { overlay = MonitorOverlay.NONE },
                                     )
                                 MonitorOverlay.MEDIA ->
@@ -1317,6 +1328,7 @@ class MainActivity : ComponentActivity() {
                                         cameraID = cameraID,
                                         cameraConnected =
                                             currentSessionState is CameraSessionState.Connected,
+                                        cacheRevision = mediaCacheRevision,
                                         savedCameraID = activeSavedCamera?.id,
                                         cameraDisplayName = activeSavedCamera?.displayTitle,
                                         cameraStorageSlots = currentCameraProperties.storageSlots,

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaBrowseScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaBrowseScreen.kt
@@ -79,6 +79,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -473,6 +474,8 @@ internal fun MediaBrowseScreen(
     selectedLut: FeedLutSelection,
     autoPlayFirstProxy: Boolean = false,
     galleryFailureInjection: MediaGalleryFailureInjection = MediaGalleryFailureInjection.NONE,
+    /** Bumped when Settings clears the camera media cache so an open gallery reloads. */
+    cacheRevision: Int = 0,
     /** Records a closed rating-write breadcrumb (attempted / confirmed / refused). */
     onRatingDiagnostic: (AndroidDiagnosticEvent) -> Unit = {},
     onClose: () -> Unit,
@@ -637,6 +640,7 @@ internal fun MediaBrowseScreen(
         librarySource,
         effectiveCameraConnected,
         reloadKey,
+        cacheRevision,
         pendingDeletion != null,
     ) {
         // A deletion owns the camera between the cancelled old listing and the
@@ -1414,6 +1418,11 @@ internal fun MediaBrowseScreen(
             // bottom; portrait = category strip + bottom density band.
             val showsGridControls =
                 !isSelecting && !shareInProgress && !frameioPreparationInProgress
+            val showRefresh =
+                librarySource == MediaLibrarySource.CAMERA && effectiveCameraConnected
+            val refreshInProgress =
+                state is BrowseState.Loading ||
+                    (state as? BrowseState.Loaded)?.isLoadingMore == true
             if (portrait) {
                 Column(contentModifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     MediaCategoryStrip(
@@ -1445,6 +1454,9 @@ internal fun MediaBrowseScreen(
                         deleteAvailable =
                             librarySource == MediaLibrarySource.CAMERA &&
                                 effectiveCameraConnected,
+                        showRefresh = showRefresh,
+                        refreshInProgress = refreshInProgress,
+                        onRefresh = { reloadKey += 1 },
                         onExitSelection = ::cancelActiveShareOrExitSelection,
                         onDelete = { deleteConfirmTargets = selectedSeriesClips },
                         onShare = {
@@ -1540,6 +1552,9 @@ internal fun MediaBrowseScreen(
                             deleteAvailable =
                                 librarySource == MediaLibrarySource.CAMERA &&
                                     effectiveCameraConnected,
+                            showRefresh = showRefresh,
+                            refreshInProgress = refreshInProgress,
+                            onRefresh = { reloadKey += 1 },
                             onExitSelection = ::cancelActiveShareOrExitSelection,
                             onDelete = { deleteConfirmTargets = selectedSeriesClips },
                             onShare = { presentNativeDelivery() },
@@ -2161,6 +2176,9 @@ private fun MediaLibraryHeader(
     sortOrder: MediaLibrarySortOrder,
     activeFilterCount: Int,
     deleteAvailable: Boolean,
+    showRefresh: Boolean,
+    refreshInProgress: Boolean,
+    onRefresh: () -> Unit,
     onExitSelection: () -> Unit,
     onDelete: () -> Unit,
     onShare: () -> Unit,
@@ -2189,6 +2207,9 @@ private fun MediaLibraryHeader(
     ) {
         Box(Modifier.weight(1f)) {
             MediaHeaderIdentity(state, category, displayedCount)
+        }
+        if (showRefresh) {
+            RefreshControl(enabled = !refreshInProgress, onClick = onRefresh)
         }
         FilterControl(activeCount = activeFilterCount, onClick = onShowFilters)
         SortControl(sortOrder = sortOrder, onSelect = onSortChange)
@@ -2474,6 +2495,30 @@ private fun LayoutControl(layout: MediaLibraryLayout, onToggle: (MediaLibraryLay
         Text(
             if (layout == MediaLibraryLayout.GRID) "☷" else "▦",
             style = chromeStyle(18f, FontWeight.Medium),
+            color = LiveDesign.muted,
+        )
+    }
+}
+
+/** iOS gallery REFRESH — an on-demand authoritative re-enumeration. */
+@Composable
+private fun RefreshControl(enabled: Boolean, onClick: () -> Unit) {
+    val description = stringResource(R.string.media_refresh_cd)
+    Row(
+        Modifier.glass(CapsuleShape)
+            .alpha(if (enabled) 1f else 0.5f)
+            .semantics {
+                contentDescription = description
+                role = Role.Button
+                if (!enabled) disabled()
+            }
+            .chromeClickable(enabled = enabled, onClick = onClick)
+            .padding(horizontal = 10.dp, vertical = 9.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            stringResource(R.string.media_refresh),
+            style = chromeStyle(10f, FontWeight.Bold, mono = true),
             color = LiveDesign.muted,
         )
     }

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaLibraryState.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/media/MediaLibraryState.kt
@@ -269,6 +269,7 @@ internal class MediaLibraryIndex(private val preferences: MediaLibraryPreference
                             indexKey(cameraID),
                             MediaLibraryRecordCodec.encode(reconciled),
                         )
+                        rememberIndexedCameraLocked(cameraID)
                     }
                     reconciled
                 }
@@ -293,6 +294,20 @@ internal class MediaLibraryIndex(private val preferences: MediaLibraryPreference
     /** Returns only records previously received from the shared-core listing wire. */
     fun persistedClips(cameraID: String): List<MediaClipRecord> =
         synchronized(persistenceLock) { persistedClipsLocked(cameraID) }
+
+    /**
+     * Drops every camera catalog the Settings cache-clear must not leave behind.
+     * Favorites stay — they are a separate store — so a shot still on the card
+     * can remain favorited after the next authoritative listing.
+     */
+    fun clearCameraCatalogs() {
+        synchronized(persistenceLock) {
+            indexedCameraIDsLocked().forEach { cameraID ->
+                preferences.putString(indexKey(cameraID), null)
+            }
+            preferences.putString(INDEXED_CAMERAS_KEY, null)
+        }
+    }
 
     /**
      * Drops one deliberately deleted clip's index row and favorite (iOS
@@ -431,6 +446,25 @@ internal class MediaLibraryIndex(private val preferences: MediaLibraryPreference
 
     private fun favoritesKey(cameraID: String): String = "favorites.${digest(cameraID)}"
 
+    private fun rememberIndexedCameraLocked(cameraID: String) {
+        val ids = indexedCameraIDsLocked()
+        if (cameraID in ids) return
+        preferences.putString(
+            INDEXED_CAMERAS_KEY,
+            (ids + cameraID).sorted().joinToString(separator = "\n"),
+        )
+    }
+
+    private fun indexedCameraIDsLocked(): Set<String> {
+        val recorded =
+            preferences.getString(INDEXED_CAMERAS_KEY)
+                ?.lineSequence()
+                ?.filter { it.isNotBlank() }
+                ?.toSet()
+                .orEmpty()
+        return recorded + registeredCameraBuckets().map { it.cameraID }
+    }
+
     private fun registeredCameraBuckets(): List<MediaLibraryCameraBucket> =
         preferences.getString(CAMERA_BUCKETS_KEY)
             ?.let(MediaLibraryCameraBucketCodec::decode)
@@ -438,6 +472,7 @@ internal class MediaLibraryIndex(private val preferences: MediaLibraryPreference
 
     private companion object {
         const val CAMERA_BUCKETS_KEY = "camera-buckets"
+        const val INDEXED_CAMERAS_KEY = "indexed-cameras"
         const val PREF_SOURCE = "view.source"
         const val PREF_CATEGORY = "view.category"
         const val PREF_LAYOUT = "view.layout"

--- a/Apps/Android/app/src/main/res/values/strings.xml
+++ b/Apps/Android/app/src/main/res/values/strings.xml
@@ -1135,7 +1135,9 @@
     <string name="help_sharing_camera_control">Take the camera back. This device holds the link, so it never has to ask.</string>
     <string name="help_storage_frameio">Sign in once here and the share sheet\'s Frame.io option unlocks everywhere. On the camera\'s Wi-Fi, Sign in over internet hops to another Wi-Fi network or cellular, signs in, then reconnects the camera. Logging out removes the stored sign-in and remembered project.</string>
     <string name="help_storage_cache">Clips and thumbnails cached from the camera for offline playback and sharing, across all paired cameras.</string>
-    <string name="help_storage_clear_cache">Removes completed cached clip files and thumbnails for every camera. Transfers still running are kept so they can resume, and favorites, upload history and camera indexes survive — clips re-cache from the camera on demand.</string>
+    <string name="help_storage_clear_cache">Removes completed cached clip files, thumbnails, and camera indexes for every camera. Transfers still running are kept so they can resume. Favorites survive; the gallery reloads from the camera when connected.</string>
+    <string name="media_refresh">REFRESH</string>
+    <string name="media_refresh_cd">Refresh camera media</string>
 
     <!-- Consented camera-AP internet hop from Operator Setup (iOS SettingsInternetDestination). -->
     <string name="settings_report_hop_title">Leave camera Wi-Fi?</string>

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/media/MediaLibraryStateTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/media/MediaLibraryStateTest.kt
@@ -295,7 +295,8 @@ class MediaLibraryStateTest {
         }
         checkpoint.commit()
 
-        assertEquals(1, preferences.writeCount)
+        // One catalog encode plus the first-time indexed-cameras registry write.
+        assertEquals(2, preferences.writeCount)
         assertEquals(1_280, index.persistedClips("camera").size)
     }
 
@@ -319,6 +320,46 @@ class MediaLibraryStateTest {
             listOf(stillOnCard.handle, deletedButDownloaded.handle),
             index.persistedClips("camera").map { it.handle }.sorted(),
         )
+    }
+
+    @Test
+    fun `a complete pass replaces a reused PTP handle with the new identity`() {
+        val index = MediaLibraryIndex(MemoryPreferences())
+        val stale =
+            clip(
+                handle = 1,
+                filename = "OLD.JPG",
+                kind = MediaContentKind.STILL_PHOTO,
+                captureDate = "20260101T120000",
+            )
+        val fresh =
+            clip(
+                handle = 1,
+                filename = "NEW.JPG",
+                kind = MediaContentKind.STILL_PHOTO,
+                captureDate = "20260818T090000",
+            )
+        index.rememberCameraListing("camera", listOf(stale))
+
+        index.beginCameraListing("camera").apply {
+            applyPage(listOf(fresh), emptyList())
+            commit(prunesUnlistedClips = true)
+        }
+
+        assertEquals(listOf("NEW.JPG"), index.persistedClips("camera").map { it.filename })
+    }
+
+    @Test
+    fun `cache clear drops camera catalogs and keeps favorites`() {
+        val index = MediaLibraryIndex(MemoryPreferences())
+        val clip = clip(handle = 4, filename = "C0001.MOV")
+        index.rememberCameraListing("serial-a", listOf(clip))
+        index.setFavorite("serial-a", clip, favorite = true)
+
+        index.clearCameraCatalogs()
+
+        assertTrue(index.persistedClips("serial-a").isEmpty())
+        assertEquals(setOf(clip.libraryKey("serial-a")), index.favoriteIDs("serial-a"))
     }
 
     @Test

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,3 +1,4 @@
+- New: Media has REFRESH. After a format it follows the card, not old names; Clear Cache reloads Media from the camera.
 - Fixed: Share and Save to Photos work on clips from the camera.
 - Fixed: Share in playback is available while the camera is still connected.
 - New: Settings > Controls has Auto-Rotate Feed. Turn it off if you want the picture to stay put when the camera is on its side.

--- a/Sources/OpenZCineCore/MediaClipDiscoveryDelta.swift
+++ b/Sources/OpenZCineCore/MediaClipDiscoveryDelta.swift
@@ -13,23 +13,63 @@ public struct MediaObjectHandle: Hashable, Sendable, Equatable, Codable {
     }
 }
 
+/// Camera-reported object identity used to detect PTP handle reuse after a card
+/// format or generation change. Handle values are recycled; filename + capture
+/// date name the actual file.
+public struct MediaClipObjectIdentity: Hashable, Sendable, Equatable {
+    public let location: MediaObjectHandle
+    public let filename: String
+    public let captureDate: String
+    public let sizeBytes: UInt64
+
+    public init(
+        location: MediaObjectHandle,
+        filename: String,
+        captureDate: String,
+        sizeBytes: UInt64
+    ) {
+        self.location = location
+        self.filename = filename
+        self.captureDate = captureDate
+        self.sizeBytes = sizeBytes
+    }
+
+    /// True when this cached identity still names the same camera object.
+    /// A zero or PTP UINT32-sentinel size is unknown and does not count as a mismatch.
+    public func matchesCameraObject(_ camera: MediaClipObjectIdentity) -> Bool {
+        guard filename == camera.filename, captureDate == camera.captureDate else { return false }
+        if !hasKnownSize || !camera.hasKnownSize { return true }
+        return sizeBytes == camera.sizeBytes
+    }
+
+    private var hasKnownSize: Bool {
+        sizeBytes > 0 && sizeBytes != 0xFFFF_FFFF
+    }
+}
+
 /// Result of comparing a cached library index with the camera's current handle set.
 public struct MediaClipDiscoveryDelta: Sendable, Equatable {
-    /// Locations present on both camera and cache — `GetObjectInfo` can be skipped.
+    /// Locations present on both camera and cache — `GetObjectInfo` can be skipped
+    /// only after identity verification confirms the object did not change.
     public let reuseHandles: Set<MediaObjectHandle>
     /// Locations on camera but absent from cache — require `GetObjectInfo`.
     public let fetchHandles: Set<MediaObjectHandle>
     /// Locations in cache but no longer on camera — evict or clear references.
     public let removedHandles: Set<MediaObjectHandle>
+    /// Cached locations the camera still reports whose object identity changed
+    /// (format / handle recycle). Drop the old row, then fetch the new object.
+    public let supersededHandles: Set<MediaObjectHandle>
 
     public init(
         reuseHandles: Set<MediaObjectHandle>,
         fetchHandles: Set<MediaObjectHandle>,
-        removedHandles: Set<MediaObjectHandle>
+        removedHandles: Set<MediaObjectHandle>,
+        supersededHandles: Set<MediaObjectHandle> = []
     ) {
         self.reuseHandles = reuseHandles
         self.fetchHandles = fetchHandles
         self.removedHandles = removedHandles
+        self.supersededHandles = supersededHandles
     }
 
     /// Plans incremental discovery: reuse cached metadata for stable locations, fetch only new
@@ -43,6 +83,51 @@ public struct MediaClipDiscoveryDelta: Sendable, Equatable {
             reuseHandles: cachedHandles.intersection(cameraSet),
             fetchHandles: cameraSet.subtracting(cachedHandles),
             removedHandles: cachedHandles.subtracting(cameraSet)
+        )
+    }
+
+    /// Spread of reused handles to `GetObjectInfo` for identity checks. Newest first
+    /// so a formatted card that recycled low handles is still sampled at both ends.
+    public func identityProbeHandles(budget: Int) -> [MediaObjectHandle] {
+        guard budget > 0 else { return [] }
+        let reused = reuseHandles.sorted {
+            if $0.storageID != $1.storageID { return $0.storageID < $1.storageID }
+            return $0.handle > $1.handle
+        }
+        if reused.count <= budget { return reused }
+        if budget == 1 { return [reused[0]] }
+        var selected: [MediaObjectHandle] = []
+        selected.reserveCapacity(budget)
+        for step in 0..<budget {
+            let index = step * (reused.count - 1) / (budget - 1)
+            let handle = reused[index]
+            if selected.last != handle { selected.append(handle) }
+        }
+        return selected
+    }
+
+    /// Splits reuse vs superseded using probed camera objects. A mismatch on one
+    /// handle invalidates every reused handle on that storage — after a format the
+    /// whole card's handles are recycled, and sampling one is enough to know.
+    public func verifyingReusedIdentities(
+        cached: [MediaObjectHandle: MediaClipObjectIdentity],
+        probed: [MediaObjectHandle: MediaClipObjectIdentity]
+    ) -> MediaClipDiscoveryDelta {
+        var dirtyStorages = Set<UInt32>()
+        for (location, cameraObject) in probed {
+            guard reuseHandles.contains(location) else { continue }
+            if let cachedObject = cached[location], cachedObject.matchesCameraObject(cameraObject) {
+                continue
+            }
+            dirtyStorages.insert(location.storageID)
+        }
+        guard !dirtyStorages.isEmpty else { return self }
+        let superseded = Set(reuseHandles.filter { dirtyStorages.contains($0.storageID) })
+        return MediaClipDiscoveryDelta(
+            reuseHandles: reuseHandles.subtracting(superseded),
+            fetchHandles: fetchHandles.union(superseded),
+            removedHandles: removedHandles,
+            supersededHandles: supersededHandles.union(superseded)
         )
     }
 }

--- a/Tests/OpenZCineCoreTests/MediaClipDiscoveryDeltaTests.swift
+++ b/Tests/OpenZCineCoreTests/MediaClipDiscoveryDeltaTests.swift
@@ -64,4 +64,123 @@ import Testing
     #expect(delta.reuseHandles == [MediaObjectHandle(storageID: 0x0001_0001, handle: 7)])
     #expect(delta.fetchHandles == [MediaObjectHandle(storageID: 0x0002_0001, handle: 7)])
     #expect(delta.removedHandles.isEmpty)
+    #expect(delta.supersededHandles.isEmpty)
+}
+
+/// After a card format Nikon recycles PTP handles. Matching handles with a different
+/// filename/date are a new generation — reuse would keep the old names and hide the new files.
+@Test func discoveryDeltaInvalidatesAStorageWhenAReusedHandleChangesIdentity() {
+    let slot: UInt32 = 0x0001_0001
+    let oldTen = MediaObjectHandle(storageID: slot, handle: 10)
+    let oldTwenty = MediaObjectHandle(storageID: slot, handle: 20)
+    let delta = MediaClipDiscoveryDelta.compute(
+        cachedHandles: [oldTen, oldTwenty],
+        cameraHandles: [oldTen, oldTwenty]
+    )
+    #expect(delta.reuseHandles == [oldTen, oldTwenty])
+
+    let verified = delta.verifyingReusedIdentities(
+        cached: [
+            oldTen: MediaClipObjectIdentity(
+                location: oldTen, filename: "DSC_0001.JPG", captureDate: "20260101T120000",
+                sizeBytes: 1_000),
+            oldTwenty: MediaClipObjectIdentity(
+                location: oldTwenty, filename: "DSC_0002.JPG", captureDate: "20260101T120100",
+                sizeBytes: 2_000),
+        ],
+        probed: [
+            oldTen: MediaClipObjectIdentity(
+                location: oldTen, filename: "DSC_0100.JPG", captureDate: "20260818T090000",
+                sizeBytes: 3_000)
+        ]
+    )
+
+    #expect(verified.reuseHandles.isEmpty)
+    #expect(verified.fetchHandles == [oldTen, oldTwenty])
+    #expect(verified.supersededHandles == [oldTen, oldTwenty])
+    #expect(verified.removedHandles.isEmpty)
+}
+
+@Test func discoveryDeltaKeepsMatchingIdentitiesAsReuse() {
+    let location = MediaObjectHandle(storageID: 1, handle: 5)
+    let identity = MediaClipObjectIdentity(
+        location: location, filename: "C0001.MOV", captureDate: "20260713T101010",
+        sizeBytes: 4_000)
+    let delta = MediaClipDiscoveryDelta.compute(
+        cachedHandles: [location], cameraHandles: [location])
+    let verified = delta.verifyingReusedIdentities(
+        cached: [location: identity], probed: [location: identity])
+    #expect(verified.reuseHandles == [location])
+    #expect(verified.fetchHandles.isEmpty)
+    #expect(verified.supersededHandles.isEmpty)
+}
+
+@Test func discoveryDeltaUnknownSizeDoesNotInvalidateAMatchingNameAndDate() {
+    let location = MediaObjectHandle(storageID: 1, handle: 9)
+    let cached = MediaClipObjectIdentity(
+        location: location, filename: "C0001.MOV", captureDate: "20260713T101010",
+        sizeBytes: 8_000)
+    let probed = MediaClipObjectIdentity(
+        location: location, filename: "C0001.MOV", captureDate: "20260713T101010",
+        sizeBytes: 0)
+    let delta = MediaClipDiscoveryDelta.compute(
+        cachedHandles: [location], cameraHandles: [location])
+    let verified = delta.verifyingReusedIdentities(
+        cached: [location: cached], probed: [location: probed])
+    #expect(verified.reuseHandles == [location])
+    #expect(verified.supersededHandles.isEmpty)
+}
+
+/// A mismatch on slot 1 must not force GetObjectInfo on an untouched slot 2.
+@Test func discoveryDeltaHandleReuseInvalidationStaysOnTheDirtyCard() {
+    let slot1 = MediaObjectHandle(storageID: 0x0001_0001, handle: 7)
+    let slot2 = MediaObjectHandle(storageID: 0x0002_0001, handle: 7)
+    let delta = MediaClipDiscoveryDelta.compute(
+        cachedHandles: [slot1, slot2], cameraHandles: [slot1, slot2])
+    let verified = delta.verifyingReusedIdentities(
+        cached: [
+            slot1: MediaClipObjectIdentity(
+                location: slot1, filename: "A.JPG", captureDate: "20260101T000000", sizeBytes: 1),
+            slot2: MediaClipObjectIdentity(
+                location: slot2, filename: "B.JPG", captureDate: "20260101T000000", sizeBytes: 1),
+        ],
+        probed: [
+            slot1: MediaClipObjectIdentity(
+                location: slot1, filename: "C.JPG", captureDate: "20260818T000000", sizeBytes: 2)
+        ]
+    )
+    #expect(verified.supersededHandles == [slot1])
+    #expect(verified.reuseHandles == [slot2])
+    #expect(verified.fetchHandles == [slot1])
+}
+
+@Test func discoveryDeltaUnprobedReuseStaysReuse() {
+    let kept = MediaObjectHandle(storageID: 1, handle: 1)
+    let delta = MediaClipDiscoveryDelta.compute(
+        cachedHandles: [kept], cameraHandles: [kept])
+    let verified = delta.verifyingReusedIdentities(cached: [:], probed: [:])
+    #expect(verified == delta)
+}
+
+@Test func discoveryDeltaProbeSpreadHitsNewestOldestAndMiddle() {
+    let slot: UInt32 = 1
+    let handles = (1...10).map { MediaObjectHandle(storageID: slot, handle: UInt32($0)) }
+    let delta = MediaClipDiscoveryDelta.compute(
+        cachedHandles: Set(handles), cameraHandles: handles)
+    let probed = delta.identityProbeHandles(budget: 4)
+    #expect(probed.count == 4)
+    #expect(probed.first == MediaObjectHandle(storageID: slot, handle: 10))
+    #expect(probed.last == MediaObjectHandle(storageID: slot, handle: 1))
+    #expect(Set(probed).isSubset(of: Set(handles)))
+}
+
+@Test func discoveryDeltaProbeBudgetCoversEveryReusedHandleWhenSmall() {
+    let handles = [
+        MediaObjectHandle(storageID: 1, handle: 3),
+        MediaObjectHandle(storageID: 1, handle: 1),
+    ]
+    let delta = MediaClipDiscoveryDelta.compute(
+        cachedHandles: Set(handles), cameraHandles: handles)
+    #expect(Set(delta.identityProbeHandles(budget: 8)) == Set(handles))
+    #expect(delta.identityProbeHandles(budget: 0).isEmpty)
 }

--- a/ios/Runner/MediaBrowser.swift
+++ b/ios/Runner/MediaBrowser.swift
@@ -928,10 +928,10 @@ struct MediaBrowserView: View {
 
     /// Authoritative re-enumeration on demand (#296): the camera's inventory is the truth, and
     /// after a card format the operator wants a way to say "ask it again" without reconnecting.
-    /// The pass it schedules already reconciles removals and cannot duplicate (delta-keyed).
+    /// Refresh probes reused PTP handles so a recycled generation cannot keep stale filenames.
     private var refreshButton: some View {
         Button {
-            model.scheduleFetchClipsFromCamera()
+            model.refreshCameraMediaInventory()
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: "arrow.clockwise")

--- a/ios/Runner/MonitorPanels.swift
+++ b/ios/Runner/MonitorPanels.swift
@@ -4921,7 +4921,7 @@ struct OperatorSettingsPanel: View {
             SettingsInlineRow(
                 title: "Clear Cache",
                 help:
-                    "Removes cached clip files and thumbnails for every camera. Favorites, upload history, and camera indexes survive — clips re-cache from the camera on demand."
+                    "Removes cached clip files, thumbnails, and camera indexes for every camera. The on-device library is left intact. Connected, the gallery reloads from the camera; favorites of remote-only shots are rebuilt only if those shots are still on the card."
             ) {
                 Button {
                     model.clearAllMediaCaches()

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -2288,7 +2288,10 @@ final class NativeAppModel {
     /// `fetchThumbnail` so a body that serves garbage for a clip isn't re-queried every scroll.
     @ObservationIgnored private var thumblessClipIDs: Set<String> = []
     @ObservationIgnored private var mediaFetchTask: Task<Void, Never>?
-    /// Bumped per listing pass so a cancelled pass finishing late can't clear a successor's state.
+    /// Debounced re-list while the gallery is open and the body is still writing objects.
+    @ObservationIgnored private var galleryRelistTask: Task<Void, Never>?
+    /// Bumped per listing pass so a cancelled pass finishing late can't clear a successor's state
+    /// or write an older snapshot into a cleared index.
     @ObservationIgnored private var mediaFetchGeneration = 0
     /// Tab the last listing pass that ran to completion (not cancelled) was scoped to, nil when
     /// none has. Lets the tab `didSet` skip redundant re-lists; cleared whenever a fresh pass is
@@ -6467,6 +6470,8 @@ final class NativeAppModel {
         cancelClipStream()
         mediaFetchTask?.cancel()
         mediaFetchTask = nil
+        galleryRelistTask?.cancel()
+        galleryRelistTask = nil
         mediaFetchCompletedTab = nil
         cancelThumbnailWork(resumingWaiters: true)
         resetLinkHealthMeasurements()
@@ -7240,6 +7245,9 @@ final class NativeAppModel {
         // The card object set changed — the next media pass must re-list (a backup twin fires
         // no event of its own).
         mediaFetchCompletedTab = nil
+        if isStandaloneMediaLibraryPresented, mediaBrowserSource == .camera {
+            scheduleDebouncedGalleryRelist()
+        }
         guard !isStillCapturing, !pendingStillCapture,
             StillCapturePolicy.prefersPhotographyChrome(
                 selector: cameraPropertySnapshot.captureSelector)
@@ -13661,14 +13669,39 @@ extension NativeAppModel {
     }
 
     /// Cancels any in-flight listing pass and starts a fresh camera discovery.
-    func scheduleFetchClipsFromCamera() {
+    /// `identityProbeBudget` caps how many reused handles are `GetObjectInfo`'d to
+    /// catch a formatted card that recycled PTP handles (#296).
+    func scheduleFetchClipsFromCamera(identityProbeBudget: Int = 8) {
         mediaFetchTask?.cancel()
         // Coverage re-arms only when the new pass runs to completion — until then a tab
         // switch must fall back to scheduling (see `mediaCategoryTab.didSet`).
         mediaFetchCompletedTab = nil
         mediaFetchGeneration += 1
         let generation = mediaFetchGeneration
-        mediaFetchTask = Task { await fetchClipsFromCamera(generation: generation) }
+        mediaFetchTask = Task {
+            await fetchClipsFromCamera(
+                generation: generation, identityProbeBudget: identityProbeBudget)
+        }
+    }
+
+    /// Operator Refresh: probe every reused handle so a recycled PTP generation cannot
+    /// keep stale filenames. Automatic listing uses the smaller default budget.
+    func refreshCameraMediaInventory() {
+        scheduleFetchClipsFromCamera(identityProbeBudget: Int.max)
+    }
+
+    /// Coalesces ObjectAdded bursts while the gallery is open into one listing pass.
+    private func scheduleDebouncedGalleryRelist() {
+        galleryRelistTask?.cancel()
+        galleryRelistTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(800))
+            guard !Task.isCancelled, isStandaloneMediaLibraryPresented else { return }
+            scheduleFetchClipsFromCamera()
+        }
+    }
+
+    private func mediaFetchIsCurrent(_ generation: Int) -> Bool {
+        mediaFetchGeneration == generation && !Task.isCancelled
     }
 
     /// Total cached clip bytes across every camera bucket on disk (Settings → Storage readout).
@@ -13678,15 +13711,22 @@ extension NativeAppModel {
         }
     }
 
-    /// Clears cached clip files and thumbnails for EVERY bucket (Settings → Storage), preserving
-    /// each bucket's `index.json` (favorites, handles, upload flags) for re-fetch.
+    /// Clears cached clip files and thumbnails for every camera bucket (Settings → Storage).
+    /// Camera indexes are cache — preserving them after a format is what left thumbnail-less
+    /// ghosts in the gallery (#296). The on-device `local` library is left intact.
     func clearAllMediaCaches() {
         cancelClipStream()
+        mediaFetchTask?.cancel()
+        mediaFetchGeneration += 1
+        mediaFetchCompletedTab = nil
         mediaDownloadProgress.removeAll()
-        for bucket in mediaClipStore.allBucketIDs() {
-            mediaClipStore.clearCache(cameraID: bucket)
+        for bucket in mediaClipStore.allBucketIDs() where bucket != MediaClipStore.localBucketID {
+            mediaClipStore.clearCache(cameraID: bucket, preservingIndex: false)
         }
         refreshMediaClips()
+        if mediaBrowserSource == .camera, cameraSession != nil {
+            scheduleFetchClipsFromCamera(identityProbeBudget: Int.max)
+        }
     }
 
     /// Clears on-disk clip cache for the active Media browser source bucket. Cancels any in-flight
@@ -13709,7 +13749,7 @@ extension NativeAppModel {
         refreshMediaClips()
         // Connected and looking at the camera → rebuild authoritatively right away.
         if clearingCameraBucket, cameraSession != nil {
-            scheduleFetchClipsFromCamera()
+            scheduleFetchClipsFromCamera(identityProbeBudget: Int.max)
         }
     }
 
@@ -13737,7 +13777,7 @@ extension NativeAppModel {
     /// unchanged handles skip `GetObjectInfo`; discovers in batches so the grid updates
     /// incrementally without blocking the main thread. Thumbnails fetch on demand when cells
     /// appear. Safe no-op with no session. [ZR · verify-on-HW]
-    private func fetchClipsFromCamera(generation: Int) async {
+    private func fetchClipsFromCamera(generation: Int, identityProbeBudget: Int) async {
         guard let session = cameraSession else { return }
         mediaFetchInProgress = true
         mediaFetchListedCount = 0
@@ -13766,36 +13806,49 @@ extension NativeAppModel {
         let cachedLocationSet = Set(cachedByLocation.keys)
 
         let listedHandles = await session.listMediaObjectHandles()
-        if Task.isCancelled { return }
+        guard mediaFetchIsCurrent(generation) else { return }
 
         // Removal detection always runs against the FULL listing — a scoped pass must never
         // read "absent from my category" as "deleted from the card".
-        let delta = MediaClipDiscoveryDelta.compute(
+        var delta = MediaClipDiscoveryDelta.compute(
             cachedHandles: cachedLocationSet,
             cameraHandles: listedHandles
         )
+        delta = await verifyReusedIdentities(
+            delta,
+            cachedByLocation: cachedByLocation,
+            session: session,
+            budget: identityProbeBudget,
+            generation: generation
+        )
+        guard mediaFetchIsCurrent(generation) else { return }
 
         // The pass itself is scoped to the active sidebar category: Videos fetches only videos,
         // Photos only stills. Other categories' metadata is NOT enumerated here — each tab runs
         // its own delta pass on selection (mediaCategoryTab.didSet).
+        // Superseded handles no longer name the cached file — drop them from the tab cache so
+        // they are treated as unknown and fetched, not skipped as the old type.
+        var scopedCache = cachedByLocation
+        for location in delta.supersededHandles { scopedCache.removeValue(forKey: location) }
         let cameraHandles = await scopedHandles(
             listedHandles,
             for: mediaCategoryTab,
-            cachedByLocation: cachedByLocation,
+            cachedByLocation: scopedCache,
             session: session
         )
-        if Task.isCancelled { return }
+        guard mediaFetchIsCurrent(generation) else { return }
 
-        if !delta.removedHandles.isEmpty {
+        let staleHandles = delta.removedHandles.union(delta.supersededHandles)
+        if !staleHandles.isEmpty {
             let removedFilenames = mediaClipStore.applyCameraRemoval(
                 cameraID: bucket,
-                removedHandles: delta.removedHandles,
+                removedHandles: staleHandles,
                 hasLocalFile: { isClipDownloaded($0) }
             )
             if mediaBrowserSource == .camera, bucket == mediaBucketID {
                 applyRemovedClipsToMemory(
                     removedFilenames: removedFilenames,
-                    clearedLocations: delta.removedHandles
+                    clearedLocations: staleHandles
                 )
             }
         }
@@ -13809,6 +13862,7 @@ extension NativeAppModel {
         var lastFlush = ContinuousClock.now
 
         func flushPendingBatch(force: Bool = false) {
+            guard mediaFetchIsCurrent(generation) else { return }
             guard force || !pendingBatch.isEmpty else { return }
             let shouldFlush =
                 force
@@ -13839,7 +13893,7 @@ extension NativeAppModel {
         }
         var learnedOffTab = 0
         for objectHandle in cameraHandles {
-            if Task.isCancelled { break }
+            if !mediaFetchIsCurrent(generation) { break }
 
             let record: MediaClip
             if delta.reuseHandles.contains(objectHandle),
@@ -13875,7 +13929,7 @@ extension NativeAppModel {
 
         flushPendingBatch(force: true)
         mediaLibraryLogger.info(
-            "delta sync listed \(listedCount, privacy: .public) clip(s) on this tab — card objects: \(delta.reuseHandles.count, privacy: .public) reused, \(delta.fetchHandles.count, privacy: .public) fetched (\(learnedOffTab, privacy: .public) learned off-tab), \(delta.removedHandles.count, privacy: .public) removed"
+            "delta sync listed \(listedCount, privacy: .public) clip(s) on this tab — card objects: \(delta.reuseHandles.count, privacy: .public) reused, \(delta.fetchHandles.count, privacy: .public) fetched (\(learnedOffTab, privacy: .public) learned off-tab), \(delta.removedHandles.count, privacy: .public) removed, \(delta.supersededHandles.count, privacy: .public) superseded"
         )
 
         /// R3D masters in this bucket with no same-stem playable proxy, plus the proxy census.
@@ -13897,16 +13951,17 @@ extension NativeAppModel {
         // flat listing dropping them is exactly the symptom this fallback covers.
         var (unpairedMasters, proxyCount) = unpairedR3DMasters()
         var fallbackProxyCount = 0
-        if !unpairedMasters.isEmpty, !Task.isCancelled,
+        if !unpairedMasters.isEmpty, mediaFetchIsCurrent(generation),
             let videoHandles = try? await session.listMediaObjectHandles(
                 formats: MediaObjectFormats.video)
         {
             let seenThisPass = Set(cameraHandles)
+            let refetchable = delta.removedHandles.union(delta.supersededHandles)
             for objectHandle in videoHandles {
-                if Task.isCancelled { break }
+                if !mediaFetchIsCurrent(generation) { break }
                 guard !seenThisPass.contains(objectHandle),
                     cachedByLocation[objectHandle] == nil
-                        || delta.removedHandles.contains(objectHandle)
+                        || refetchable.contains(objectHandle)
                 else { continue }
                 guard
                     let camera = await session.fetchMediaClip(
@@ -13938,9 +13993,56 @@ extension NativeAppModel {
 
         // Arm the tab-switch skip only for a pass that ran to the end — a cancelled pass may
         // have left this tab's handles unfetched.
-        if !Task.isCancelled, mediaFetchGeneration == generation {
+        if mediaFetchIsCurrent(generation) {
             mediaFetchCompletedTab = passTab
         }
+    }
+
+    /// `GetObjectInfo` a spread of reused handles. One filename/date mismatch on a card
+    /// means that card's handles were recycled (format) and cached metadata is a lie.
+    private func verifyReusedIdentities(
+        _ delta: MediaClipDiscoveryDelta,
+        cachedByLocation: [MediaObjectHandle: MediaClip],
+        session: NativeCameraSession,
+        budget: Int,
+        generation: Int
+    ) async -> MediaClipDiscoveryDelta {
+        guard !delta.reuseHandles.isEmpty, budget > 0 else { return delta }
+        var cachedIdentities: [MediaObjectHandle: MediaClipObjectIdentity] = [:]
+        cachedIdentities.reserveCapacity(cachedByLocation.count)
+        for (location, clip) in cachedByLocation {
+            cachedIdentities[location] = MediaClipObjectIdentity(
+                location: location,
+                filename: clip.filename,
+                captureDate: clip.captureDate,
+                sizeBytes: clip.sizeBytes
+            )
+        }
+        var probed: [MediaObjectHandle: MediaClipObjectIdentity] = [:]
+        var working = delta
+        for location in delta.identityProbeHandles(budget: budget) {
+            guard mediaFetchIsCurrent(generation) else { return working }
+            guard working.reuseHandles.contains(location) else { continue }
+            let identity: MediaClipObjectIdentity
+            if let camera = await session.fetchMediaClip(
+                handle: location.handle, storageID: location.storageID),
+                let filename = MediaClipFilename.safeCameraBasename(camera.info.filename)
+            {
+                identity = MediaClipObjectIdentity(
+                    location: location,
+                    filename: filename,
+                    captureDate: camera.info.captureDate,
+                    sizeBytes: UInt64(camera.info.compressedSize)
+                )
+            } else {
+                identity = MediaClipObjectIdentity(
+                    location: location, filename: "", captureDate: "", sizeBytes: 0)
+            }
+            probed[location] = identity
+            working = working.verifyingReusedIdentities(
+                cached: cachedIdentities, probed: probed)
+        }
+        return working
     }
 
     /// The handles a listing pass should process for the active sidebar category, newest first.

--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -1229,6 +1229,84 @@ extension RunnerTests {
         XCTAssertEqual(Set(sorted.suffix(2)), ["A.JPG", "D.JPG"])
     }
 
+    /// A formatted card recycles PTP handles. Removal of those handles must drop the
+    /// remote-only old filename so the next fetch can install the new object.
+    func testApplyCameraRemovalDropsRemoteOnlyRowWhenHandleIsSuperseded() {
+        let root = mediaRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = MediaClipStore(root: root)
+        var clip = mediaClip("DSC_0001.JPG")
+        clip.handle = 10
+        clip.storageID = 0x0001_0001
+        store.upsertBatch([clip], cameraID: "cam")
+
+        let removed = store.applyCameraRemoval(
+            cameraID: "cam",
+            removedHandles: [MediaObjectHandle(storageID: 0x0001_0001, handle: 10)],
+            hasLocalFile: { _ in false }
+        )
+
+        XCTAssertEqual(removed, ["DSC_0001.JPG"])
+        XCTAssertTrue(store.list(cameraID: "cam").isEmpty)
+    }
+
+    /// Intentionally downloaded copies survive a card generation change as local-only rows.
+    func testApplyCameraRemovalKeepsDownloadedCopyWhenHandleLeavesTheCard() throws {
+        let root = mediaRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = MediaClipStore(root: root)
+        var clip = mediaClip("C0001.MOV")
+        clip.handle = 4
+        clip.storageID = 0x0001_0001
+        clip.sizeBytes = 4
+        store.upsertBatch([clip], cameraID: "cam")
+        let url = try store.localURL(cameraID: "cam", filename: "C0001.MOV")
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("clip".utf8).write(to: url)
+
+        let removed = store.applyCameraRemoval(
+            cameraID: "cam",
+            removedHandles: [MediaObjectHandle(storageID: 0x0001_0001, handle: 4)],
+            hasLocalFile: { candidate in
+                store.cachedByteCount(cameraID: candidate.cameraID, filename: candidate.filename)
+                    > 0
+            }
+        )
+
+        XCTAssertTrue(removed.isEmpty)
+        let row = try XCTUnwrap(store.list(cameraID: "cam").first)
+        XCTAssertEqual(row.filename, "C0001.MOV")
+        XCTAssertNil(row.handle)
+        XCTAssertNil(row.storageID)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    /// Camera-bucket cache is not source of truth — clearing it must drop `index.json`.
+    func testClearingCameraCacheDropsTheIndex() {
+        let root = mediaRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = MediaClipStore(root: root)
+        store.upsertBatch([mediaClip("DSC_0001.JPG")], cameraID: "cam")
+
+        store.clearCache(cameraID: "cam", preservingIndex: false)
+
+        XCTAssertTrue(store.list(cameraID: "cam").isEmpty)
+    }
+
+    /// The on-device library has no camera to rebuild from, so its index survives a cache clear.
+    func testClearingLocalCachePreservesTheIndex() {
+        let root = mediaRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let store = MediaClipStore(root: root)
+        store.upsertBatch([mediaClip("IMPORT.MOV")], cameraID: MediaClipStore.localBucketID)
+
+        store.clearCache(cameraID: MediaClipStore.localBucketID, preservingIndex: true)
+
+        XCTAssertEqual(
+            store.list(cameraID: MediaClipStore.localBucketID).map(\.filename), ["IMPORT.MOV"])
+    }
+
     // MARK: - Fused peaking kernel vs the reference filter chain
 
     /// The single-pass CIKL detector must reproduce the filter chain exactly — every constant in

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -9,6 +9,7 @@ New and changed
 
 Fixes
 
+- Format a card and Media used to keep the old clip names. REFRESH now follows the card, and Settings > Clear Cache reloads Media from the card.
 - Share and Save to Photos work on clips from the camera. They used to fail with "Invalid sample cursor".
 - Share on the player is available while the camera is connected. You no longer have to disconnect and go through Operator Setup to reach it.
 - On iPad in photo mode, the battery gauges sit beside the lock instead of covering PLAY.
@@ -16,12 +17,12 @@ Fixes
 - Changing stills focus settings no longer flips the video FOCUS readout or makes taps refocus single-shot on a camera set to full-time AF.
 - A weak or busy link degrades the picture instead of dropping the session, and screen recording while you share your feed no longer walks the watcher's picture behind the action.
 - A watcher granted camera control can now start and stop the take, and keeps that control through a brief drop-out instead of losing it the moment the link stutters.
-- Fixed a crash that could end a live session on some iPads while Feed Noise Reduction was on. Thank you to whoever sent that report — the log had exactly what was needed.
 - Changes made on the camera reach the app quickly again - the aperture ring, ISO or shutter used to take twenty seconds, or in video never.
 - Unplugging the cable or power-cycling the camera used to wedge the app. Both recover on their own, or offer Retry connection.
 
 What to test
 
+- Format a spare card or delete a shot, then tap REFRESH on Media: gone files leave and new ones show. Clear Cache in Settings and reopen Media to rebuild from the card.
 - Connect to the camera, play a clip, tap Share, then Share and Save to Photos. Both should finish. You should not have to disconnect first.
 - Save the same body on two different Wi-Fi networks. Each should stay its own setup with its own Stream Preset and Quality Bias, and renaming one should not touch the other.
 - Turn the camera on its side, then turn Auto-Rotate Feed off in Settings > Controls: the picture should stay put. Turn it back on and the picture should stand up. Then flip the iPhone to the opposite landscape: picture and controls swap sides, nothing under the island.


### PR DESCRIPTION
Fixes #296.

## Why

A TestFlight report on 0.2.5 (build 260) reopened this: after formatting or shooting new media, the iOS gallery kept traces of the previous card and **Refresh / Settings → Clear Cache had no effect**. New photos and videos never appeared.

The August 1 handle-delta fix was incomplete:

1. **Handle reuse.** Nikon recycles PTP object handles after a format. Matching `(storageID, handle)` skipped `GetObjectInfo`, so old filenames stayed and the new files were never indexed. Refresh used the same delta, so it did nothing.
2. **Settings clear preserved indexes.** Per-bucket `clearMediaCache()` dropped a camera `index.json`; Settings → Clear Cache (`clearAllMediaCaches`) still used `preservingIndex: true` and never re-listed.
3. **Generation bump did not gate writes.** A cancelled listing could still upsert its old snapshot into a freshly cleared index.
4. **ObjectAdded while the gallery is open** only cleared a tab-skip flag; it did not schedule a listing pass.

## What changed

**Shared core**
- `MediaClipObjectIdentity` + `MediaClipDiscoveryDelta.verifyingReusedIdentities`: one filename/date mismatch on a card invalidates every reused handle on that storage.
- Probe a spread of reused handles (newest/oldest/middle) so a format is caught without `GetObjectInfo` on every object; operator Refresh probes all of them.

**iOS**
- Listing probes reused identities, treats superseded handles as removals (downloaded copies stay local-only), and ignores stale listing writes from an older generation.
- Settings Clear Cache drops camera indexes (not the on-device library) and re-enumerates when connected.
- Refresh runs a full identity probe. Body captures while the gallery is open debounce a re-list.

**Android**
- Listing already keys identity on `(storage, handle, date, filename)` and prunes unlisted remote-only rows on a complete pass.
- Add a gallery **REFRESH** control (parity with iOS).
- Settings cache clear drops camera catalogs and reloads an open gallery. Favorites stay; a shot still on the card can remain favorited after the next listing.

## Test plan

- [x] `just native-check` (Swift tests, iOS tests, iOS + watch builds)
- [x] `just android-check` (assemble, JVM tests, lint)
- [ ] Hardware: format a card while connected, Refresh, confirm old remote-only rows leave and new files appear (Z6III / ZR, both slots if present)
- [ ] Hardware: shoot new stills/video with the gallery open; they appear after the debounce without leaving the gallery
- [ ] Settings → Clear Cache: camera ghosts gone, on-device library intact, connected gallery reloads
- [ ] Downloaded clips survive a format as local-only rows
- [ ] Android: REFRESH in landscape, cache clear drops the catalog and reloads
- [ ] In-flight listing after a clear cannot restore the old index

## Dual-platform

Same operator-visible inventory rules on iOS and Android. Core identity check is shared; Android already enumerated with content identity and now has Refresh + catalog-clear parity.
