### PR TITLE
fix: original Z6 connect skips pairing when DeviceInfo is missing

### DIFF
--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,6 +1,6 @@
+- Fixed: original Z 6, Z 5, and Z 7 connect without pairing steps they do not support.
 - Fixed: USB-C connect after Android grants permission. If the picture came up then dropped, or retry failed immediately, try the cable again — it should stay up.
 - Fixed: Aperture-priority shutter and ISO on the phone follow the camera as it meters.
 - Fixed: photo FOCUS and taps follow stills AF, not leftover video AF-F.
 - New: Media has REFRESH. After a format it follows the card, not old names; Clear Cache reloads Media from the camera.
 - Fixed: Share and Save to Photos work on clips from the camera.
-- Fixed: Share in playback is available while the camera is still connected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,11 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- **Original Z 6 / Z 5 / Z 7 connect no longer sends pairing or ChangeApplicationMode when
+  DeviceInfo is missing.** Those bodies have no pairing handshake; polling it is what put a
+  wireless error on the camera and left the app connecting. The PTP-IP name or USB product name
+  now selects the gen-1 app-mode property write instead. iOS USB also probes GetDeviceInfo
+  before OpenSession, matching Android. Cable-pairing copy on iPad no longer says iPhone.
 - **Aperture-priority (and other auto-exposure) shutter and ISO no longer sit stale.** Nikon
   often does not announce those camera-owned changes on `DevicePropChanged`, so after the first
   #268 fix a photo A-mode body could show 1/30 · ISO 1000 while the app still read 1/125 · A900.
@@ -113,7 +118,6 @@ All notable changes to this project are documented here. The format is based on
 - Playback Share is available while the camera is connected. The delivery run caches the clip
   from the camera first; disconnecting and opening Operator Setup media is no longer required
   (iOS and Android).
-
 - A stills-side focus-mode event no longer repaints the movie FOCUS readout or makes feed taps
   fire a one-shot AF drive on a body running continuous AF — the two modes were decoding into
   one field, last writer wins (both platforms).

--- a/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
+++ b/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
@@ -904,6 +904,7 @@ public final class PTPIPClientSession: @unchecked Sendable {
         /// streams 24 fps, full metadata.]
         private static func establishUSBSession(
             on session: PTPIPClientSession,
+            policy: ZCameraOperationPolicy,
             onPhase: (CameraConnectionPhase, String) -> Void
         ) throws {
             try performingUSBHandshake(.openSession) {
@@ -916,8 +917,10 @@ public final class PTPIPClientSession: @unchecked Sendable {
             // is serviced with a concurrent event pump. The camera has no
             // GetPairingInfo/ConfirmPairing over USB (absent from its USB
             // OperationsSupported), so there is no pairing fallback here.
+            // App-control must follow the probed/name-fallback policy: sending
+            // ChangeApplicationMode at a gen-1 Z 6 is the USB twin of #292/#348.
             try performingUSBHandshake(.appMode) {
-                if try session.enableAppControlServicingEvents() != .ok {
+                if try session.enableAppControlServicingEvents(policy: policy) != .ok {
                     // App mode still refused. Degrade to remote mode: the live
                     // feed works, though the camera body stays on "Connected to
                     // computer" (tracked follow-up). Better a working feed than a
@@ -1052,15 +1055,22 @@ public final class PTPIPClientSession: @unchecked Sendable {
                 // an OpenSession-first sequence is held unanswered while
                 // CloseSession still answers instantly — so match the
                 // universal order. Outside a session the TransactionID is 0.
-                try performingUSBHandshake(.deviceInfo) {
-                    _ = try transport.executeTransactionSynchronously(
+                let probe = try performingUSBHandshake(.deviceInfo) {
+                    try transport.executeTransactionSynchronously(
                         operationCode: .getDeviceInfo,
                         transactionID: 0,
                         dataPhase: .dataIn,
                         deadline: .seconds(5)
                     )
                 }
-                try establishUSBSession(on: session, onPhase: onPhase)
+                var policy = ZCameraOperationPolicy(operations: [])
+                if probe.operationResponse.responseCode == .ok,
+                    let info = try? PTPDeviceInfo(data: probe.data)
+                {
+                    policy = ZCameraOperationPolicy(deviceInfo: info)
+                }
+                policy = policy.resolvingUnknown(cameraName: cameraNameHint)
+                try establishUSBSession(on: session, policy: policy, onPhase: onPhase)
                 return session
             } catch {
                 session.disconnect()
@@ -1138,13 +1148,16 @@ public final class PTPIPClientSession: @unchecked Sendable {
     /// own screen (#292). Best-effort: a failed fetch yields an unknown policy, which keeps the
     /// modern-surface behaviour on every path. [verify-on-HW: Z 5 over camera AP]
     private func probeOperationPolicy() -> ZCameraOperationPolicy {
-        guard let probe = try? executeTransaction(.getDeviceInfo, dataPhase: .dataIn),
+        let probed: ZCameraOperationPolicy
+        if let probe = try? executeTransaction(.getDeviceInfo, dataPhase: .dataIn),
             probe.operationResponse.responseCode == .ok,
             let info = try? PTPDeviceInfo(data: probe.data)
-        else {
-            return ZCameraOperationPolicy(operations: [])
+        {
+            probed = ZCameraOperationPolicy(deviceInfo: info)
+        } else {
+            probed = ZCameraOperationPolicy(operations: [])
         }
-        return ZCameraOperationPolicy(deviceInfo: info)
+        return probed.resolvingUnknown(cameraName: identity.cameraName)
     }
 
     /// Nikon app-control gate. `true` when the camera accepted app control —
@@ -1181,8 +1194,10 @@ public final class PTPIPClientSession: @unchecked Sendable {
         /// stalls; our establish is single-threaded, so pump events here. The
         /// event endpoint has its own lock — this never blocks the command
         /// pipe carrying the app-mode request itself.
-        func enableAppControlServicingEvents() throws -> PTPResponseCode {
-            guard let usbTransport else { return try enableAppControlResponse() }
+        func enableAppControlServicingEvents(
+            policy: ZCameraOperationPolicy = ZCameraOperationPolicy(operations: [])
+        ) throws -> PTPResponseCode {
+            guard let usbTransport else { return try enableAppControlResponse(policy: policy) }
             let pump = USBEventPumpFlag()
             Thread.detachNewThread {
                 while !pump.stopRequested {
@@ -1190,7 +1205,7 @@ public final class PTPIPClientSession: @unchecked Sendable {
                 }
             }
             defer { pump.requestStop() }
-            return try enableAppControlResponse()
+            return try enableAppControlResponse(policy: policy)
         }
     #endif
 

--- a/Sources/OpenZCineCore/ZCameraCapabilityProfile.swift
+++ b/Sources/OpenZCineCore/ZCameraCapabilityProfile.swift
@@ -83,6 +83,60 @@ public struct ZCameraOperationPolicy: Equatable, Sendable {
 
     /// Parameter for `GetVendorCodes` selecting the vendor DevicePropCode array.
     public static let vendorCodesPropertyListParameter: UInt32 = 0x0D
+
+    /// Conservative gen-1 OperationsSupported used only when DeviceInfo did not
+    /// arrive and the handshake / USB product name is an original Z 5 / Z 6 / Z 7 / Z 50.
+    ///
+    /// This is not a model table for op selection on a live body — advertised ops still
+    /// win. It exists so a failed probe cannot fall through to GetPairingInfo /
+    /// ChangeApplicationMode, which is how a gen-1 body shows a wireless error (#292)
+    /// and how an original Z 6 fails to connect (#348).
+    public static let generation1FallbackOperations: Set<UInt16> = [
+        0x90CA, 0x90C2, 0x9201, 0x9202, 0x9203, 0x9428, 0x90C7, 0x941C, 0x90C8,
+        0x100E, 0x9207, 0x90C0, 0x90CB, 0x920C,
+    ]
+
+    /// When DeviceInfo was not fetched, use a gen-1 surface if the camera name is an
+    /// original Z 5 / Z 6 / Z 7 / Z 50. Later bodies and unknown names keep the
+    /// modern-surface default so a failed probe cannot lock a gen-3 body out of pairing.
+    public func resolvingUnknown(cameraName: String?) -> ZCameraOperationPolicy {
+        guard !isKnown else { return self }
+        guard let cameraName, ZCameraBodyGeneration.inferred(fromCameraName: cameraName) == .one
+        else { return self }
+        return ZCameraOperationPolicy(operations: Self.generation1FallbackOperations)
+    }
+}
+
+/// Coarse Z-lineup generation inferred from a PTP-IP friendly name, USB product
+/// name, or camera-AP SSID. Used only when DeviceInfo is missing.
+public enum ZCameraBodyGeneration: Equatable, Sendable {
+    /// Z 5 / Z 6 / Z 7 / Z 50 — property app-mode, no pairing handshake.
+    case one
+    /// Z 6II / Z 7II / Z fc / Z 30 — ChangeApplicationMode, still no Ex ops.
+    case two
+    /// Z 8 / Z 9 / Z 6III / Z f / Z 5II / Z 50II / ZR — modern vendor + pairing surface.
+    case three
+
+    /// Longest-token match so "Z 6III" is not classified as the original Z 6.
+    public static func inferred(fromCameraName raw: String) -> ZCameraBodyGeneration? {
+        let compact = raw.uppercased().replacingOccurrences(of: "NIKON", with: "").filter {
+            $0.isLetter || $0.isNumber
+        }
+        guard !compact.isEmpty else { return nil }
+        let tokens: [(token: String, generation: ZCameraBodyGeneration)] = [
+            ("Z6III", .three), ("Z7III", .three),
+            ("Z50II", .three), ("Z5II", .three),
+            ("Z6II", .two), ("Z7II", .two),
+            ("ZFC", .two), ("Z30", .two),
+            ("Z50", .one),
+            ("ZR", .three), ("Z8", .three), ("Z9", .three), ("ZF", .three),
+            ("Z5", .one), ("Z6", .one), ("Z7", .one),
+        ]
+        for entry in tokens where compact.contains(entry.token) {
+            return entry.generation
+        }
+        return nil
+    }
 }
 
 /// Decodes the vendor property-code array returned by the vendor discovery ops:

--- a/Tests/OpenZCineAndroidFacadeTests/PTPIPClientSessionTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/PTPIPClientSessionTests.swift
@@ -184,6 +184,34 @@ struct PTPIPClientSessionTests {
         #expect(write?.data == Data([1]))
     }
 
+    /// #348: original Z 6 over Wi-Fi whose DeviceInfo ops list is empty (probe failed or
+    /// MTP-shaped) still must not be polled with GetPairingInfo / ChangeApplicationMode —
+    /// the Init ACK name is enough to take the gen-1 path.
+    @Test func generation1HandshakeNameConnectsWithoutPairingWhenDeviceInfoOpsAreUnknown() throws {
+        var options = FakeZRServer.Options()
+        options.cameraName = "Z 6_1234567"
+        options.model = "Z 6"
+        options.advertisedOperations = []
+        let server = try FakeZRServer(options: options)
+        defer { server.stop() }
+
+        var phases: [CameraConnectionPhase] = []
+        let session = try connect(to: server, strategy: .firstTimePairing) { phase, _ in
+            phases.append(phase)
+        }
+        defer { session.disconnect() }
+
+        #expect(phases == [.handshaking, .connected])
+        let operations = server.receivedOperations()
+        #expect(!operations.contains(.getPairingInfo))
+        #expect(!operations.contains(.confirmPairing))
+        #expect(!operations.contains(.changeApplicationMode))
+        #expect(operations.prefix(3) == [.openSession, .getDeviceInfo, .setDevicePropValue])
+        let write = server.receivedPropertyWrites().first
+        #expect(write?.property == PTPPropertyCode.applicationMode.rawValue)
+        #expect(write?.data == Data([1]))
+    }
+
     @Test func savedProfileRejectsWithoutStartingFirstTimePairing() throws {
         var options = FakeZRServer.Options()
         options.acceptsAppControlImmediately = false

--- a/Tests/OpenZCineCoreTests/ZCameraCapabilityProfileTests.swift
+++ b/Tests/OpenZCineCoreTests/ZCameraCapabilityProfileTests.swift
@@ -53,6 +53,38 @@ struct ZCameraCapabilityProfileTests {
         #expect(policy.supportsPairing)
     }
 
+    /// #348 / residual of #292: when DeviceInfo never arrives, the handshake or USB
+    /// product name is the only generation signal. Original Z 6 / Z 5 / Z 7 / Z 50
+    /// names must not keep the modern pairing + ChangeApplicationMode surface.
+    @Test func unknownOpsWithGeneration1NameUsePropertyAppModeAndSkipPairing() {
+        for name in ["Z 6_1234567", "Z6_1234567", "Nikon Z 6", "NIKON_Z6_01234", "Z 5_7654321"] {
+            let policy = ZCameraOperationPolicy(operations: []).resolvingUnknown(cameraName: name)
+            #expect(policy.isKnown, "name: \(name)")
+            #expect(!policy.appModeViaOperation, "name: \(name)")
+            #expect(!policy.supportsPairing, "name: \(name)")
+            #expect(policy.vendorCodeDiscoveryOperation == .getVendorPropCodes, "name: \(name)")
+        }
+    }
+
+    @Test func unknownOpsWithLaterGenerationNameKeepModernPairingSurface() {
+        for name in [
+            "ZR_6001234", "Z 6III_1234567", "Z 6II_1234567", "Z 5II_123", "NIKON_ZR_01234",
+        ] {
+            let policy = ZCameraOperationPolicy(operations: []).resolvingUnknown(cameraName: name)
+            #expect(!policy.isKnown, "name: \(name)")
+            #expect(policy.supportsPairing, "name: \(name)")
+            #expect(policy.appModeViaOperation, "name: \(name)")
+        }
+    }
+
+    @Test func advertisedOpsAreNotOverriddenByAGeneration1Name() {
+        let policy = ZCameraOperationPolicy(operations: Self.gen3Ops.union([0x952B]))
+            .resolvingUnknown(cameraName: "Z 6_1234567")
+        #expect(policy.supportsPairing)
+        #expect(policy.appModeViaOperation)
+        #expect(policy.supportsExtendedPropertyOps)
+    }
+
     @Test func missingMediaCaptureFallsBackToStandardCapture() {
         let policy = ZCameraOperationPolicy(operations: [0x100E])
         #expect(policy.stillCaptureOperation == .initiateCapture)

--- a/docs/investigations/debug/z6-firmware-3.80-ipad-connect.md
+++ b/docs/investigations/debug/z6-firmware-3.80-ipad-connect.md
@@ -1,0 +1,61 @@
+---
+status: awaiting_hardware_verify
+trigger: "Nikon Z6 firmware 3.80 cannot connect from iPad Pro via USB or Wi-Fi (#348)"
+created: 2026-08-23
+updated: 2026-08-23
+---
+
+## Current Focus
+
+hypothesis: PARTIAL — gen-1 connect still assumed a modern pairing surface whenever
+`GetDeviceInfo` did not advertise operations, which an original Z 6 (same generation as the
+Z 5 in #292) can hit on both USB and Wi-Fi
+next_action: Hardware matrix on an original Z 6 firmware 3.80, starting with iPad Pro (2018)
+USB-C and Connect-to-computer Wi-Fi
+
+## Report
+
+- Nikon Z 6, firmware 3.80 (untested in the compatibility matrix)
+- iPad Pro (2018), TestFlight identity iPad8,3, iPadOS 26.6.1
+- OpenZCine 0.2.5 (build 260), which already includes the #292 gen-1 DeviceInfo gate
+- USB does not complete; no attempted Wi-Fi method completes
+- No diagnostics export or exact in-app phase yet
+
+## Ranked hypotheses
+
+1. **Unknown DeviceInfo keeps the modern surface.** `ZCameraOperationPolicy` treats an empty
+   ops list as gen 3, so first-time Wi-Fi still sends `GetPairingInfo` / `ChangeApplicationMode`.
+   That is the #292 failure mode when the probe is missing, not merely when the ops list is
+   the gen-1 set. Confirmed in a FakeZR loop: handshake name `Z 6_…` with empty ops previously
+   paired; after the fix it writes `ApplicationMode` and never pairs.
+2. **iOS USB OpenSession-first.** Android USB already issues `GetDeviceInfo` (transaction 0)
+   before `OpenSession` because OpenSession-first hung on the cable. iOS relied on
+   ImageCaptureCore having opened the session. If ICC does not pre-open an original Z 6,
+   the 180 s first command is an unexplained “Connecting…”.
+3. **Android USB ignored the probe for app-control.** The pre-session `GetDeviceInfo` was
+   discarded; app-control always used the empty/modern policy (`ChangeApplicationMode`).
+4. **Wrong Wi-Fi menu.** SnapBridge / Connect to smart device is not PTP-IP. The wizard
+   already points at Connect to computer; still possible operator path. Not a code defect
+   if that was the method used.
+5. **iPad USB never enumerates** (charge-only cable, Photos claiming the device, camera
+   control denied). Copy now says “this device” instead of iPhone; authorization recovery
+   already exists.
+
+## Code change
+
+- Shared: `ZCameraOperationPolicy.resolvingUnknown(cameraName:)` takes the gen-1 surface
+  when DeviceInfo is unknown and the PTP-IP / USB name is an original Z 5 / Z 6 / Z 7 / Z 50.
+  `Z 6III` / `Z 6II` / `ZR` keep the modern pairing default.
+- iOS: USB probes `GetDeviceInfo` before `OpenSession`; both transports apply the name
+  fallback. Establishment diagnostics record `gateFallback=gen1-name`.
+- Android facade: Wi-Fi probe applies the same fallback; USB parses the pre-session
+  DeviceInfo and passes that policy into app-control.
+
+## Not verified on hardware
+
+Support status remains **untested**. Do not mark the Z 6 working on the landing page until
+USB and Connect-to-computer Wi-Fi complete on a real body.
+
+Still needed from the reporter: privacy-safe diagnostics, USB cable/mode, which Wi-Fi
+method, whether Nikon’s app connects from this iPad, and whether another iPhone/iPad can
+reach the same Z 6.

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -584,7 +584,7 @@ final class NativeAppModel {
             case .usbC:
                 DeviceUSBConnector.current == .lightning
                     ? "Connect through Apple's Lightning to USB camera adapter — a USB-C to Lightning cable can't host the camera."
-                    : "Plug the camera into this iPhone with a USB-C cable."
+                    : "Plug the camera into this device with a USB-C cable."
             case .hdmiCapture:
                 "Feed the camera's HDMI output into a USB capture device — full-quality picture, no camera control."
             case .wiFiNetwork:

--- a/ios/Runner/NativeCameraSession.swift
+++ b/ios/Runner/NativeCameraSession.swift
@@ -1291,12 +1291,35 @@ final class NativeCameraSession: @unchecked Sendable {
         // which scales with card fullness (thousands of stills = minutes, not seconds) — the 15 s
         // wedge backstop would mistake that wait for a dead camera. Wi-Fi keeps the short deadline.
         // [verify-on-HW: ZR over USB-C with a full card]
+        //
+        // USB matches libgphoto2 / Android: GetDeviceInfo is valid outside a session. An
+        // OpenSession-first sequence has been observed to hang unanswered on the cable until
+        // CloseSession; ICC often already opened the session, in which case this probe is a
+        // normal in-session GetDeviceInfo. Keep the deadline short so a wedged probe cannot
+        // eat the 180 s USB first-command budget. [verify-on-HW: Z 6 over USB-C on iPad]
+        let isUSB = transport.kind == .usb
+        var gatePolicy = ZCameraOperationPolicy(operations: [])
+        if isUSB {
+            onStage?("capability probe")
+            if let probe = try? await transact(
+                operationCode: .getDeviceInfo,
+                transactionID: 0,
+                dataPhase: .dataIn,
+                deadline: .seconds(8)
+            ),
+                probe.operationResponse.responseCode == .ok,
+                let probedInfo = try? PTPDeviceInfo(data: probe.data)
+            {
+                gatePolicy = ZCameraOperationPolicy(deviceInfo: probedInfo)
+            }
+        }
+
         onStage?("first command (OpenSession)")
         let open = try await transact(
             operationCode: .openSession,
             transactionID: 0,
             parameters: [1],
-            deadline: transport.kind == .usb ? .seconds(180) : Self.commandTransactionTimeout
+            deadline: isUSB ? .seconds(180) : Self.commandTransactionTimeout
         )
         // `Session_Already_Open` is success: over USB, ImageCaptureCore opens the PTP session
         // itself before handing the device to the app. [VERIFY-ON-HW] on the ZR over USB-C.
@@ -1305,28 +1328,34 @@ final class NativeCameraSession: @unchecked Sendable {
             throw NativeCameraSessionError.operationRejected(.openSession, openResponse)
         }
 
-        // DeviceInfo FIRST, before pairing or the app-control switch, because both must be gated
+        // DeviceInfo before pairing or the app-control switch, because both must be gated
         // on what this body actually advertises. Sending gen-3 operations at a gen-1 body isn't a
         // harmless rejection — a Z 5 polled with a pairing op it never implemented put a wireless
         // error on its own screen while the app spun (#292). GetDeviceInfo itself is the one
         // operation every generation answers from a fresh session. Best-effort: a failed fetch
-        // yields an unknown policy, which keeps today's modern-surface behaviour on every path.
-        // [verify-on-HW: Z 5 over camera AP; ZR unpaired first-connect still reaches the PIN]
-        onStage?("capability probe")
-        var gatePolicy = ZCameraOperationPolicy(operations: [])
-        if let probe = try? await transact(operationCode: .getDeviceInfo, dataPhase: .dataIn),
-            probe.operationResponse.responseCode == .ok,
-            let probedInfo = try? PTPDeviceInfo(data: probe.data)
-        {
-            gatePolicy = ZCameraOperationPolicy(deviceInfo: probedInfo)
+        // yields an unknown policy, then a gen-1 handshake/USB name (#348) takes the property
+        // app-mode path instead of pairing. [verify-on-HW: Z 5 / Z 6 over camera AP; ZR unpaired
+        // first-connect still reaches the PIN]
+        if !gatePolicy.isKnown {
+            onStage?("capability probe")
+            if let probe = try? await transact(operationCode: .getDeviceInfo, dataPhase: .dataIn),
+                probe.operationResponse.responseCode == .ok,
+                let probedInfo = try? PTPDeviceInfo(data: probe.data)
+            {
+                gatePolicy = ZCameraOperationPolicy(deviceInfo: probedInfo)
+            }
         }
+        let probedKnown = gatePolicy.isKnown
+        gatePolicy = gatePolicy.resolvingUnknown(cameraName: cameraName)
         establishmentSummary += "gateOps=\(gatePolicy.isKnown ? "known" : "unknown") "
+        if !probedKnown, gatePolicy.isKnown {
+            establishmentSummary += "gateFallback=gen1-name "
+        }
 
         // USB has no pairing surface: GetPairingInfo/ConfirmPairing are absent from the camera's
         // USB OperationsSupported, so polling them only times the connect out — the cable itself is
         // the trust boundary. [verify-on-HW: ZR over USB-C] Gen-1 bodies have no pairing surface
         // over the network either; joining their access point is the trust boundary there.
-        let isUSB = transport.kind == .usb
         if requestPairing, !isUSB, gatePolicy.supportsPairing {
             onStage?("pairing")
             try await completePairing(onPairingChallenge: onPairingChallenge)

--- a/ios/Runner/StartupDesign.swift
+++ b/ios/Runner/StartupDesign.swift
@@ -1742,7 +1742,7 @@ enum StartupWizardContent {
         case .usbC:
             return [
                 "In the camera's setup menu, set USB to MTP/PTP.",
-                "Connect the USB‑C cable between the camera and your iPhone.",
+                "Connect the USB‑C cable between the camera and this device.",
                 "Leave the camera switched on — no network profile is needed.",
             ]
         case .wiFiNetwork:
@@ -1810,11 +1810,11 @@ enum StartupWizardContent {
                     device: .camera,
                     steps: tight
                         ? [
-                            "Plug the camera into this iPhone with USB-C",
+                            "Plug the camera into this device with USB-C",
                             "Confirm any connection prompt on the camera",
                         ]
                         : [
-                            "Plug the camera into this iPhone with a USB-C cable",
+                            "Plug the camera into this device with a USB-C cable",
                             "If the camera shows a connection prompt, confirm it",
                         ]
                 ),
@@ -1874,7 +1874,7 @@ enum StartupWizardContent {
         case .usbC:
             return tight
                 ? "Plug in the cable, allow camera access, then find your camera."
-                : "Connect the cable, confirm the camera's prompt, and allow camera access on this iPhone when asked."
+                : "Connect the cable, confirm the camera's prompt, and allow camera access on this device when asked."
         case .wiFiNetwork:
             return tight
                 ? "Put both on the same network, then find the camera."

--- a/ios/RunnerTests/FirstPairWizardStepTests.swift
+++ b/ios/RunnerTests/FirstPairWizardStepTests.swift
@@ -38,6 +38,18 @@ struct FirstPairWizardStepTests {
                 transport: .cameraAccessPoint, skipsPermissions: true) == 3)
     }
 
+    @Test("USB-C prepare and network copy is device-neutral for iPad")
+    func usbCopyDoesNotAssumeIPhone() {
+        let steps = StartupWizardContent.preparationSteps(for: .usbC).joined(separator: " ")
+        #expect(!steps.localizedCaseInsensitiveContains("iPhone"))
+        let network = StartupWizardContent.networkSections(for: .usbC, tight: false)
+            .flatMap(\.steps).joined(separator: " ")
+        #expect(!network.localizedCaseInsensitiveContains("iPhone"))
+        #expect(
+            !StartupWizardContent.networkSubtitle(for: .usbC, tight: false)
+                .localizedCaseInsensitiveContains("iPhone"))
+    }
+
     @Test("Phone Hotspot and USB-C keep five steps when permissions are shown")
     func hotspotAndUSBWithPermissions() {
         for transport: NativeAppModel.FirstPairTransportMethod in [.phoneHotspot, .usbC] {

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -9,6 +9,7 @@ New and changed
 
 Fixes
 
+- Original Z 6, Z 5, and Z 7 no longer get pairing steps they do not support. iPad USB-C copy says this device, not iPhone.
 - Format a card and Media used to keep the old clip names. REFRESH now follows the card, and Settings > Clear Cache reloads Media from the card.
 - Share and Save to Photos work on clips from the camera. They used to fail with "Invalid sample cursor".
 - Share on the player is available while the camera is connected. You no longer have to disconnect and go through Operator Setup to reach it.
@@ -28,6 +29,7 @@ What to test
 - Save the same body on two different Wi-Fi networks. Each should stay its own setup with its own Stream Preset and Quality Bias, and renaming one should not touch the other.
 - Turn the camera on its side, then turn Auto-Rotate Feed off in Settings > Controls: the picture should stay put. Turn it back on and the picture should stand up. Then flip the iPhone to the opposite landscape: picture and controls swap sides, nothing under the island.
 - Turn on Share This Feed, ask for control from the second device, and start a take from it. Then screen-record on the sharing device and check the watcher stays with the action.
+- If you have an original Z 6, Z 5, or Z 7, connect over USB-C and the camera's own Wi-Fi. It should reach the monitor without a wireless error on the camera.
 - Watch a dim high-ISO shot with Feed Noise Reduction on and off, then step the Feed Upscaler through Fast, Quality and AI on the same framing.
 - Put the body in Aperture-priority photo, change the light, and check shutter and ISO on the phone match the camera. With full-time AF for video, change stills focus settings and tap the feed: FOCUS should hold.
 - Set stills AF-S and video full-time AF. Photo FOCUS should match the Focus panel, not leftover AF-F. Pull the focus dial, then tap: it should focus without a half-press. Set the clock a minute off, connect, and check it corrects.


### PR DESCRIPTION
## What & why

[#348](https://github.com/erik-sutton95/OpenZCine/issues/348) — original Nikon Z 6 firmware 3.80 cannot connect from an iPad Pro (2018) over USB or Wi-Fi. The Z 6 is the same generation as the Z 5 in #292: no pairing handshake, app control is a write to `ApplicationMode`.

Build 260 already had the #292 DeviceInfo gate, but that only fired when the body *advertised* the gen-1 op set. An empty or failed probe still assumed a modern surface and sent `GetPairingInfo` / `ChangeApplicationMode` — the wireless-error path on a gen-1 body.

This PR:

- Falls back to the gen-1 surface from the PTP-IP / USB product name when DeviceInfo is unknown (`Z 5` / `Z 6` / `Z 7` / `Z 50` only; `Z 6III` / `ZR` keep pairing).
- Probes `GetDeviceInfo` before `OpenSession` on iOS USB (Android already did).
- Passes the probed policy into Android USB app-control instead of discarding it.
- Makes iPad USB-C pairing copy say “this device”, not iPhone.

Support status stays **untested**. Do not mark the Z 6 working until USB and Connect-to-computer Wi-Fi complete on a real body. Not closing #348 for that reason.

Kaneo: OPE-167

## TestFlight notes

Updated `ios/TestFlight/WhatToTest.en-US.txt`.

## Google Play notes

Updated `Apps/Android/distribution/whatsnew/whatsnew-en-US`.

## Test plan

- [x] `just check`
- [x] `just native-check` (iOS + shared Swift)
- [x] `just android-check`
- [x] FakeZR: handshake name `Z 6_…` with empty DeviceInfo ops writes `ApplicationMode` and never pairs; `ZR` / `Z 6III` still pair
- [ ] **[VERIFY-ON-HW]** Original Z 6 firmware 3.80 over USB-C from an iPad (MTP/PTP, data cable, camera access allowed)
- [ ] **[VERIFY-ON-HW]** Same body over camera AP: Network → Connect to computer → Direct connection (not SnapBridge)
- [ ] ZR / Z 6III unpaired first-connect still reaches the PIN

## Checklist

- [x] `just check` passes.
- [x] Native production changes: `just native-check` passes.
- [x] Android production changes: `just android-check` passes.
- [x] Commits follow Conventional Commits.
- [x] No proprietary assets (`vendor/`, `ref/`) are included.
- [x] Docs/CHANGELOG updated if behavior or setup changed.
- [x] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy.
- [x] Play-triggering changes include reviewed `Apps/Android/distribution/whatsnew/whatsnew-en-US` copy.