### PR TITLE
fix(android): USB connect can recover after permission and a dropped event pipe

### DIFF
--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSession.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSession.kt
@@ -18,7 +18,9 @@ import com.opencapture.openzcine.core.CameraSessionState
 import com.opencapture.openzcine.core.LiveFrameSource
 import com.opencapture.openzcine.core.MFDriveOutcome
 import com.opencapture.openzcine.core.StillReleasePoll
+import com.opencapture.openzcine.transport.UsbPtpOpenResult
 import com.opencapture.openzcine.transport.UsbPtpTransport
+import com.opencapture.openzcine.transport.UsbPtpTransportReopener
 import com.opencapture.openzcine.withOptimisticControlValue
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
@@ -310,13 +312,15 @@ class SwiftCoreCameraSession internal constructor(
     private val selectorPollIntervalMillis: Long = SELECTOR_POLL_INTERVAL_MILLIS,
     private val propertyEventDebounceMillis: Long = PROPERTY_EVENT_DEBOUNCE_MILLIS,
     private val automaticallyRefreshProperties: Boolean = true,
-    private val usbTransport: UsbPtpTransport? = null,
+    usbTransport: UsbPtpTransport? = null,
+    private val usbReopener: UsbPtpTransportReopener? = null,
     private val cameraNameHint: String? = null,
     private val connectionStrategy: PtpIpConnectionStrategy =
         PtpIpConnectionStrategy.RESTORE_PROFILE_THEN_PAIRING,
     initiatorGuid: ByteArray = defaultPtpIpInitiatorGuid,
 ) : CameraSession {
     private val initiatorGuid: ByteArray = initiatorGuid.copyOf()
+    private var usbTransport: UsbPtpTransport? = usbTransport
 
     init {
         require(initiatorGuid.size == INITIATOR_GUID_BYTE_COUNT) {
@@ -349,12 +353,14 @@ class SwiftCoreCameraSession internal constructor(
         host: String,
         cameraNameHint: String,
         usbTransport: UsbPtpTransport,
+        usbReopener: UsbPtpTransportReopener? = null,
         phaseLogger: (String, String) -> Unit = { _, _ -> },
     ) : this(
         host = host,
         phaseLogger = phaseLogger,
         core = SwiftCoreSessionBridge.Production,
         usbTransport = usbTransport,
+        usbReopener = usbReopener,
         cameraNameHint = cameraNameHint,
     )
 
@@ -364,12 +370,14 @@ class SwiftCoreCameraSession internal constructor(
         cameraNameHint: String,
         usbTransport: UsbPtpTransport,
         connectionStrategy: PtpIpConnectionStrategy,
+        usbReopener: UsbPtpTransportReopener? = null,
         phaseLogger: (String, String) -> Unit = { _, _ -> },
     ) : this(
         host = host,
         phaseLogger = phaseLogger,
         core = SwiftCoreSessionBridge.Production,
         usbTransport = usbTransport,
+        usbReopener = usbReopener,
         cameraNameHint = cameraNameHint,
         connectionStrategy = connectionStrategy,
     )
@@ -528,8 +536,9 @@ class SwiftCoreCameraSession internal constructor(
             if (usbTransport == null) {
                 core.connect(host, connectionOwner, connectionStrategy, initiatorGuid, listener)
             } else {
+                val transport = preparedUsbTransport(attempt) ?: return
                 core.connectUsb(
-                    transport = usbTransport,
+                    transport = transport,
                     host = host,
                     cameraNameHint = cameraNameHint.orEmpty(),
                     connectionOwner = connectionOwner,
@@ -553,6 +562,52 @@ class SwiftCoreCameraSession internal constructor(
     /** Closed phase token distinguishing USB PTP vs Wi‑Fi PTP-IP session failures. */
     private fun sessionFailurePhaseToken(): String =
         if (usbTransport != null) "failed.usb" else "failed.ptp"
+
+    /**
+     * Returns a live USB transport for this attempt, re-opening the interface
+     * when the previous one was closed by an event-channel failure.
+     *
+     * A closed handle handed back to JNI fails in ~1 ms (issue #315).
+     */
+    private fun preparedUsbTransport(attempt: Long): UsbPtpTransport? {
+        val current = usbTransport ?: return null
+        if (!current.isClosed()) return current
+        val reopener = usbReopener
+        if (reopener == null) {
+            failClosedUsbReconnect(
+                attempt,
+                "usb.reconnect.closedTransport",
+                "The USB-C camera connection was already closed.",
+            )
+            return null
+        }
+        return when (val opened = reopener.reopen()) {
+            is UsbPtpOpenResult.Opened -> {
+                usbTransport = opened.transport
+                opened.transport
+            }
+            is UsbPtpOpenResult.Rejected -> {
+                failClosedUsbReconnect(attempt, "failed.usb", opened.message)
+                null
+            }
+        }
+    }
+
+    private fun failClosedUsbReconnect(attempt: Long, phase: String, message: String) {
+        val shouldLog =
+            synchronized(attemptLock) {
+                if (activeAttempt != attempt) return
+                activeAttempt = null
+                activeConnectionOwner = null
+                _state.value = CameraSessionState.Disconnected
+                _connectionProgress.value =
+                    CameraConnectionProgress(CameraConnectionPhase.FAILED, message)
+                true
+            }
+        if (!shouldLog) return
+        phaseLogger(phase, "")
+        if (phase != "failed.usb") phaseLogger("failed.usb", message)
+    }
 
     /**
      * Reads one camera property (see `SwiftCore.PROP_*`), decoded by the Swift

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/diagnostics/DiagnosticEventStore.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/diagnostics/DiagnosticEventStore.kt
@@ -50,6 +50,27 @@ internal enum class AndroidDiagnosticEvent(val wireValue: String) {
     /** Permission held, but the ROM would not surface a USB serial descriptor. */
     USB_ATTACHED_NO_SERIAL("usb.attached.no-serial"),
     USB_ATTACHED_READY("usb.attached.ready"),
+
+    // USB open / handshake stages. The generic `error.connection.usb.failed`
+    // breadcrumb could not tell a claim failure from a dead interrupt endpoint
+    // from a PTP OpenSession refusal (issue #315).
+    USB_OPEN_DETACHED("usb.open.detached"),
+    USB_OPEN_NO_PERMISSION("usb.open.no-permission"),
+    USB_OPEN_NO_PTP_INTERFACE("usb.open.no-ptp-interface"),
+    USB_OPEN_DEVICE("usb.open.device"),
+    USB_OPEN_CLAIM("usb.open.claim"),
+    USB_OPEN_EVENT_ENDPOINT("usb.open.event-endpoint"),
+    USB_OPEN_CHANGED("usb.open.changed"),
+    USB_RECONNECT_CLOSED_TRANSPORT("usb.reconnect.closed-transport"),
+    USB_RECONNECT_NOT_READY("usb.reconnect.not-ready"),
+    USB_HANDSHAKE_DEVICE_INFO("usb.handshake.device-info"),
+    USB_HANDSHAKE_OPEN_SESSION("usb.handshake.open-session"),
+    USB_HANDSHAKE_APP_MODE("usb.handshake.app-mode"),
+    USB_HANDSHAKE_IDENTIFY("usb.handshake.identify"),
+    USB_HANDSHAKE_WRITE("usb.handshake.write"),
+    USB_HANDSHAKE_READ("usb.handshake.read"),
+    USB_HANDSHAKE_TIMEOUT("usb.handshake.timeout"),
+    USB_HANDSHAKE_CLOSED("usb.handshake.closed"),
     LIVE_VIEW_FAILED("error.live-view.failed"),
     LIVE_VIEW_STALLED("warning.live-view.stalled"),
     // Object star-rating writes. The vocabulary stays closed (no wire code leaks into the log);
@@ -115,6 +136,23 @@ internal enum class AndroidDiagnosticEvent(val wireValue: String) {
                 "usb.attached.permissionDenied" -> USB_ATTACHED_PERMISSION_DENIED
                 "usb.attached.noSerial" -> USB_ATTACHED_NO_SERIAL
                 "usb.attached.ready" -> USB_ATTACHED_READY
+                "usb.open.detached" -> USB_OPEN_DETACHED
+                "usb.open.noPermission" -> USB_OPEN_NO_PERMISSION
+                "usb.open.noPtpInterface" -> USB_OPEN_NO_PTP_INTERFACE
+                "usb.open.device" -> USB_OPEN_DEVICE
+                "usb.open.claim" -> USB_OPEN_CLAIM
+                "usb.open.eventEndpoint" -> USB_OPEN_EVENT_ENDPOINT
+                "usb.open.changed" -> USB_OPEN_CHANGED
+                "usb.reconnect.closedTransport" -> USB_RECONNECT_CLOSED_TRANSPORT
+                "usb.reconnect.notReady" -> USB_RECONNECT_NOT_READY
+                "usb.handshake.deviceInfo" -> USB_HANDSHAKE_DEVICE_INFO
+                "usb.handshake.openSession" -> USB_HANDSHAKE_OPEN_SESSION
+                "usb.handshake.appMode" -> USB_HANDSHAKE_APP_MODE
+                "usb.handshake.identify" -> USB_HANDSHAKE_IDENTIFY
+                "usb.handshake.write" -> USB_HANDSHAKE_WRITE
+                "usb.handshake.read" -> USB_HANDSHAKE_READ
+                "usb.handshake.timeout" -> USB_HANDSHAKE_TIMEOUT
+                "usb.handshake.closed" -> USB_HANDSHAKE_CLOSED
                 "failed.scannerRecognizer" -> SCANNER_RECOGNIZER_UNAVAILABLE
                 "failed.scannerRecognizerUnsupported" -> SCANNER_RECOGNIZER_UNSUPPORTED
                 "liveViewFailed" -> LIVE_VIEW_FAILED

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/PairingExperience.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/pairing/PairingExperience.kt
@@ -89,6 +89,8 @@ import com.opencapture.openzcine.transport.UsbPtpCamera
 import com.opencapture.openzcine.transport.UsbPtpCameraAccess
 import com.opencapture.openzcine.transport.UsbPtpCameraSource
 import com.opencapture.openzcine.transport.UsbPtpOpenResult
+import com.opencapture.openzcine.transport.UsbPtpTransportReopener
+import com.opencapture.openzcine.transport.reopenReadyUsbTransport
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
@@ -252,28 +254,25 @@ public fun realPairingEnvironment(
         },
         usbCameraSource = usbCameraSource,
         createUsbSession = { opened ->
-            SwiftCoreCameraSession(
-                host = opened.hostKey,
-                cameraNameHint = opened.displayName,
-                usbTransport = opened.transport,
+            usbCameraSession(
+                opened = opened,
+                source = usbCameraSource,
                 connectionStrategy = PtpIpConnectionStrategy.RESTORE_PROFILE_THEN_PAIRING,
                 phaseLogger = combinedPhaseLogger,
             )
         },
         createSavedProfileUsbSession = { opened ->
-            SwiftCoreCameraSession(
-                host = opened.hostKey,
-                cameraNameHint = opened.displayName,
-                usbTransport = opened.transport,
+            usbCameraSession(
+                opened = opened,
+                source = usbCameraSource,
                 connectionStrategy = PtpIpConnectionStrategy.SAVED_PROFILE,
                 phaseLogger = combinedPhaseLogger,
             )
         },
         createFirstTimePairingUsbSession = { opened ->
-            SwiftCoreCameraSession(
-                host = opened.hostKey,
-                cameraNameHint = opened.displayName,
-                usbTransport = opened.transport,
+            usbCameraSession(
+                opened = opened,
+                source = usbCameraSource,
                 connectionStrategy = PtpIpConnectionStrategy.RESTORE_PROFILE_THEN_PAIRING,
                 phaseLogger = combinedPhaseLogger,
             )
@@ -286,6 +285,24 @@ public fun realPairingEnvironment(
         },
     )
 }
+
+private fun usbCameraSession(
+    opened: UsbPtpOpenResult.Opened,
+    source: UsbPtpCameraSource,
+    connectionStrategy: PtpIpConnectionStrategy,
+    phaseLogger: (String, String) -> Unit,
+): SwiftCoreCameraSession =
+    SwiftCoreCameraSession(
+        host = opened.hostKey,
+        cameraNameHint = opened.displayName,
+        usbTransport = opened.transport,
+        connectionStrategy = connectionStrategy,
+        usbReopener =
+            UsbPtpTransportReopener {
+                reopenReadyUsbTransport(source, opened.hostKey)
+            },
+        phaseLogger = phaseLogger,
+    )
 
 /** Emits only safe connection failures to logcat, never pairing-phase details. */
 private fun logCameraSessionPhase(phase: String, detail: String) {
@@ -311,7 +328,12 @@ internal fun cameraSessionDiagnosticMessage(phase: String, detail: String): Stri
         // no pairing credential can ride it.
         "propertyWriteSlow",
         -> "$phase: $detail"
-        else -> null
+        else ->
+            if (phase.startsWith("usb.")) {
+                "$phase: $detail"
+            } else {
+                null
+            }
     }
 
 /** Closed diagnostic phase token for the first-run transport choice. */

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/AndroidUsbPtpHost.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/AndroidUsbPtpHost.kt
@@ -70,6 +70,40 @@ public interface UsbPtpTransport : Closeable {
     public fun isClosed(): Boolean
 }
 
+/**
+ * Re-claims a USB PTP interface after the previous transport closed.
+ *
+ * Monitor recovery reconnects through the same session object. USB events share
+ * that claimed interface, so an interrupt failure closes it; the next connect
+ * must open a new one instead of handing JNI a dead handle.
+ */
+public fun interface UsbPtpTransportReopener {
+    /** Opens a fresh transport, or a closed diagnostic reason the camera cannot be claimed. */
+    public fun reopen(): UsbPtpOpenResult
+}
+
+/**
+ * Re-opens the currently attached, permissioned camera that matches [hostKey].
+ *
+ * Used by USB monitor recovery after the previous transport closed. Never
+ * invents a device identity: if the body is gone or still needs permission,
+ * the operator sees a reconnect failure instead of a 1 ms handshake collapse.
+ */
+internal fun reopenReadyUsbTransport(
+    source: UsbPtpCameraSource,
+    hostKey: String,
+): UsbPtpOpenResult {
+    val camera =
+        source.cameras.value.firstOrNull { candidate ->
+            candidate.access == UsbPtpCameraAccess.READY && candidate.hostKey == hostKey
+        }
+            ?: return UsbPtpOpenResult.Rejected(
+                message = "Connect your USB-C camera and approve access, then try again.",
+                diagnosticPhase = "usb.reconnect.notReady",
+            )
+    return source.open(camera)
+}
+
 /** Result of opening a platform-owned USB transport for the Swift facade. */
 public sealed interface UsbPtpOpenResult {
     /** A permissioned connection with a stable saved-record host key. */
@@ -81,7 +115,11 @@ public sealed interface UsbPtpOpenResult {
     ) : UsbPtpOpenResult
 
     /** The requested camera was no longer available for a safe connection. */
-    public data class Rejected(public val message: String) : UsbPtpOpenResult
+    public data class Rejected(
+        public val message: String,
+        /** Closed diagnostic token; never a device path, serial, or exception text. */
+        public val diagnosticPhase: String = "failed.usb",
+    ) : UsbPtpOpenResult
 }
 
 /**
@@ -206,36 +244,47 @@ public class AndroidUsbPtpCameraSource(
 
     override fun open(camera: UsbPtpCamera): UsbPtpOpenResult {
         val device = usbManager.deviceList[camera.token]
-            ?: return UsbPtpOpenResult.Rejected(
+            ?: return rejectOpen(
                 "The USB-C camera is no longer attached. Reconnect the cable and try again.",
+                "usb.open.detached",
             )
         val attachmentLease =
             synchronized(lifecycleLock) {
-                if (closed) return UsbPtpOpenResult.Rejected("USB camera discovery is no longer active.")
+                if (closed) {
+                    return rejectOpen(
+                        "USB camera discovery is no longer active.",
+                        "usb.open.detached",
+                    )
+                }
                 attachmentState.captureOpenLease(device.deviceName)
             }
-                ?: return UsbPtpOpenResult.Rejected(
+                ?: return rejectOpen(
                     "The USB-C camera is no longer attached. Reconnect the cable and try again.",
+                    "usb.open.detached",
                 )
         if (!usbManager.hasPermission(device)) {
-            return UsbPtpOpenResult.Rejected(
+            return rejectOpen(
                 "Allow USB access for this camera, then try connecting again.",
+                "usb.open.noPermission",
             )
         }
         val selection = descriptorSelection(device)
-            ?: return UsbPtpOpenResult.Rejected(
+            ?: return rejectOpen(
                 "This USB device does not expose the complete PTP camera interface OpenZCine needs.",
+                "usb.open.noPtpInterface",
             )
         val hostKey = stableHostKey(device)
         val connection = usbManager.openDevice(device)
-            ?: return UsbPtpOpenResult.Rejected(
+            ?: return rejectOpen(
                 "Android could not open this USB camera. Disconnect it, approve access again, and retry.",
+                "usb.open.device",
             )
         val usbInterface = device.getInterface(selection.interfaceIndex)
         if (!connection.claimInterface(usbInterface, true)) {
             connection.close()
-            return UsbPtpOpenResult.Rejected(
+            return rejectOpen(
                 "Android could not claim the camera's PTP USB interface. Close other camera apps and retry.",
+                "usb.open.claim",
             )
         }
         val bulkIn = endpoint(usbInterface, selection.bulkInAddress)
@@ -253,8 +302,9 @@ public class AndroidUsbPtpCameraSource(
             connection.releaseInterface(usbInterface)
             connection.close()
             eventRequest.close()
-            return UsbPtpOpenResult.Rejected(
+            return rejectOpen(
                 "Android could not open the camera's PTP event endpoint. Reconnect the cable and retry.",
+                "usb.open.eventEndpoint",
             )
         }
         val transport =
@@ -263,6 +313,7 @@ public class AndroidUsbPtpCameraSource(
                 usbInterface = usbInterface,
                 bulkIn = bulkIn,
                 bulkOut = bulkOut,
+                eventIn = eventIn,
                 eventRequest = eventRequest,
             )
         transport.setOnClosed {
@@ -289,8 +340,9 @@ public class AndroidUsbPtpCameraSource(
             }
         if (rejectOpenedTransport) {
             transport.close()
-            return UsbPtpOpenResult.Rejected(
+            return rejectOpen(
                 "The USB-C camera changed while Android opened it. Reconnect the cable and try again.",
+                "usb.open.changed",
             )
         }
         replacedTransport?.close()
@@ -484,6 +536,11 @@ public class AndroidUsbPtpCameraSource(
         return if (device.vendorId == NIKON_VENDOR_ID) "Nikon USB camera" else "USB PTP camera"
     }
 
+    private fun rejectOpen(message: String, diagnosticPhase: String): UsbPtpOpenResult.Rejected {
+        onDiagnosticPhase(diagnosticPhase)
+        return UsbPtpOpenResult.Rejected(message, diagnosticPhase)
+    }
+
     private fun permissionIntent(): PendingIntent =
         PendingIntent.getBroadcast(
             appContext,
@@ -506,6 +563,18 @@ public class AndroidUsbPtpCameraSource(
         const val usbPermissionAction: String = "com.opencapture.openzcine.USB_PTP_PERMISSION"
         const val USB_DIAG_TAG: String = "UsbPtpDiag"
     }
+}
+
+/** Copies completed UsbRequest bytes from a heap or direct buffer. */
+private fun copyUsbRequestPayload(buffer: ByteBuffer): ByteArray {
+    val length = buffer.position().coerceAtLeast(0)
+    if (length == 0) return ByteArray(0)
+    val bytes = ByteArray(length)
+    val savedPosition = buffer.position()
+    buffer.rewind()
+    buffer.get(bytes)
+    buffer.position(savedPosition)
+    return bytes
 }
 
 private const val PTP_STATUS_OK: Int = 0x2001
@@ -643,7 +712,7 @@ internal class UsbInterruptEventPump(private val channel: UsbInterruptChannel) {
                     return@synchronized null
                 }
                 queuedBuffer = null
-                buffer.array().copyOf(buffer.position())
+                copyUsbRequestPayload(buffer)
             } catch (_: TimeoutException) {
                 // A sparse PTP event channel is healthy. The request stays
                 // queued on purpose and its buffer is still framework-owned, so
@@ -689,7 +758,10 @@ internal class UsbInterruptEventPump(private val channel: UsbInterruptChannel) {
 
     /** Queues a fresh buffer, or retires the pump when the framework refuses. */
     private fun queueLocked(maxBytes: Int): ByteBuffer? {
-        val fresh = ByteBuffer.allocate(maxBytes)
+        // Direct: some OEM USB HALs reject UsbRequest.queue on a heap array
+        // (HyperOS / Snapdragon 8 Elite) while the bulkTransfer byte[] path
+        // still works — handshake succeeds, then the event channel dies.
+        val fresh = ByteBuffer.allocateDirect(maxBytes.coerceAtLeast(1))
         // Guarded, not bare: the framework throws for a closed connection or a
         // request teardown retired underneath us, and this is the exact call
         // that used to escape the event pump and kill the process.
@@ -753,12 +825,14 @@ private class AndroidUsbPtpTransport(
     private val usbInterface: UsbInterface,
     private val bulkIn: UsbEndpoint,
     private val bulkOut: UsbEndpoint,
+    private val eventIn: UsbEndpoint,
     eventRequest: UsbRequest,
 ) : UsbPtpTransport {
     private val closeLock = Any()
     private val commandLock = Any()
     private val eventPump =
         UsbInterruptEventPump(UsbRequestInterruptChannel(connection, eventRequest))
+    private val eventPacketBytes: Int = interruptUrbSize(eventIn.maxPacketSize, INITIAL_EVENT_BYTES)
     @Volatile private var closed: Boolean = false
     private var deadWriteRecoveryDone: Boolean = false
     private var onClosed: (() -> Unit)? = null
@@ -769,8 +843,9 @@ private class AndroidUsbPtpTransport(
         // application mode makes the ZR emit StoreRemoved here, and it stalls
         // that switch until the event is drained (see the Swift establish's
         // concurrent event pump). This just ensures a buffer is already
-        // waiting before the pump's first read.
-        eventPump.prime(INITIAL_EVENT_BYTES)
+        // waiting before the pump's first read. Size is one interrupt packet,
+        // never the bulk-sized chunk Swift asks for on later reads.
+        eventPump.prime(eventPacketBytes)
     }
 
     fun setOnClosed(callback: () -> Unit) {
@@ -806,7 +881,7 @@ private class AndroidUsbPtpTransport(
 
     override fun readEvent(maxBytes: Int, timeoutMillis: Int): ByteArray? {
         if (closed || maxBytes !in 1..MAX_READ_BYTES) return null
-        val bytes = eventPump.read(maxBytes, timeoutMillis)
+        val bytes = eventPump.read(interruptUrbSize(eventIn.maxPacketSize, maxBytes), timeoutMillis)
         // A retired pump can never queue another interrupt read, so this USB
         // session is over. Close it here instead of letting the caller retry
         // into a pipe that will never deliver; Swift then sees a typed

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/UsbPtpSelection.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/UsbPtpSelection.kt
@@ -83,6 +83,24 @@ public object UsbPtpInterfaceSelector {
 }
 
 /**
+ * Interrupt URB length for one PTP event read.
+ *
+ * The Swift session asks the event endpoint for a bulk-sized chunk (256 KiB).
+ * Queuing that on interrupt-IN makes some USB host controllers — notably
+ * Qualcomm on HyperOS — fail the transfer immediately. Handshake then succeeds
+ * on the bulk pipes and the event channel dies a few milliseconds later
+ * (field report: Redmi K90 Ultra, issue #315). One packet is the USB-correct
+ * size; Swift already assembles multi-packet PTP event containers.
+ */
+internal fun interruptUrbSize(maxPacketSize: Int, requestedMaxBytes: Int): Int {
+    val packet = maxPacketSize.coerceAtLeast(MINIMUM_INTERRUPT_PACKET_BYTES)
+    if (requestedMaxBytes <= 0) return packet
+    return requestedMaxBytes.coerceAtMost(packet)
+}
+
+private const val MINIMUM_INTERRUPT_PACKET_BYTES: Int = 8
+
+/**
  * Privacy-safe persistent identity for a USB camera.
  *
  * The USB serial never leaves the platform layer: the saved-camera host key

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSessionTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/bridge/SwiftCoreCameraSessionTest.kt
@@ -13,6 +13,7 @@ import com.opencapture.openzcine.core.CameraRecordingState
 import com.opencapture.openzcine.core.CameraSessionEvent
 import com.opencapture.openzcine.core.CameraSessionState
 import com.opencapture.openzcine.core.CodecBitDepthOption
+import com.opencapture.openzcine.transport.UsbPtpOpenResult
 import com.opencapture.openzcine.transport.UsbPtpTransport
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -708,6 +709,85 @@ class SwiftCoreCameraSessionTest {
         assertEquals(CameraSessionState.Disconnected, session.state.value)
         assertEquals(1, bridge.disconnects)
         assertTrue(transport.isClosed())
+    }
+
+    @Test
+    fun `USB reconnect after event teardown does not reuse the closed transport`() = runTest {
+        // Field report #315 (Redmi K90 Ultra): handshake succeeded, the interrupt
+        // channel ended, then every reconnect failed in ~1 ms. Monitor recovery
+        // called connect() on the same session, which handed the already-closed
+        // Kotlin transport back to JNI.
+        val bridge = FakeBridge()
+        val transport = FakeUsbTransport()
+        val session =
+            SwiftCoreCameraSession(
+                host = "usb:5d6f4d746ecf9da40a1b0ce273d3d8d3",
+                phaseLogger = { _, _ -> },
+                core = bridge,
+                propertyRefreshScope = this,
+                propertyRefreshDispatcher = StandardTestDispatcher(testScheduler),
+                automaticallyRefreshProperties = false,
+                usbTransport = transport,
+                cameraNameHint = "Nikon USB camera",
+            )
+        val connecting = async { session.connect() }
+        runCurrent()
+        bridge.listeners.single().onConnected("ZR", "NIKON ZR", "6001234")
+        connecting.await()
+
+        bridge.eventListeners.single().onEnded("The camera closed the USB event endpoint.")
+        runCurrent()
+        assertTrue(transport.isClosed())
+
+        val reconnecting = async { session.connect() }
+        runCurrent()
+        reconnecting.await()
+
+        assertEquals(1, bridge.usbConnects.size)
+        assertEquals(CameraSessionState.Disconnected, session.state.value)
+    }
+
+    @Test
+    fun `USB reconnect after event teardown opens a fresh transport`() = runTest {
+        val bridge = FakeBridge()
+        val first = FakeUsbTransport()
+        val second = FakeUsbTransport()
+        val session =
+            SwiftCoreCameraSession(
+                host = "usb:5d6f4d746ecf9da40a1b0ce273d3d8d3",
+                phaseLogger = { _, _ -> },
+                core = bridge,
+                propertyRefreshScope = this,
+                propertyRefreshDispatcher = StandardTestDispatcher(testScheduler),
+                automaticallyRefreshProperties = false,
+                usbTransport = first,
+                usbReopener = {
+                    UsbPtpOpenResult.Opened(
+                        transport = second,
+                        hostKey = "usb:5d6f4d746ecf9da40a1b0ce273d3d8d3",
+                        displayName = "Nikon USB camera",
+                    )
+                },
+                cameraNameHint = "Nikon USB camera",
+            )
+        val connecting = async { session.connect() }
+        runCurrent()
+        bridge.listeners.single().onConnected("ZR", "NIKON ZR", "6001234")
+        connecting.await()
+
+        bridge.eventListeners.single().onEnded("The camera closed the USB event endpoint.")
+        runCurrent()
+        assertTrue(first.isClosed())
+
+        val reconnecting = async { session.connect() }
+        runCurrent()
+        assertEquals(2, bridge.usbConnects.size)
+        assertEquals(second, bridge.usbConnects.last().transport)
+        bridge.listeners.last().onConnected("ZR", "NIKON ZR", "6001234")
+        reconnecting.await()
+
+        assertTrue(session.state.value is CameraSessionState.Connected)
+        assertFalse(second.isClosed())
     }
 
     @Test

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/diagnostics/DiagnosticEventStoreTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/diagnostics/DiagnosticEventStoreTest.kt
@@ -256,4 +256,28 @@ class DiagnosticEventStoreTest {
         assertTrue(wording.none { it.contains("/dev/") }, "a device path is not a diagnostic")
         assertTrue(wording.all { it.startsWith("usb.attached.") })
     }
+
+    @Test
+    fun `USB handshake stages map to distinct closed codes`() {
+        val codes =
+            listOf(
+                    "usb.open.claim",
+                    "usb.open.eventEndpoint",
+                    "usb.reconnect.closedTransport",
+                    "usb.handshake.deviceInfo",
+                    "usb.handshake.openSession",
+                    "usb.handshake.appMode",
+                    "usb.handshake.write",
+                    "usb.handshake.read",
+                )
+                .map { AndroidDiagnosticEvent.fromPhase(it) }
+
+        assertEquals(codes.size, codes.toSet().size, "each stage needs its own code")
+        assertTrue(codes.all { it != null })
+        assertTrue(codes.none { it == AndroidDiagnosticEvent.CONNECTION_USB_FAILED })
+        assertEquals(
+            AndroidDiagnosticEvent.USB_HANDSHAKE_WRITE,
+            AndroidDiagnosticEvent.fromPhase("usb.handshake.write"),
+        )
+    }
 }

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/pairing/CameraSessionDiagnosticsTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/pairing/CameraSessionDiagnosticsTest.kt
@@ -28,6 +28,10 @@ class CameraSessionDiagnosticsTest {
             "failed.ptp: unreachable",
             cameraSessionDiagnosticMessage("failed.ptp", "unreachable"),
         )
+        assertEquals(
+            "usb.handshake.write: ",
+            cameraSessionDiagnosticMessage("usb.handshake.write", ""),
+        )
     }
 
     @Test

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/transport/UsbInterruptEventPumpTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/transport/UsbInterruptEventPumpTest.kt
@@ -54,6 +54,8 @@ private class FakeInterruptChannel : UsbInterruptChannel {
     var connectionOpen: Boolean = true
     var queueAttempts: Int = 0
         private set
+    var lastQueuedWasDirect: Boolean = false
+        private set
     var cancelCount: Int = 0
         private set
     var waitCount: Int = 0
@@ -81,6 +83,7 @@ private class FakeInterruptChannel : UsbInterruptChannel {
 
     override fun queue(buffer: ByteBuffer): Boolean {
         queueAttempts += 1
+        lastQueuedWasDirect = buffer.isDirect
         if (queued != null) {
             illegalQueueAttempts += 1
             throw IllegalStateException("this request is currently queued")
@@ -148,6 +151,20 @@ class UsbInterruptEventPumpTest {
         assertEquals(1, channel.queueAttempts)
         assertTrue(channel.isQueued)
         assertEquals(0, channel.waitCount)
+    }
+
+    @Test
+    fun `interrupt URBs use a direct buffer so OEM host stacks that reject heap arrays can complete`() {
+        // AOSP UsbRequest.queue has a native_queue_array path for heap buffers.
+        // Some OEM USB HALs (HyperOS on Snapdragon 8 Elite) fail that path and
+        // succeed only with a DirectByteBuffer. The payload must still copy out.
+        val pump = primedPump()
+        val payload = byteArrayOf(0x10, 0x00, 0x00, 0x00, 0x01, 0x40)
+        assertTrue(channel.lastQueuedWasDirect)
+        channel.script(FakeInterruptChannel.Completion.Own(payload))
+
+        assertContentEquals(payload, pump.read(READ_BYTES, TIMEOUT_MILLIS))
+        assertEquals(0, channel.illegalQueueAttempts)
     }
 
     @Test

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/transport/UsbPtpSelectionTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/transport/UsbPtpSelectionTest.kt
@@ -186,4 +186,16 @@ class UsbPtpSelectionTest {
         assertFalse(state.isCurrent(originalLease))
         assertTrue(requireNotNull(state.captureOpenLease(token)).generation > originalLease.generation)
     }
+
+    @Test
+    fun `interrupt URBs are one packet, never a bulk-sized chunk`() {
+        // Swift asks the event endpoint for a 256 KiB bulk-style chunk. Queuing
+        // that on interrupt-IN makes some host controllers fail immediately
+        // (Redmi K90 Ultra / Snapdragon 8 Elite, issue #315): handshake
+        // succeeds on bulk, then the event channel dies within milliseconds.
+        assertEquals(16, interruptUrbSize(maxPacketSize = 16, requestedMaxBytes = 256 * 1024))
+        assertEquals(64, interruptUrbSize(maxPacketSize = 64, requestedMaxBytes = 512))
+        assertEquals(8, interruptUrbSize(maxPacketSize = 8, requestedMaxBytes = 8))
+        assertEquals(8, interruptUrbSize(maxPacketSize = 0, requestedMaxBytes = 512))
+    }
 }

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,6 +1,6 @@
+- Fixed: USB-C connect after Android grants permission. If the picture came up then dropped, or retry failed immediately, try the cable again — it should stay up.
 - Fixed: Aperture-priority shutter and ISO on the phone follow the camera as it meters.
 - Fixed: photo FOCUS and taps follow stills AF, not leftover video AF-F.
 - New: Media has REFRESH. After a format it follows the card, not old names; Clear Cache reloads Media from the camera.
 - Fixed: Share and Save to Photos work on clips from the camera.
 - Fixed: Share in playback is available while the camera is still connected.
-- New: Settings > Controls has Auto-Rotate Feed. Turn it off if you want the picture to stay put when the camera is on its side.

--- a/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
+++ b/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
@@ -906,7 +906,9 @@ public final class PTPIPClientSession: @unchecked Sendable {
             on session: PTPIPClientSession,
             onPhase: (CameraConnectionPhase, String) -> Void
         ) throws {
-            try session.openSession()
+            try performingUSBHandshake(.openSession) {
+                try session.openSession()
+            }
             // Application mode — NOT remote mode — is what keeps the camera
             // BODY awake (remote mode locks it to "Connected to computer").
             // iOS only ever uses application mode. Over USB the ZR's app-mode
@@ -914,15 +916,32 @@ public final class PTPIPClientSession: @unchecked Sendable {
             // is serviced with a concurrent event pump. The camera has no
             // GetPairingInfo/ConfirmPairing over USB (absent from its USB
             // OperationsSupported), so there is no pairing fallback here.
-            if try session.enableAppControlServicingEvents() != .ok {
-                // App mode still refused. Degrade to remote mode: the live
-                // feed works, though the camera body stays on "Connected to
-                // computer" (tracked follow-up). Better a working feed than a
-                // failed connect.
-                _ = try? session.executeTransaction(.changeCameraMode, parameters: [1])
+            try performingUSBHandshake(.appMode) {
+                if try session.enableAppControlServicingEvents() != .ok {
+                    // App mode still refused. Degrade to remote mode: the live
+                    // feed works, though the camera body stays on "Connected to
+                    // computer" (tracked follow-up). Better a working feed than a
+                    // failed connect.
+                    _ = try? session.executeTransaction(.changeCameraMode, parameters: [1])
+                }
             }
-            try session.identify()
+            try performingUSBHandshake(.identify) {
+                try session.identify()
+            }
             onPhase(.connected, session.identity.displayName)
+        }
+
+        private static func performingUSBHandshake<Result>(
+            _ stage: USBHandshakeStage,
+            _ body: () throws -> Result
+        ) throws -> Result {
+            do {
+                return try body()
+            } catch let error as USBHandshakeError {
+                throw error
+            } catch {
+                throw USBHandshakeError(stage: stage, underlying: error)
+            }
         }
     #endif
 
@@ -1033,12 +1052,14 @@ public final class PTPIPClientSession: @unchecked Sendable {
                 // an OpenSession-first sequence is held unanswered while
                 // CloseSession still answers instantly — so match the
                 // universal order. Outside a session the TransactionID is 0.
-                _ = try transport.executeTransactionSynchronously(
-                    operationCode: .getDeviceInfo,
-                    transactionID: 0,
-                    dataPhase: .dataIn,
-                    deadline: .seconds(5)
-                )
+                try performingUSBHandshake(.deviceInfo) {
+                    _ = try transport.executeTransactionSynchronously(
+                        operationCode: .getDeviceInfo,
+                        transactionID: 0,
+                        dataPhase: .dataIn,
+                        deadline: .seconds(5)
+                    )
+                }
                 try establishUSBSession(on: session, onPhase: onPhase)
                 return session
             } catch {

--- a/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
+++ b/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
@@ -1259,6 +1259,11 @@
                     session.identity.displayName, session.identity.model,
                     session.identity.serialNumber,
                 ])
+        } catch let error as USBHandshakeError {
+            ActiveSessionSlot.shared.clearPendingConnection(owner: owner)?.close()
+            transport.close()
+            callStrings(handle.onPhase, [error.diagnosticPhase, ""])
+            callStrings(handle.onFailed, [error.localizedDescription ?? "USB handshake failed."])
         } catch {
             ActiveSessionSlot.shared.clearPendingConnection(owner: owner)?.close()
             transport.close()

--- a/Sources/OpenZCineAndroidFacade/USBPTPTransactionTransport.swift
+++ b/Sources/OpenZCineAndroidFacade/USBPTPTransactionTransport.swift
@@ -51,6 +51,52 @@ enum AndroidUSBPTPTransportError: Error, LocalizedError, Equatable {
     }
 }
 
+/// Closed USB handshake stage for the privacy-safe diagnostic export.
+enum USBHandshakeStage: String, Sendable {
+    case deviceInfo = "usb.handshake.deviceInfo"
+    case openSession = "usb.handshake.openSession"
+    case appMode = "usb.handshake.appMode"
+    case identify = "usb.handshake.identify"
+}
+
+/// A USB establish failure tagged with the stage that threw, so the export
+/// names the step instead of collapsing everything into `failed.usb`.
+struct USBHandshakeError: Error, LocalizedError {
+    let stage: USBHandshakeStage
+    let underlying: Error
+
+    var diagnosticPhase: String {
+        usbHandshakeDiagnosticPhase(stage: stage, error: underlying)
+    }
+
+    var errorDescription: String? {
+        (underlying as? LocalizedError)?.errorDescription ?? String(describing: underlying)
+    }
+}
+
+/// Maps a USB handshake throw to a closed diagnostic token.
+///
+/// Transport pipe failures (write/read/timeout/closed) are more specific than
+/// the PTP stage that happened to be in flight. A camera-level rejection keeps
+/// the stage token (OpenSession, application mode, identify).
+func usbHandshakeDiagnosticPhase(stage: USBHandshakeStage, error: Error) -> String {
+    if let transport = error as? AndroidUSBPTPTransportError {
+        switch transport {
+        case .connectionClosed:
+            return "usb.handshake.closed"
+        case .writeFailed:
+            return "usb.handshake.write"
+        case .readFailed:
+            return "usb.handshake.read"
+        case .timeout:
+            return "usb.handshake.timeout"
+        default:
+            break
+        }
+    }
+    return stage.rawValue
+}
+
 /// Generic-container PTP transport over Android's platform-owned USB bytes.
 ///
 /// This type is platform-neutral so its framing and idle-event semantics run

--- a/Tests/OpenZCineAndroidFacadeTests/USBPTPTransactionTransportTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/USBPTPTransactionTransportTests.swift
@@ -213,6 +213,34 @@ struct USBPTPTransactionTransportTests {
         #expect(raw.isClosed())
         #expect(finished.wait(timeout: .now() + 1) == .success)
     }
+
+    @Test func usbHandshakeWriteFailureIsAClosedDiagnosticToken() {
+        #expect(
+            usbHandshakeDiagnosticPhase(
+                stage: .openSession,
+                error: AndroidUSBPTPTransportError.writeFailed(expected: 12, actual: -1)
+            ) == "usb.handshake.write")
+        #expect(
+            usbHandshakeDiagnosticPhase(
+                stage: .deviceInfo,
+                error: AndroidUSBPTPTransportError.timeout("the camera response")
+            ) == "usb.handshake.timeout")
+        #expect(
+            usbHandshakeDiagnosticPhase(
+                stage: .appMode,
+                error: AndroidUSBPTPTransportError.connectionClosed
+            ) == "usb.handshake.closed")
+    }
+
+    @Test func usbHandshakeCameraRejectionKeepsTheStageToken() {
+        struct CameraRejected: Error {}
+        #expect(
+            usbHandshakeDiagnosticPhase(stage: .openSession, error: CameraRejected())
+                == "usb.handshake.openSession")
+        #expect(
+            usbHandshakeDiagnosticPhase(stage: .identify, error: CameraRejected())
+                == "usb.handshake.identify")
+    }
 }
 
 private func response(transactionID: UInt32) -> [UInt8] {


### PR DESCRIPTION
Fixes #315.

## What was happening

Field reports (Redmi K90 Ultra, Android 16, and a later 0.2.5 / API 36 export) showed USB permission succeeding, then `connection.handshaking` collapsing into `error.connection.usb.failed`. The original diagnostic is more specific than the title: handshake *did* complete once, the monitor appeared, then `error.connection.event-channel-ended` and every reconnect failed in ~1 ms.

Two Android-only USB-host bugs stacked:

1. **Dead transport reuse.** USB events share the claimed interface, so an interrupt failure correctly closes the transport. Monitor recovery then called `connect()` on the same session and handed that closed handle back to JNI.
2. **Oversized heap interrupt URBs.** Swift asked the event endpoint for a 256 KiB bulk-style chunk on a heap `ByteBuffer`. Some OEM host controllers (notably Qualcomm on HyperOS) reject that after OpenSession already succeeded, so the event channel dies a few milliseconds later.

## What changed

- Re-open a live, permissioned USB interface on reconnect instead of reusing a closed transport.
- Queue one-packet **direct** interrupt URBs; Swift still assembles multi-packet PTP event containers.
- Keep the handshake / open stage in the privacy-safe diagnostic export (`usb.open.*`, `usb.handshake.*`, `usb.reconnect.*`) instead of only `error.connection.usb.failed`.

## Platform

Android USB Host only. iOS uses a different USB stack; there is no matching shell change.

## Test plan

- [x] JVM: USB event teardown no longer reuses a closed transport; a reopener supplies a fresh one
- [x] JVM: interrupt URBs are one packet; payloads copy out of a direct buffer
- [x] JVM: handshake / open stages map to distinct closed diagnostic codes
- [x] Swift: transport write/timeout/closed map to closed handshake tokens; camera rejections keep the stage
- [x] `just android-check`
- [x] `just native-check`
- [ ] Hardware: USB-C on a Snapdragon 8 Elite / HyperOS phone (K90 Ultra if available) — grant permission, confirm connect stays up, unplug/replug, and export diagnostics if it still fails
- [ ] Hardware: a phone that already connects (e.g. Redmi Note 12 Pro) still pairs over USB-C