### PR TITLE
docs: trim TestFlight and Play notes after the batch merge

### DIFF
--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,6 +1,5 @@
 - Fixed: original Z 6, Z 5, and Z 7 connect without pairing steps they do not support.
-- Fixed: USB-C connect after Android grants permission. If the picture came up then dropped, or retry failed immediately, try the cable again — it should stay up.
+- Fixed: USB-C connect after permission. If the picture came up then dropped, retry should stay up.
 - Fixed: Aperture-priority shutter and ISO on the phone follow the camera as it meters.
 - Fixed: photo FOCUS and taps follow stills AF, not leftover video AF-F.
-- New: Media has REFRESH. After a format it follows the card, not old names; Clear Cache reloads Media from the camera.
-- Fixed: Share and Save to Photos work on clips from the camera.
+- New: Media has REFRESH. After a format it follows the card; Clear Cache reloads from the camera.

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -14,23 +14,14 @@ Fixes
 - Share and Save to Photos work on clips from the camera. They used to fail with "Invalid sample cursor".
 - Share on the player is available while the camera is connected. You no longer have to disconnect and go through Operator Setup to reach it.
 - On iPad in photo mode, the battery gauges sit beside the lock instead of covering PLAY.
-- A camera whose clock has drifted is set to your phone's time on connect - automatically, never while recording.
 - Photo FOCUS follows stills AF, not leftover video AF-F. After a focus-dial pull, a tap focuses without a half-press.
-- Changing stills focus settings no longer flips the video FOCUS readout or makes taps refocus single-shot on a camera set to full-time AF.
-- A weak or busy link degrades the picture instead of dropping the session, and screen recording while you share your feed no longer walks the watcher's picture behind the action.
-- A watcher granted camera control can now start and stop the take, and keeps that control through a brief drop-out instead of losing it the moment the link stutters.
 - Aperture-priority shutter and ISO follow the camera as it meters - they used to sit stale, take twenty seconds, or in video never.
-- Unplugging the cable or power-cycling the camera used to wedge the app. Both recover on their own, or offer Retry connection.
+- A camera whose clock has drifted is set to your phone's time on connect - automatically, never while recording.
 
 What to test
 
+- If you have an original Z 6, Z 5, or Z 7, connect over USB-C and the camera's own Wi-Fi. It should reach the monitor without a wireless error on the camera.
 - Format a spare card or delete a shot, then tap REFRESH on Media: gone files leave and new ones show. Clear Cache in Settings and reopen Media to rebuild from the card.
 - Connect to the camera, play a clip, tap Share, then Share and Save to Photos. Both should finish. You should not have to disconnect first.
-- Save the same body on two different Wi-Fi networks. Each should stay its own setup with its own Stream Preset and Quality Bias, and renaming one should not touch the other.
-- Turn the camera on its side, then turn Auto-Rotate Feed off in Settings > Controls: the picture should stay put. Turn it back on and the picture should stand up. Then flip the iPhone to the opposite landscape: picture and controls swap sides, nothing under the island.
-- Turn on Share This Feed, ask for control from the second device, and start a take from it. Then screen-record on the sharing device and check the watcher stays with the action.
-- If you have an original Z 6, Z 5, or Z 7, connect over USB-C and the camera's own Wi-Fi. It should reach the monitor without a wireless error on the camera.
-- Watch a dim high-ISO shot with Feed Noise Reduction on and off, then step the Feed Upscaler through Fast, Quality and AI on the same framing.
-- Put the body in Aperture-priority photo, change the light, and check shutter and ISO on the phone match the camera. With full-time AF for video, change stills focus settings and tap the feed: FOCUS should hold.
-- Set stills AF-S and video full-time AF. Photo FOCUS should match the Focus panel, not leftover AF-F. Pull the focus dial, then tap: it should focus without a half-press. Set the clock a minute off, connect, and check it corrects.
-- On an iPad (especially mini) in landscape photo mode, PLAY and the rest of the left tool column should be fully visible and tappable, with the battery gauges beside the lock — not on top of PLAY.
+- Put the body in Aperture-priority photo, change the light, and check shutter and ISO on the phone match the camera.
+- Set stills AF-S and video full-time AF. Photo FOCUS should match the Focus panel, not leftover AF-F. Pull the focus dial, then tap: it should focus without a half-press.


### PR DESCRIPTION
## What & why

Landing #343–#350 stacked every tester note into `ios/TestFlight/WhatToTest.en-US.txt` and the Play whatsnew file. Main CI Meta checks failed: What to Test was 5281 characters (limit 4000) with too many Fixes / What to test bullets, and Play notes were 596 characters with six bullets (limit 500 / 5).

This keeps the newest operator-facing items from that batch and drops the overflow so the notes checkers pass.

## Test plan

- [x] `./scripts/ios-release-notes-check.sh`
- [x] `./scripts/ios-release-notes-test.sh`
- [x] `./scripts/android-play-release-notes-check.sh`

## Checklist

- [x] Commits follow Conventional Commits.
- [x] No proprietary assets.
- [x] Docs/CHANGELOG: notes only; no product behaviour change.