### PR TITLE
fix: keep iPad photo-mode batteries off the PLAY rail

### DIFF
--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/AssistToolbar.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/AssistToolbar.kt
@@ -184,7 +184,8 @@ internal const val ASSIST_RAIL_BOTTOM_FADE_DP = 40f
 /**
  * Seats photography's collapsible vertical assist rail beside the lock/battery
  * lane (iOS `MonitorUnified` photo-rail placement): the rail clears whichever
- * left-edge chrome reaches furthest (lock button or battery stack) plus 12dp,
+ * left-edge chrome reaches furthest (lock button, phone battery stack, or the
+ * width-constrained inline cluster beside the lock) plus 12dp,
  * hugs the lock row while expanded, centre-aligns the collapsed pill on the
  * lock button, and runs down to the assist band's bottom edge unless the
  * measured capture strip actually enters the rail's lane — then it stops 10dp

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MonitorScreen.kt
@@ -105,6 +105,7 @@ import com.opencapture.openzcine.bridge.SwiftCoreCameraSession
 import com.opencapture.openzcine.bridge.SwiftLiveViewPolicyInput
 import com.opencapture.openzcine.bridge.SwiftLiveViewPreviewState
 import com.opencapture.openzcine.bridge.ZoneFrame
+import com.opencapture.openzcine.bridge.ZoneStyle
 import com.opencapture.openzcine.core.CameraControl
 import com.opencapture.openzcine.core.CameraControlException
 import com.opencapture.openzcine.core.CameraPropertySnapshot
@@ -1997,9 +1998,10 @@ internal fun MonitorScreen(
         val landscapePhotoFeed =
             if (!isPortrait && isPhotographyMode && !isCommand) {
                 val batteryTrailing =
-                    zones.batteryPhone?.let { anchor ->
-                        val stack = batteryRowStackFrame(anchor = anchor, lock = zones.lock)
-                        stack.x + stack.width
+                    if (railMounts(ChromeSection.BATTERY_INDICATORS)) {
+                        photographyBatteryTrailing(zones)
+                    } else {
+                        null
                     }
                 val leftChromeTrailing =
                     maxOf(zones.lock.x + zones.lock.width, batteryTrailing ?: 0f)
@@ -2782,13 +2784,10 @@ internal fun MonitorScreen(
                     if (assistToolbarVisible && isPhotography && !locked) {
                         zones.assistStrip?.let { band ->
                             val batteryTrailing =
-                                zones.batteryPhone?.let { anchor ->
-                                    val stack =
-                                        batteryRowStackFrame(
-                                            anchor = anchor,
-                                            lock = zones.lock,
-                                        )
-                                    stack.x + stack.width
+                                if (railMounts(ChromeSection.BATTERY_INDICATORS)) {
+                                    photographyBatteryTrailing(zones)
+                                } else {
+                                    null
                                 }
                             val railFrame =
                                 photographyAssistRailFrame(
@@ -2995,25 +2994,22 @@ internal fun MonitorScreen(
                         ),
                     ) { locked = !locked }
                 }
-                // Like iOS seating the combined indicator directly under the
-                // lock button, the two battery rows stack at the top of the
-                // leading lane, just below the lock's clearance.
-                zones.batteryPhone?.takeIf {
+                // Phone rails stack the gauges under the lock; width-constrained
+                // (tablet) maps seat them inline beside the lock in the top band.
+                landscapeBatteryIndicatorsFrame(zones)?.takeIf {
                     railMounts(ChromeSection.BATTERY_INDICATORS)
-                }?.let { anchor ->
+                }?.let { frame ->
+                    val placed =
+                        if (zones.batteryStyle == ZoneStyle.BATTERY_INLINE) {
+                            frame
+                        } else {
+                            frame.copy(x = frame.x - LEADING_RAIL_LEFT_NUDGE_DP)
+                        }
                     BatteryRowStack(
                         phonePercent = phoneBatteryReadout.percent,
                         cameraPercent = cameraReadouts.batteryPercent,
                         modifier =
-                            Modifier.zone(
-                                batteryRowStackFrame(
-                                    anchor =
-                                        anchor.copy(
-                                            x = anchor.x - LEADING_RAIL_LEFT_NUDGE_DP,
-                                        ),
-                                    lock = zones.lock,
-                                ),
-                            ).chromeEditable(
+                            Modifier.zone(placed).chromeEditable(
                                 ChromeSection.BATTERY_INDICATORS,
                                 chromeEditorMode,
                                 operatorSettings,
@@ -4652,6 +4648,21 @@ internal fun batteryRowStackFrame(anchor: ZoneFrame, lock: ZoneFrame): ZoneFrame
         width = BATTERY_STACK_WIDTH_DP,
         height = BATTERY_STACK_HEIGHT_DP,
     )
+
+/**
+ * Where the landscape battery gauges actually draw. Phone rails stack under the
+ * lock using the per-indicator `batteryPhone` anchor; width-constrained maps
+ * emit `.batteryInline` beside the lock and omit those per-indicator frames.
+ */
+internal fun landscapeBatteryIndicatorsFrame(zones: MonitorZones): ZoneFrame? =
+    when (zones.batteryStyle) {
+        ZoneStyle.BATTERY_INLINE -> zones.batteryCluster
+        else -> zones.batteryPhone?.let { batteryRowStackFrame(it, zones.lock) }
+    }
+
+/** Trailing x of lock-side batteries for photography rail / feed-lane clearance. */
+internal fun photographyBatteryTrailing(zones: MonitorZones): Float? =
+    landscapeBatteryIndicatorsFrame(zones)?.let { it.x + it.width }
 
 /**
  * Photography hides the command display mode — its dashboard is still

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/PhotographyChromeTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/PhotographyChromeTest.kt
@@ -1,9 +1,12 @@
 package com.opencapture.openzcine
 
+import com.opencapture.openzcine.bridge.MonitorZones
 import com.opencapture.openzcine.bridge.ZoneFrame
+import com.opencapture.openzcine.bridge.ZoneStyle
 import com.opencapture.openzcine.settings.MonitorDisplayMode
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /** JVM coverage for photography chrome policy helpers. */
@@ -69,6 +72,90 @@ class PhotographyChromeTest {
         val laneCentre = lock.x + lock.width + 12f + ASSIST_RAIL_EXPANDED_WIDTH_DP / 2f
         assertEquals(laneCentre - ASSIST_RAIL_COLLAPSED_PILL_DP / 2f, frame.x)
     }
+
+    @Test
+    fun `inline battery cluster trailing is the cluster right edge, not the phone pill`() {
+        val lock = ZoneFrame(x = 16f, y = 12f, width = 40f, height = 40f)
+        val cluster = ZoneFrame(x = 68f, y = 12f, width = 52f, height = 40f)
+        val zones = tabletZones(lock = lock, batteryCluster = cluster)
+
+        assertEquals(cluster, landscapeBatteryIndicatorsFrame(zones))
+        assertEquals(120f, photographyBatteryTrailing(zones))
+
+        val rail =
+            photographyAssistRailFrame(
+                lock = lock,
+                batteryTrailing = photographyBatteryTrailing(zones),
+                assistBand = band,
+                measuredCaptureBar = null,
+                expanded = true,
+            )
+        assertEquals(120f + 12f, rail.x)
+        assertTrue(rail.x >= cluster.x + cluster.width)
+    }
+
+    @Test
+    fun `phone rail batteries still use the stacked row frame`() {
+        val lock = ZoneFrame(x = 16f, y = 12f, width = 40f, height = 40f)
+        val phone = ZoneFrame(x = 16f, y = 90f, width = 38f, height = 70f)
+        val zones =
+            tabletZones(
+                lock = lock,
+                batteryStyle = ZoneStyle.BATTERY_RAIL,
+                batteryCluster = ZoneFrame(x = 16f, y = 12f, width = 38f, height = 300f),
+                batteryPhone = phone,
+            )
+        val stack = batteryRowStackFrame(phone, lock)
+        assertEquals(stack, landscapeBatteryIndicatorsFrame(zones))
+        assertEquals(stack.x + stack.width, photographyBatteryTrailing(zones))
+    }
+
+    @Test
+    fun `photo rail hugs the lock when there is no battery cluster`() {
+        val zones =
+            tabletZones(
+                lock = lock,
+                batteryStyle = null,
+                batteryCluster = null,
+                batteryPhone = null,
+            )
+        assertNull(photographyBatteryTrailing(zones))
+        val rail =
+            photographyAssistRailFrame(
+                lock = lock,
+                batteryTrailing = photographyBatteryTrailing(zones),
+                assistBand = band,
+                measuredCaptureBar = null,
+                expanded = true,
+            )
+        assertEquals(lock.x + lock.width + 12f, rail.x)
+    }
+
+    private fun tabletZones(
+        lock: ZoneFrame,
+        batteryStyle: ZoneStyle? = ZoneStyle.BATTERY_INLINE,
+        batteryCluster: ZoneFrame?,
+        batteryPhone: ZoneFrame? = null,
+    ): MonitorZones =
+        MonitorZones(
+            feed = ZoneFrame(0f, 0f, 1133f, 744f),
+            infoBar = ZoneFrame(140f, 8f, 800f, 46f),
+            captureStrip = null,
+            assistStrip = band,
+            systemCluster = lock,
+            lock = lock,
+            disp = ZoneFrame(1000f, 300f, 44f, 34f),
+            record = ZoneFrame(1050f, 600f, 72f, 72f),
+            media = ZoneFrame(1000f, 12f, 40f, 40f),
+            settings = ZoneFrame(1090f, 12f, 40f, 40f),
+            batteryCluster = batteryCluster,
+            batteryStyle = batteryStyle,
+            batteryPhone = batteryPhone,
+            batteryCamera = null,
+            scopes = null,
+            controlsGrid = null,
+        )
+
     @Test
     fun `photo feed spans the full height between the reserved side lanes`() {
         val viewport = ZoneFrame(0f, 0f, 914f, 384f)

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,5 +1,5 @@
 - New: Settings > Controls has Auto-Rotate Feed. Turn it off if you want the picture to stay put when the camera is on its side.
-- Fixed: settings popups always close - the X and tapping outside work even during a slow camera write.
+- Fixed: in photo mode on a tablet, the battery gauges sit beside the lock instead of covering PLAY.
 - Fixed: joining the camera's own Wi-Fi finds the camera instead of failing with an address error.
 - Fixed: stills focus settings no longer change how video focus taps behave.
 - New: your camera's clock syncs to the phone on connect - never while recording.

--- a/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
+++ b/Sources/OpenZCineCore/MonitorLayoutPolicy.swift
@@ -897,6 +897,32 @@ public struct MonitorBatteryRailLayout: Equatable, Sendable {
         usesClassicSideNotch(safeArea: safeArea) ? 0 : pillLeading + pillWidth
     }
 
+    /// Trailing x of lock-side chrome that photography's vertical assist rail must clear.
+    ///
+    /// On phones the stacked pill lives *under* the lock, so the rail only has to beat the
+    /// lock button and the island-hugging pill width. On width-constrained (4:3-ish iPad)
+    /// landscape the gauges sit *beside* the lock in the top band — using the phone pill
+    /// constant there parks PLAY on top of the cluster (GitHub #93).
+    public static func photographyLeftChromeTrailing(
+        lock: MonitorModuleFrame,
+        batteryCluster: MonitorZone?,
+        batteriesVisible: Bool,
+        safeArea: MonitorEdgeInsets
+    ) -> Double {
+        let lockTrailing = lock.x + lock.width
+        guard batteriesVisible, let battery = batteryCluster else { return lockTrailing }
+        let batteryTrailing: Double
+        switch battery.style {
+        case .batteryInline:
+            batteryTrailing = battery.frame.x + battery.frame.width
+        case .batteryRail:
+            batteryTrailing = batteryPillTrailing(safeArea: safeArea)
+        default:
+            batteryTrailing = battery.frame.x + battery.frame.width
+        }
+        return max(lockTrailing, batteryTrailing)
+    }
+
     /// Horizontal nudge that aligns the indicators with the Dynamic Island, which sits slightly
     /// inboard of the chrome's leading inset.
     public static let notchAlignmentInsetX = 3.0

--- a/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
+++ b/Tests/OpenZCineCoreTests/MonitorZoneLayoutTests.swift
@@ -528,6 +528,67 @@ private enum PadMiniViewport {
     }
 }
 
+@Test func padMiniPhotographyAssistRailClearsInlineBatteryCluster() throws {
+    let map = PadMiniViewport.map()
+    let lock = map.systemSlots.lock
+    let battery = try #require(map.batteryCluster)
+    #expect(battery.style == .batteryInline)
+
+    let trailing = MonitorBatteryRailLayout.photographyLeftChromeTrailing(
+        lock: lock,
+        batteryCluster: battery,
+        batteriesVisible: true,
+        safeArea: PadMiniViewport.safeArea
+    )
+    // PLAY sits 12pt past this trailing edge. It must not start inside the cluster.
+    #expect(trailing == battery.frame.x + battery.frame.width)
+    #expect(trailing > lock.x + lock.width)
+}
+
+@Test func photographyAssistRailHugsLockWhenBatteriesAreHidden() throws {
+    let map = PadMiniViewport.map()
+    let lock = map.systemSlots.lock
+    let battery = try #require(map.batteryCluster)
+
+    let trailing = MonitorBatteryRailLayout.photographyLeftChromeTrailing(
+        lock: lock,
+        batteryCluster: battery,
+        batteriesVisible: false,
+        safeArea: PadMiniViewport.safeArea
+    )
+    #expect(trailing == lock.x + lock.width)
+}
+
+@Test func phonePhotographyAssistRailStillClearsLockAndIslandPill() throws {
+    let safeArea = MonitorEdgeInsets(top: 0, leading: 59, bottom: 0, trailing: 0)
+    let map = MonitorZoneLayout.map(
+        viewportWidth: 874,
+        viewportHeight: 402,
+        safeArea: safeArea,
+        mode: .live,
+        isPortrait: false,
+        aspect: .fill,
+        scopeCount: 0,
+        horizontalDirection: .standard,
+        bottomBarHeight: 58
+    )
+    let lock = map.systemSlots.lock
+    let battery = try #require(map.batteryCluster)
+    #expect(battery.style == .batteryRail)
+
+    let trailing = MonitorBatteryRailLayout.photographyLeftChromeTrailing(
+        lock: lock,
+        batteryCluster: battery,
+        batteriesVisible: true,
+        safeArea: safeArea
+    )
+    #expect(
+        trailing
+            == max(
+                lock.x + lock.width,
+                MonitorBatteryRailLayout.batteryPillTrailing(safeArea: safeArea)))
+}
+
 @Test func padMiniMirroredInfoBarBandMirrorsWithTheCornerClusters() {
     let standard = PadMiniViewport.map()
     let mirrored = PadMiniViewport.map(direction: .mirrored)

--- a/ios/Runner/MonitorUnified.swift
+++ b/ios/Runner/MonitorUnified.swift
@@ -1805,11 +1805,18 @@ struct MonitorShell: View {
                 let band = map.assistStrip
             {
                 let lock = map.systemSlots.lock
-                // The rail clears whichever left-edge chrome reaches furthest: the lock
-                // button or the combined battery pill.
-                let leftChromeTrailing = max(
-                    lock.x + lock.width,
-                    MonitorBatteryRailLayout.batteryPillTrailing(safeArea: context.feedSafeArea))
+                // The rail clears whichever lock-side chrome reaches furthest: the lock
+                // button, the island pill, or — on width-constrained iPad — the inline
+                // battery cluster beside the lock. Using the phone-pill constant there
+                // parked PLAY on top of the gauges (#93).
+                let leftChromeTrailing =
+                    MonitorBatteryRailLayout.photographyLeftChromeTrailing(
+                        lock: lock,
+                        batteryCluster: map.batteryCluster,
+                        batteriesVisible: model.railControlMounts(
+                            .batteryIndicators, plan: model.monitorSideRailPlan),
+                        safeArea: context.feedSafeArea
+                    )
                 let railX =
                     leftChromeTrailing + 12 + Double(MonitorAssistStrip.expandedWidth) / 2
                 // Expanded: the tool column's top hugs the lock row. Collapsed: the pill is
@@ -1876,19 +1883,33 @@ struct MonitorShell: View {
                 // landscape since the mirrored layout landed — no island there, just a bezel —
                 // which is how it went unseen: this button only mounts with an AF point active.)
                 let mirroredLane = context.horizontalDirection == .mirrored
-                let photographyRailEdge =
-                    mirroredLane
-                    ? min(
-                        map.systemSlots.lock.x,
-                        Double(context.viewportWidth)
-                            - MonitorBatteryRailLayout.batteryPillTrailing(
-                                safeArea: context.feedSafeArea)
-                    ) - 12 - Double(MonitorAssistStrip.expandedWidth)
-                    : max(
-                        map.systemSlots.lock.x + map.systemSlots.lock.width,
-                        MonitorBatteryRailLayout.batteryPillTrailing(
-                            safeArea: context.feedSafeArea)
-                    ) + 12 + Double(MonitorAssistStrip.expandedWidth)
+                let batteriesVisible = model.railControlMounts(
+                    .batteryIndicators, plan: model.monitorSideRailPlan)
+                let photographyLeftChromeTrailing =
+                    MonitorBatteryRailLayout.photographyLeftChromeTrailing(
+                        lock: map.systemSlots.lock,
+                        batteryCluster: battery,
+                        batteriesVisible: batteriesVisible,
+                        safeArea: context.feedSafeArea
+                    )
+                // Closure, not a ViewBuilder `if`: this is geometry, not a view branch.
+                let photographyRailEdge: Double = {
+                    if mirroredLane {
+                        // Frames are already mirrored: lock-side chrome is on the right,
+                        // and "toward the feed" is the inner (min-x) edge of that cluster.
+                        let lockInner = map.systemSlots.lock.x
+                        let batteryInner =
+                            (batteriesVisible && battery.style == .batteryInline)
+                            ? battery.frame.x
+                            : Double(context.viewportWidth)
+                                - MonitorBatteryRailLayout.batteryPillTrailing(
+                                    safeArea: context.feedSafeArea)
+                        return min(lockInner, batteryInner) - 12
+                            - Double(MonitorAssistStrip.expandedWidth)
+                    }
+                    return photographyLeftChromeTrailing + 12
+                        + Double(MonitorAssistStrip.expandedWidth)
+                }()
                 let assistInlineX =
                     map.assistStrip.map {
                         mirroredLane

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -9,9 +9,9 @@ New and changed
 
 Fixes
 
+- On iPad in photo mode, the battery gauges sit beside the lock instead of covering PLAY.
 - A camera whose clock has drifted is set to your phone's time on connect - automatically, never while recording.
 - Changing stills focus settings no longer flips the video FOCUS readout or makes taps refocus single-shot on a camera set to full-time AF.
-- A Wi-Fi connection no longer asks you to join the camera's own network, and saved setups no longer read as offline while you are on that network.
 - A weak or busy link degrades the picture instead of dropping the session, and screen recording while you share your feed no longer walks the watcher's picture behind the action.
 - A watcher granted camera control can now start and stop the take, and keeps that control through a brief drop-out instead of losing it the moment the link stutters.
 - Fixed a crash that could end a live session on some iPads while Feed Noise Reduction was on. Thank you to whoever sent that report — the log had exactly what was needed.
@@ -24,4 +24,4 @@ What to test
 - Turn the camera on its side, then turn Auto-Rotate Feed off in Settings > Controls: the picture should stay put. Turn it back on and the picture should stand up. Then flip the iPhone to the opposite landscape: picture and controls swap sides, nothing under the island.
 - Turn on Share This Feed, ask for control from the second device, and start a take from it. Then screen-record on the sharing device and check the watcher stays with the action.
 - Watch a dim high-ISO shot with Feed Noise Reduction on and off, then step the Feed Upscaler through Fast, Quality and AI on the same framing.
-- With the body in full-time AF for video, change stills focus settings and tap around the feed: the FOCUS readout should hold, and focus should stay continuous. Set the camera clock a minute off, connect, and check it corrects.
+- On an iPad (especially mini) in landscape photo mode, PLAY and the rest of the left tool column should be fully visible and tappable, with the battery gauges beside the lock — not on top of PLAY.


### PR DESCRIPTION
## What & why

On compact iPads in photo mode, the battery gauges sat on top of PLAY ([#93](https://github.com/erik-sutton95/OpenZCine/issues/93)). The gauges already lived inline beside the lock; photography's vertical assist rail was still clearing a phone Dynamic Island pill (~56pt from the edge). On iPad mini that lands inside the inline cluster (trailing 120pt), so PLAY is drawn on top of the batteries.

The rail now clears the inline cluster when batteries are visible. Android tablets use the same trailing edge, and the inline gauges actually draw there — width-constrained maps omit the phone-rail frames the shell used to mount.

Phone Dynamic Island math is unchanged.

Fixes #93.

## Test plan

- iPad mini landscape, photo mode: lock, then batteries, then a fully visible PLAY column — not overlapping. Confirmed on the iPad mini (A17 Pro) simulator.
- Same layout on a larger iPad (Pro 11 class): batteries stay beside the lock, PLAY stays tappable.
- iPhone landscape photo: batteries stay under the lock / island pill; PLAY still clears them.
- Android tablet landscape photo: batteries sit beside the lock; PLAY is not covered.
- Hide batteries (DISP chrome): the photo rail hugs the lock.

## TestFlight notes

Updated `ios/TestFlight/WhatToTest.en-US.txt` — testers on iPad, especially mini, should check landscape photo mode: PLAY fully visible beside the lock-side batteries.

## Google Play notes

Updated `Apps/Android/distribution/whatsnew/whatsnew-en-US` — tablet photo mode, same outcome.

## Checklist

- [x] `just native-check` passes.
- [x] `just android-check` passes.
- [x] Hygiene and secret scan passed; TestFlight and Play notes checks passed.
- [x] Commits follow Conventional Commits.
- [x] No proprietary assets (`vendor/`, `ref/`) are included.
- [x] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy.
- [x] Play-triggering changes include reviewed `Apps/Android/distribution/whatsnew/whatsnew-en-US` copy.
- [ ] iOS release PRs: no marketing-version bump; this is a behaviour fix on the current 0.2.5 train.
