### PR TITLE
fix(ios): finish LUT export when a Nikon proxy's media is truncated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,10 @@ All notable changes to this project are documented here. The format is based on
 - Native Share and Save to Photos no longer fail with AVFoundation `Invalid sample cursor` on
   Nikon proxy clips. Export now strips the camera timecode track before the session, uses the
   stable export path, and restores timecode afterwards (iOS).
+- LUT-baked Share, Save to Photos, and Frame.io finish a playable file when a Nikon proxy's
+  media data is shorter than the header (iOS). Those clips still failed with `Invalid sample
+  cursor` after #343 because the reader threw before `finishWriting`; export now treats that as
+  end-of-readable-media, writes the `moov`, and the progress bar follows the readable duration.
 - Playback Share is available while the camera is connected. The delivery run caches the clip
   from the camera first; disconnecting and opening Operator Setup media is no longer required
   (iOS and Android).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,9 @@ All notable changes to this project are documented here. The format is based on
   media data is shorter than the header (iOS). Those clips still failed with `Invalid sample
   cursor` after #343 because the reader threw before `finishWriting`; export now treats that as
   end-of-readable-media, writes the `moov`, and the progress bar follows the readable duration.
+- Save to Photos asks for library access before the long export, then shows “Saving to Photos…”
+  with a spinner while Photos ingests the file (iOS). The bar used to freeze mid-percent through
+  the permission prompt and the save, looking like a hang.
 - Playback Share is available while the camera is connected. The delivery run caches the clip
   from the camera first; disconnecting and opening Operator Setup media is no longer required
   (iOS and Android).

--- a/docs/flows/media-delivery-frameio.md
+++ b/docs/flows/media-delivery-frameio.md
@@ -177,7 +177,8 @@ flowchart TD
   `MediaLUTExport.swift` (`MediaLUT.export`).
 - **Detail:** Per-clip LUT bake via Metal/AVFoundation export to `Documents/exports`, or raw cached
   file when bake off. Sets `exportStatus` (.exported / .failed). Combined batch progress:
-  `(clipIndex-1 + fraction) / total`.
+  `(clipIndex-1 + fraction) / total`. Nikon proxies whose `mdat` is shorter than the header
+  duration are transcoded to the readable media and still get a finished `moov` (iOS).
 - 📝 Notes:
 
 ### DELIVERY-08 — Share sheet

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		TEST00000000000000000092 /* RelayRecordControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00000000000000000093 /* RelayRecordControlTests.swift */; };
 		TEST00000000000000000094 /* LiveFeedNoiseFilterWindowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00000000000000000095 /* LiveFeedNoiseFilterWindowTests.swift */; };
 		TEST00000000000000000100 /* MediaDeliveryEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00000000000000000101 /* MediaDeliveryEligibilityTests.swift */; };
+		TEST00000000000000000102 /* MediaDeliveryOverlayStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TEST00000000000000000103 /* MediaDeliveryOverlayStateTests.swift */; };
 		USBC00000000000000000002 /* PTPUSBContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = USBC00000000000000000001 /* PTPUSBContainer.swift */; };
 		USBT00000000000000000002 /* USBCameraTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = USBT00000000000000000001 /* USBCameraTransport.swift */; };
 		RLNK00000000000000000002 /* MonitorRelayLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = RLNK00000000000000000001 /* MonitorRelayLink.swift */; };
@@ -355,6 +356,7 @@
 		TEST00000000000000000093 /* RelayRecordControlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelayRecordControlTests.swift; sourceTree = "<group>"; };
 		TEST00000000000000000095 /* LiveFeedNoiseFilterWindowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveFeedNoiseFilterWindowTests.swift; sourceTree = "<group>"; };
 		TEST00000000000000000101 /* MediaDeliveryEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDeliveryEligibilityTests.swift; sourceTree = "<group>"; };
+		TEST00000000000000000103 /* MediaDeliveryOverlayStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDeliveryOverlayStateTests.swift; sourceTree = "<group>"; };
 		USBC00000000000000000001 /* PTPUSBContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PTPUSBContainer.swift; path = ../Sources/OpenZCineCore/PTPUSBContainer.swift; sourceTree = SOURCE_ROOT; };
 		USBT00000000000000000001 /* USBCameraTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = USBCameraTransport.swift; sourceTree = "<group>"; };
 		RLNK00000000000000000001 /* MonitorRelayLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonitorRelayLink.swift; sourceTree = "<group>"; };
@@ -415,6 +417,7 @@
 				TEST00000000000000000093 /* RelayRecordControlTests.swift */,
 				TEST00000000000000000095 /* LiveFeedNoiseFilterWindowTests.swift */,
 				TEST00000000000000000101 /* MediaDeliveryEligibilityTests.swift */,
+				TEST00000000000000000103 /* MediaDeliveryOverlayStateTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -765,6 +768,7 @@
 				TEST00000000000000000092 /* RelayRecordControlTests.swift in Sources */,
 				TEST00000000000000000094 /* LiveFeedNoiseFilterWindowTests.swift in Sources */,
 				TEST00000000000000000100 /* MediaDeliveryEligibilityTests.swift in Sources */,
+				TEST00000000000000000102 /* MediaDeliveryOverlayStateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/MediaDelivery.swift
+++ b/ios/Runner/MediaDelivery.swift
@@ -192,6 +192,7 @@ extension NativeAppModel {
                     fraction in
                     Task { @MainActor in onProgress(index + 1, total, fraction) }
                 }
+                await MainActor.run { onProgress(index + 1, total, 1) }
                 result.exportedURLs.append(export.videoURL)
                 if let metadataURL = export.metadataURL {
                     result.metadataURLs.append(metadataURL)

--- a/ios/Runner/MediaDelivery.swift
+++ b/ios/Runner/MediaDelivery.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Foundation
+import os
 
 /// Container format for baked media exports.
 enum MediaExportFormat: String, Sendable, CaseIterable, Identifiable {
@@ -199,8 +200,12 @@ extension NativeAppModel {
                     setClipExportStatus(.exported, for: clip)
                 }
             } catch {
+                let ns = error as NSError
+                let detail = "\(ns.domain) code=\(ns.code) \(ns.localizedDescription)"
                 result.failedClips.append((clip, error.localizedDescription))
                 if configuration.bakeLUT { setClipExportStatus(.failed, for: clip) }
+                Logger(subsystem: "OpenZCine", category: "media-export").error(
+                    "clip failed \(clip.filename, privacy: .public): \(detail, privacy: .public)")
             }
         }
         return result

--- a/ios/Runner/MediaDeliveryOverlay.swift
+++ b/ios/Runner/MediaDeliveryOverlay.swift
@@ -29,6 +29,13 @@ enum MediaDeliveryRunOutcome: Sendable {
 
 /// Live progress for the on-clip delivery overlay.
 struct MediaDeliveryOverlayState: Equatable {
+    /// Operator-visible step after export, when the determinate bar would otherwise freeze.
+    enum Phase: Equatable {
+        case working
+        case awaitingPhotosAccess
+        case savingToPhotos
+    }
+
     let destination: MediaDeliveryDestination
     let totalClips: Int
     var clipIndex: Int
@@ -37,6 +44,8 @@ struct MediaDeliveryOverlayState: Equatable {
     var isCaching = false
     /// True while the phone hops off the camera's Wi‑Fi to reach the internet (Frame.io on AP).
     var isSwitchingNetworks = false
+    var postExportAction: MediaDeliveryPostExportAction = .systemShare
+    var phase: Phase = .working
 
     var overallFraction: Double {
         guard totalClips > 0 else { return 0 }
@@ -46,20 +55,37 @@ struct MediaDeliveryOverlayState: Equatable {
 
     var isPreparingClip: Bool { clipFraction <= 0 }
 
+    /// Spinner stays up during permission and Photos ingest — the bar does not move then.
+    var showsBusySpinner: Bool {
+        isPreparingClip || isSwitchingNetworks || phase != .working
+    }
+
     var percentText: String {
-        guard !isPreparingClip else { return "" }
+        guard !isPreparingClip, phase == .working else { return "" }
         return "\(Int((overallFraction * 100).rounded()))%"
     }
 
     var statusLine: String {
         if isSwitchingNetworks { return "Switching networks…" }
+        switch phase {
+        case .awaitingPhotosAccess:
+            return "Waiting for Photos access…"
+        case .savingToPhotos:
+            return "Saving to Photos…"
+        case .working:
+            break
+        }
         let verb: String
         if isCaching {
             verb = isPreparingClip ? "Caching from camera…" : "Caching from camera"
         } else {
             switch destination {
             case .nativeShare:
-                verb = isPreparingClip ? "Preparing…" : "Preparing to share"
+                if postExportAction == .saveToPhotos {
+                    verb = isPreparingClip ? "Saving to Photos…" : "Saving to Photos"
+                } else {
+                    verb = isPreparingClip ? "Preparing…" : "Preparing to share"
+                }
             case .frameio:
                 verb = isPreparingClip ? "Preparing…" : "Uploading to Frame.io"
             }
@@ -280,7 +306,7 @@ struct MediaDeliveryGlobalOverlay: View {
                 withAnimation(.spring(duration: 0.28)) { coordinator.isExpanded = true }
             } label: {
                 HStack(spacing: 10) {
-                    if state.isPreparingClip {
+                    if state.showsBusySpinner {
                         ProgressView()
                             .controlSize(.small)
                             .tint(LiveDesign.accent)
@@ -371,7 +397,7 @@ struct MediaDeliveryOverlay: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .center, spacing: 10) {
-                if state.isPreparingClip {
+                if state.showsBusySpinner {
                     ProgressView()
                         .controlSize(.small)
                         .tint(LiveDesign.accent)
@@ -435,6 +461,25 @@ enum MediaDeliveryRunner {
         model: NativeAppModel,
         onProgress: @escaping (MediaDeliveryOverlayState) -> Void
     ) async -> MediaDeliveryRunOutcome {
+        if request.destination == .nativeShare, request.postExportAction == .saveToPhotos {
+            if MediaPhotosSaver.addOnlyStatus == .notDetermined {
+                onProgress(
+                    MediaDeliveryOverlayState(
+                        destination: request.destination,
+                        totalClips: max(request.clips.count, 1),
+                        clipIndex: 1,
+                        clipFraction: 0,
+                        postExportAction: .saveToPhotos,
+                        phase: .awaitingPhotosAccess
+                    ))
+            }
+            do {
+                try await MediaPhotosSaver.ensureAuthorized()
+            } catch {
+                return .failed(message: error.localizedDescription)
+            }
+        }
+
         // Cache on-camera clips first, sequentially (one PTP data channel); clips that still
         // can't cache (disconnected, no handle) are reported, not silently dropped.
         let toCache = request.clips.filter { !model.isClipDownloaded($0) }
@@ -485,7 +530,8 @@ enum MediaDeliveryRunner {
             destination: request.destination,
             totalClips: total,
             clipIndex: 1,
-            clipFraction: 0
+            clipFraction: 0,
+            postExportAction: request.postExportAction
         )
         onProgress(overlay)
 
@@ -523,6 +569,9 @@ enum MediaDeliveryRunner {
 
             switch request.postExportAction {
             case .saveToPhotos:
+                overlay.phase = .savingToPhotos
+                overlay.clipFraction = max(overlay.clipFraction, 0.9)
+                onProgress(overlay)
                 do {
                     let count = try await MediaPhotosSaver.saveVideos(at: result.exportedURLs)
                     return .savedToPhotos(count: count)
@@ -743,6 +792,24 @@ enum MediaPhotosSaver {
         }
     }
 
+    static var addOnlyStatus: PHAuthorizationStatus {
+        PHPhotoLibrary.authorizationStatus(for: .addOnly)
+    }
+
+    static func ensureAuthorized() async throws {
+        switch addOnlyStatus {
+        case .authorized, .limited:
+            return
+        case .notDetermined:
+            let granted = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
+            guard granted == .authorized || granted == .limited else {
+                throw SaveError.permissionDenied
+            }
+        default:
+            throw SaveError.permissionDenied
+        }
+    }
+
     static func saveVideos(at urls: [URL]) async throws -> Int {
         let videos = MediaShareStaging.filterShareableVideos(urls)
         guard !videos.isEmpty else { throw SaveError.noVideos }
@@ -751,10 +818,7 @@ enum MediaPhotosSaver {
             try MediaShareStaging.validateReadableFile(at: url)
         }
 
-        let status = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
-        guard status == .authorized || status == .limited else {
-            throw SaveError.permissionDenied
-        }
+        try await ensureAuthorized()
 
         var saved = 0
         var failed = 0

--- a/ios/Runner/MediaDeliveryOverlay.swift
+++ b/ios/Runner/MediaDeliveryOverlay.swift
@@ -3,6 +3,7 @@ import Photos
 import SwiftUI
 import UIKit
 import UniformTypeIdentifiers
+import os
 
 /// What to do with exported clips when the destination is native share.
 enum MediaDeliveryPostExportAction: Sendable {
@@ -526,6 +527,10 @@ enum MediaDeliveryRunner {
                     let count = try await MediaPhotosSaver.saveVideos(at: result.exportedURLs)
                     return .savedToPhotos(count: count)
                 } catch {
+                    let ns = error as NSError
+                    Logger(subsystem: "OpenZCine", category: "media-export").error(
+                        "save to photos failed: \(ns.domain, privacy: .public) code=\(ns.code) \(ns.localizedDescription, privacy: .public)"
+                    )
                     return .failed(message: error.localizedDescription)
                 }
             case .systemShare:

--- a/ios/Runner/MediaLUTExport.swift
+++ b/ios/Runner/MediaLUTExport.swift
@@ -581,6 +581,7 @@ enum MediaLUT {
             throw error
         }
 
+        progress(0.9)
         videoInput.markAsFinished()
         audioInput?.markAsFinished()
         await writer.finishWriting()

--- a/ios/Runner/MediaLUTExport.swift
+++ b/ios/Runner/MediaLUTExport.swift
@@ -9,8 +9,19 @@ import os
 /// LUT baking for media playback preview and export. Builds the same `CIColorCube` pipeline the live
 /// view uses (`cube.rgbaComponents` + `inputCubeDimension`, display-encoded sRGB working space,
 /// 16-bit half-float intermediates) and applies it either as a playback `AVVideoComposition`
-/// (preview) or baked into a new file via `AVAssetExportSession` (export).
+/// (preview) or baked into a new file via `AVAssetReader` / `AVAssetWriter` (export).
 enum MediaLUT {
+    private static let logger = Logger(subsystem: "OpenZCine", category: "media-export")
+
+    private static func describe(_ error: Error) -> String {
+        let ns = error as NSError
+        return "\(ns.domain) code=\(ns.code) \(ns.localizedDescription)"
+    }
+
+    private static func trace(_ message: String) {
+        logger.info("\(message, privacy: .public)")
+    }
+
     // Match `LiveFrameProcessor`: RGBAh working buffers in display-encoded sRGB so cube
     // trilinear interpolation doesn't posterize when AVFoundation composites 8-bit source frames.
     private static let displayColorSpace =
@@ -227,30 +238,55 @@ enum MediaLUT {
     ) async throws -> ExportResult {
         let outputURL = try makeExportURL(filename: outputFilename, format: format)
         progress(0.02)
+        trace(
+            "export start source=\(sourceURL.lastPathComponent) format=\(format.rawValue) bake=\(cube != nil) dest=\(outputFilename)"
+        )
 
+        let truncated = mediaDataExtendsPastEndOfFile(at: sourceURL)
+        if truncated {
+            trace("source mdat extends past EOF; exporting readable media only")
+        }
         let passthrough =
             cube == nil
+            && !truncated
             && canPassthroughCopy(sourceURL: sourceURL, outputURL: outputURL, format: format)
         if passthrough {
+            trace("export path=passthrough-copy")
             try FileManager.default.copyItem(at: sourceURL, to: outputURL)
             progress(0.9)
         } else {
-            try await transcode(
-                sourceURL: sourceURL, outputURL: outputURL, format: format, cube: cube,
-                progress: progress)
+            trace("export path=reader-writer")
+            do {
+                try await transcode(
+                    sourceURL: sourceURL, outputURL: outputURL, format: format, cube: cube,
+                    progress: progress)
+            } catch {
+                trace("transcode failed \(describe(error))")
+                throw mappedExportError(error)
+            }
         }
 
         try await ensureFileReady(at: outputURL)
+        guard movieHasFinishedHeader(at: outputURL) else {
+            trace("export missing moov header")
+            throw ExportError.failed("export file is incomplete")
+        }
 
         if !passthrough {
-            // The export session drops the camera's tmcd track; restore it from the source so
-            // Frame.io and NLEs keep the R3D NE / N-RAW master's start timecode.
             await MediaTimecode.copySourceTimecodeTrack(
                 from: sourceURL, to: outputURL, as: format.avFileType)
+            if !movieHasFinishedHeader(at: outputURL) {
+                trace("timecode embed left an incomplete movie")
+                throw ExportError.failed("export file is incomplete")
+            }
         }
 
         let metadataURL = try writeMetadataSidecar(metadata, nextTo: outputURL)
         progress(1.0)
+        let size =
+            (try? FileManager.default.attributesOfItem(atPath: outputURL.path)[.size] as? UInt64)
+            ?? 0
+        trace("export done file=\(outputURL.lastPathComponent) bytes=\(size)")
         return ExportResult(videoURL: outputURL, metadataURL: metadataURL)
     }
 
@@ -293,6 +329,11 @@ enum MediaLUT {
         let composition = AVMutableComposition()
         let duration = try await asset.load(.duration)
         let videoTracks = try await asset.loadTracks(withMediaType: .video)
+        let audioTracks = try await asset.loadTracks(withMediaType: .audio)
+        let timecodeTracks = try await asset.loadTracks(withMediaType: .timecode)
+        trace(
+            "source tracks video=\(videoTracks.count) audio=\(audioTracks.count) tmcd=\(timecodeTracks.count) duration=\(duration.seconds)"
+        )
         guard !videoTracks.isEmpty else { throw ExportError.sessionSetupFailed }
 
         for track in videoTracks {
@@ -306,6 +347,8 @@ enum MediaLUT {
                     fallbackDuration: duration)
                 dest.preferredTransform = try await track.load(.preferredTransform)
             } catch {
+                logger.error(
+                    "video insert failed: \(describe(error), privacy: .public)")
                 composition.removeTrack(dest)
             }
         }
@@ -313,7 +356,7 @@ enum MediaLUT {
             throw ExportError.sessionSetupFailed
         }
 
-        for track in try await asset.loadTracks(withMediaType: .audio) {
+        for track in audioTracks {
             guard
                 let dest = composition.addMutableTrack(
                     withMediaType: .audio, preferredTrackID: kCMPersistentTrackID_Invalid)
@@ -323,6 +366,8 @@ enum MediaLUT {
                     track, timeRange: try await track.load(.timeRange), into: dest,
                     fallbackDuration: duration)
             } catch {
+                logger.error(
+                    "audio insert failed: \(describe(error), privacy: .public)")
                 composition.removeTrack(dest)
             }
         }
@@ -350,66 +395,74 @@ enum MediaLUT {
         cube: CubeLUT?,
         progress: @escaping @Sendable (Double) -> Void
     ) async throws {
-        let asset = AVURLAsset(
-            url: sourceURL, options: [AVURLAssetPreferPreciseDurationAndTimingKey: true])
-        _ = try await asset.load(.tracks)
-        let exportAsset: AVAsset
-        do {
-            exportAsset = try await audioVisualExportAsset(from: asset)
-        } catch {
-            exportAsset = asset
-        }
-        let fileType = format.avFileType
-        guard
-            let session = AVAssetExportSession(
-                asset: exportAsset, presetName: AVAssetExportPresetHighestQuality)
-        else { throw ExportError.sessionSetupFailed }
-
-        if let cube {
-            session.videoComposition = videoComposition(for: exportAsset, cube: cube)
-        }
+        // Device proof 2026-08-23: Nikon proxies can carry a complete `moov` whose `mdat`
+        // was cut off (edit list + truncated media). `AVAssetReader` then throws
+        // `AVErrorInvalidSampleCursor` (−11880) at the first missing sample. Treating that
+        // as end-of-readable-media and calling `finishWriting` yields a playable file;
+        // throwing leaves `mdat` size 0 and Photos/Share surface "Invalid sample cursor".
         progress(0.05)
-
-        let reporter = ExportProgressReporter(session: session, report: progress)
-        let progressTask = Task { await reporter.poll() }
-        defer { progressTask.cancel() }
-
-        do {
-            try await runExportSession(session, to: outputURL, as: fileType)
-        } catch {
-            guard isInvalidSampleCursor(error) else { throw error }
-            try? FileManager.default.removeItem(at: outputURL)
-            try await transcodeWithReaderWriter(
-                sourceURL: sourceURL, outputURL: outputURL, format: format, cube: cube,
-                progress: progress)
-        }
+        trace("reader/writer start")
+        try await transcodeWithReaderWriter(
+            sourceURL: sourceURL, outputURL: outputURL, format: format, cube: cube,
+            progress: progress)
+        trace("reader/writer completed")
         progress(0.95)
-    }
-
-    private static func runExportSession(
-        _ session: AVAssetExportSession, to outputURL: URL, as fileType: AVFileType
-    ) async throws {
-        // The iOS 18 `export(to:as:)` async API crashes with `_resumeCheckedContinuation`
-        // when the session's asset is an `AVMutableComposition` (the video+audio wrapper
-        // that drops Nikon `tmcd`). `exportAsynchronously` is the stable path.
-        session.outputURL = outputURL
-        session.outputFileType = fileType
-        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
-            nonisolated(unsafe) let exportSession = session
-            exportSession.exportAsynchronously {
-                if exportSession.status == .completed {
-                    cont.resume()
-                } else {
-                    cont.resume(throwing: exportSession.error ?? ExportError.failed("export"))
-                }
-            }
-        }
     }
 
     private static func isInvalidSampleCursor(_ error: Error) -> Bool {
         let ns = error as NSError
         return ns.domain == AVFoundationErrorDomain
             && ns.code == AVError.Code.invalidSampleCursor.rawValue
+    }
+
+    private static func mappedExportError(_ error: Error) -> Error {
+        if isInvalidSampleCursor(error) {
+            return ExportError.failed("this clip's media data is unreadable")
+        }
+        return error
+    }
+
+    private static func isEndOfReadableMedia(_ reader: AVAssetReader, samples: Int) -> Bool {
+        switch reader.status {
+        case .completed, .cancelled:
+            return true
+        case .failed:
+            if let error = reader.error, isInvalidSampleCursor(error) {
+                return true
+            }
+            return samples > 0
+        default:
+            return false
+        }
+    }
+
+    /// `copyNextSampleBuffer` can block forever on a truncated `mdat`. Time out and cancel
+    /// the reader so `finishWriting` can still emit a playable file.
+    private static let sampleCopyQueue = DispatchQueue(
+        label: "ozc.media-export.copy", attributes: .concurrent)
+
+    private final class SampleCopyBox: @unchecked Sendable {
+        var sample: CMSampleBuffer?
+    }
+
+    private static func copyNextSample(
+        from output: AVAssetReaderTrackOutput,
+        reader: AVAssetReader,
+        timeout: TimeInterval = 8
+    ) -> CMSampleBuffer? {
+        let box = SampleCopyBox()
+        let lock = DispatchSemaphore(value: 0)
+        nonisolated(unsafe) let trackOutput = output
+        sampleCopyQueue.async {
+            box.sample = trackOutput.copyNextSampleBuffer()
+            lock.signal()
+        }
+        if lock.wait(timeout: .now() + timeout) == .timedOut {
+            reader.cancelReading()
+            _ = lock.wait(timeout: .now() + 1)
+            trace("copyNext timed out status=\(reader.status.rawValue)")
+        }
+        return box.sample
     }
 
     private static func transcodeWithReaderWriter(
@@ -427,27 +480,36 @@ enum MediaLUT {
         let audioTrack = try await asset.loadTracks(withMediaType: .audio).first
         let naturalSize = try await videoTrack.load(.naturalSize)
         let transform = try await videoTrack.load(.preferredTransform)
-        let displayed = naturalSize.applying(transform)
-        let width = max(16, Int(abs(displayed.width).rounded()))
-        let height = max(16, Int(abs(displayed.height).rounded()))
+        // Encode in the track's coded size and stamp `preferredTransform`. Using the
+        // display size *and* the transform double-rotates ZR proxies that carry ±90°.
+        let width = max(16, Int(abs(naturalSize.width).rounded()))
+        let height = max(16, Int(abs(naturalSize.height).rounded()))
         let duration = try await asset.load(.duration)
+        let progressDuration = scaledProgressDuration(for: sourceURL, headerDuration: duration)
+        trace(
+            "reader tracks coded=\(width)x\(height) duration=\(duration.seconds) progressDuration=\(progressDuration.seconds) audio=\(audioTrack != nil)"
+        )
 
-        let reader = try AVAssetReader(asset: asset)
+        let videoReader = try AVAssetReader(asset: asset)
         let videoOutput = AVAssetReaderTrackOutput(
             track: videoTrack,
             outputSettings: [
                 kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA
             ])
-        videoOutput.alwaysCopiesSampleData = false
-        guard reader.canAdd(videoOutput) else { throw ExportError.sessionSetupFailed }
-        reader.add(videoOutput)
+        videoOutput.alwaysCopiesSampleData = true
+        guard videoReader.canAdd(videoOutput) else { throw ExportError.sessionSetupFailed }
+        videoReader.add(videoOutput)
 
+        var audioReader: AVAssetReader?
         var audioOutput: AVAssetReaderTrackOutput?
         if let audioTrack {
-            let output = AVAssetReaderTrackOutput(track: audioTrack, outputSettings: nil)
-            output.alwaysCopiesSampleData = false
+            let reader = try AVAssetReader(asset: asset)
+            let output = AVAssetReaderTrackOutput(
+                track: audioTrack, outputSettings: audioPCMSettings())
+            output.alwaysCopiesSampleData = true
             if reader.canAdd(output) {
                 reader.add(output)
+                audioReader = reader
                 audioOutput = output
             }
         }
@@ -474,9 +536,8 @@ enum MediaLUT {
 
         var audioInput: AVAssetWriterInput?
         if audioOutput != nil, let audioTrack {
-            let formats = try await audioTrack.load(.formatDescriptions)
             let input = AVAssetWriterInput(
-                mediaType: .audio, outputSettings: nil, sourceFormatHint: formats.first)
+                mediaType: .audio, outputSettings: await audioAACSettings(for: audioTrack))
             input.expectsMediaDataInRealTime = false
             if writer.canAdd(input) {
                 writer.add(input)
@@ -487,30 +548,54 @@ enum MediaLUT {
         guard writer.startWriting() else {
             throw writer.error ?? ExportError.sessionSetupFailed
         }
-        guard reader.startReading() else {
-            throw reader.error ?? ExportError.sessionSetupFailed
+        guard videoReader.startReading() else {
+            throw mappedExportError(videoReader.error ?? ExportError.sessionSetupFailed)
         }
-        writer.startSession(atSourceTime: .zero)
+        if let audioReader, !audioReader.startReading() {
+            trace("audio reader skipped \(audioReader.error.map(describe) ?? "nil")")
+            audioInput?.markAsFinished()
+            audioInput = nil
+            audioOutput = nil
+        }
 
         let filter = cube.flatMap(colorCubeFilter(for:))
-        try await appendReaderWriterSamples(
-            reader: reader,
-            writer: writer,
-            videoOutput: videoOutput,
-            videoInput: videoInput,
-            adaptor: adaptor,
-            audioOutput: audioOutput,
-            audioInput: audioInput,
-            filter: filter,
-            duration: duration,
-            progress: progress)
+        let stats: ReaderWriterStats
+        do {
+            stats = try await appendReaderWriterSamples(
+                videoReader: videoReader,
+                videoOutput: videoOutput,
+                videoInput: videoInput,
+                adaptor: adaptor,
+                audioReader: audioReader,
+                audioOutput: audioOutput,
+                audioInput: audioInput,
+                writer: writer,
+                filter: filter,
+                duration: progressDuration,
+                progress: progress)
+        } catch {
+            trace("pump threw \(describe(error)); cancelling writer")
+            videoInput.markAsFinished()
+            audioInput?.markAsFinished()
+            writer.cancelWriting()
+            throw error
+        }
 
         videoInput.markAsFinished()
         audioInput?.markAsFinished()
         await writer.finishWriting()
-        guard writer.status == .completed else {
-            throw writer.error ?? reader.error ?? ExportError.failed("export")
+        guard writer.status == .completed, stats.videoFrames > 0 else {
+            trace(
+                "writer failed status=\(writer.status.rawValue) video=\(stats.videoFrames) \(writer.error.map(describe) ?? "nil")"
+            )
+            try? FileManager.default.removeItem(at: outputURL)
+            throw writer.error
+                ?? mappedExportError(
+                    videoReader.error ?? ExportError.failed("export"))
         }
+        trace(
+            "writer finished frames=\(stats.videoFrames) audio=\(stats.audioSamples) lastPTS=\(stats.lastVideoPTS.seconds) truncated=\(stats.endedEarly)"
+        )
     }
 
     private static func colorCubeFilter(for cube: CubeLUT) -> CIFilter? {
@@ -524,61 +609,187 @@ enum MediaLUT {
             ])
     }
 
+    private struct ReaderWriterStats {
+        var videoFrames = 0
+        var audioSamples = 0
+        var lastVideoPTS = CMTime.zero
+        var endedEarly = false
+        var sessionStarted = false
+    }
+
+    private static func audioPCMSettings() -> [String: Any] {
+        [
+            AVFormatIDKey: kAudioFormatLinearPCM,
+            AVLinearPCMBitDepthKey: 16,
+            AVLinearPCMIsBigEndianKey: false,
+            AVLinearPCMIsFloatKey: false,
+            AVLinearPCMIsNonInterleaved: false,
+        ]
+    }
+
+    private static func audioAACSettings(for track: AVAssetTrack) async -> [String: Any] {
+        var sampleRate = 48_000.0
+        var channels = 2
+        if let format = try? await track.load(.formatDescriptions).first,
+            let asbd = CMAudioFormatDescriptionGetStreamBasicDescription(format)?.pointee
+        {
+            if asbd.mSampleRate > 0 { sampleRate = asbd.mSampleRate }
+            if asbd.mChannelsPerFrame > 0 { channels = Int(asbd.mChannelsPerFrame) }
+        }
+        return [
+            AVFormatIDKey: kAudioFormatMPEG4AAC,
+            AVSampleRateKey: sampleRate,
+            AVNumberOfChannelsKey: channels,
+            AVEncoderBitRateKey: 192_000,
+        ]
+    }
+
     private static func appendReaderWriterSamples(
-        reader: AVAssetReader,
-        writer: AVAssetWriter,
+        videoReader: AVAssetReader,
         videoOutput: AVAssetReaderTrackOutput,
         videoInput: AVAssetWriterInput,
         adaptor: AVAssetWriterInputPixelBufferAdaptor,
+        audioReader: AVAssetReader?,
         audioOutput: AVAssetReaderTrackOutput?,
         audioInput: AVAssetWriterInput?,
+        writer: AVAssetWriter,
         filter: CIFilter?,
         duration: CMTime,
         progress: @escaping @Sendable (Double) -> Void
-    ) async throws {
+    ) async throws -> ReaderWriterStats {
+        var stats = ReaderWriterStats()
         var videoDone = false
         var audioDone = audioOutput == nil || audioInput == nil
+        var idleSpins = 0
         while !videoDone || !audioDone {
             if Task.isCancelled {
-                reader.cancelReading()
+                videoReader.cancelReading()
+                audioReader?.cancelReading()
                 writer.cancelWriting()
                 throw CancellationError()
             }
             var progressed = false
-            if !videoDone, videoInput.isReadyForMoreMediaData {
-                if let sample = videoOutput.copyNextSampleBuffer() {
-                    try appendVideoSample(sample, adaptor: adaptor, filter: filter)
-                    let pts = CMSampleBufferGetPresentationTimeStamp(sample)
-                    if duration.seconds > 0, pts.seconds > 0 {
-                        progress(min(0.9, 0.05 + 0.85 * (pts.seconds / duration.seconds)))
+            if !videoDone {
+                let videoReady = videoInput.isReadyForMoreMediaData
+                let videoReaderStopped =
+                    videoReader.status == .failed || videoReader.status == .completed
+                    || videoReader.status == .cancelled
+                if videoReady {
+                    if let sample = copyNextSample(from: videoOutput, reader: videoReader) {
+                        startWriterSessionIfNeeded(
+                            writer, stats: &stats,
+                            at: CMSampleBufferGetPresentationTimeStamp(sample))
+                        try appendVideoSample(sample, adaptor: adaptor, filter: filter)
+                        stats.videoFrames += 1
+                        stats.lastVideoPTS = CMSampleBufferGetPresentationTimeStamp(sample)
+                        if duration.seconds > 0, stats.lastVideoPTS.seconds > 0 {
+                            let fraction = stats.lastVideoPTS.seconds / duration.seconds
+                            progress(min(0.9, 0.05 + 0.85 * fraction))
+                        }
+                        progressed = true
+                    } else if isEndOfReadableMedia(videoReader, samples: stats.videoFrames) {
+                        if videoReader.status == .failed {
+                            stats.endedEarly = true
+                            trace(
+                                "video readable-end frames=\(stats.videoFrames) \(videoReader.error.map(describe) ?? "nil")"
+                            )
+                            progress(0.9)
+                        }
+                        videoDone = true
+                        progressed = true
+                    } else if videoReaderStopped {
+                        videoDone = true
+                        progressed = true
                     }
-                    progressed = true
-                } else {
+                } else if videoReaderStopped {
                     videoDone = true
                     progressed = true
                 }
             }
-            if !audioDone, let audioOutput, let audioInput, audioInput.isReadyForMoreMediaData {
-                if let sample = audioOutput.copyNextSampleBuffer() {
-                    if !audioInput.append(sample) {
-                        throw writer.error ?? ExportError.failed("audio")
+            if !audioDone, let audioOutput, let audioInput, let audioReader {
+                let audioReady = audioInput.isReadyForMoreMediaData
+                let audioReaderStopped =
+                    audioReader.status == .failed || audioReader.status == .completed
+                    || audioReader.status == .cancelled
+                if audioReady {
+                    if let sample = copyNextSample(from: audioOutput, reader: audioReader) {
+                        startWriterSessionIfNeeded(
+                            writer, stats: &stats,
+                            at: CMSampleBufferGetPresentationTimeStamp(sample))
+                        if audioInput.append(sample) {
+                            stats.audioSamples += 1
+                            progressed = true
+                        } else {
+                            trace("audio append stopped \(writer.error.map(describe) ?? "nil")")
+                            audioDone = true
+                            progressed = true
+                        }
+                    } else if isEndOfReadableMedia(audioReader, samples: stats.audioSamples) {
+                        if audioReader.status == .failed {
+                            stats.endedEarly = true
+                            trace(
+                                "audio readable-end samples=\(stats.audioSamples) \(audioReader.error.map(describe) ?? "nil")"
+                            )
+                        }
+                        audioDone = true
+                        progressed = true
+                    } else if audioReaderStopped {
+                        audioDone = true
+                        progressed = true
                     }
-                    progressed = true
-                } else {
+                } else if audioReaderStopped {
                     audioDone = true
                     progressed = true
                 }
             }
-            if !progressed {
-                try await Task.sleep(for: .milliseconds(10))
-            }
-            if reader.status == .failed {
-                throw reader.error ?? ExportError.failed("export")
-            }
             if writer.status == .failed {
                 throw writer.error ?? ExportError.failed("export")
             }
+            if !progressed {
+                idleSpins += 1
+                // Writer back-pressure plus a failed reader used to spin forever and
+                // never `finishWriting`. After ~500ms with no progress, drop a stopped track.
+                if idleSpins == 50 {
+                    if !videoDone,
+                        videoReader.status == .failed || videoReader.status == .completed
+                    {
+                        videoDone = true
+                        stats.endedEarly = true
+                        trace("video idle-stop frames=\(stats.videoFrames)")
+                    }
+                    if !audioDone,
+                        let audioReader,
+                        audioReader.status == .failed || audioReader.status == .completed
+                    {
+                        audioDone = true
+                        stats.endedEarly = true
+                        trace("audio idle-stop samples=\(stats.audioSamples)")
+                    }
+                }
+                if idleSpins >= 500, stats.videoFrames > 0 {
+                    videoDone = true
+                    audioDone = true
+                    stats.endedEarly = true
+                    trace("idle timeout frames=\(stats.videoFrames) audio=\(stats.audioSamples)")
+                }
+                try await Task.sleep(for: .milliseconds(10))
+            } else {
+                idleSpins = 0
+            }
         }
+        if stats.videoFrames == 0 {
+            throw mappedExportError(
+                videoReader.error ?? ExportError.failed("this clip's media data is unreadable"))
+        }
+        return stats
+    }
+
+    private static func startWriterSessionIfNeeded(
+        _ writer: AVAssetWriter, stats: inout ReaderWriterStats, at time: CMTime
+    ) {
+        guard !stats.sessionStarted else { return }
+        writer.startSession(atSourceTime: time)
+        stats.sessionStarted = true
     }
 
     private static func appendVideoSample(
@@ -616,27 +827,6 @@ enum MediaLUT {
         }
     }
 
-    /// Polls `AVAssetExportSession.progress` during transcode without crossing Swift 6 sendability.
-    private final class ExportProgressReporter: @unchecked Sendable {
-        private let session: AVAssetExportSession
-        private let report: @Sendable (Double) -> Void
-
-        init(session: AVAssetExportSession, report: @escaping @Sendable (Double) -> Void) {
-            self.session = session
-            self.report = report
-        }
-
-        func poll() async {
-            while !Task.isCancelled {
-                let exportProgress = Double(session.progress)
-                if exportProgress > 0 {
-                    report(0.05 + exportProgress * 0.85)
-                }
-                try? await Task.sleep(for: .milliseconds(180))
-            }
-        }
-    }
-
     private static func makeExportURL(filename: String, format: MediaExportFormat) throws -> URL {
         let trimmed = filename.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { throw ExportError.invalidFilename }
@@ -665,6 +855,99 @@ enum MediaLUT {
         let data = try encoder.encode(metadata)
         try data.write(to: url, options: .atomic)
         return url
+    }
+
+    /// True when the file has a finished QuickTime/`moov` header, not just an open `mdat`.
+    static func movieHasFinishedHeader(at url: URL) -> Bool {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+        defer { try? handle.close() }
+        let fileSize = (try? handle.seekToEnd()) ?? 0
+        var offset: UInt64 = 0
+        while offset + 8 <= fileSize {
+            try? handle.seek(toOffset: offset)
+            guard let sizeBytes = try? handle.read(upToCount: 4), sizeBytes.count == 4,
+                let typeBytes = try? handle.read(upToCount: 4), typeBytes.count == 4
+            else { return false }
+            var atomSize = sizeBytes.reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
+            let type = String(bytes: typeBytes, encoding: .ascii) ?? ""
+            if atomSize == 1 {
+                guard let ext = try? handle.read(upToCount: 8), ext.count == 8 else { return false }
+                atomSize = ext.reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
+            }
+            if type == "moov" { return true }
+            if atomSize < 8 || atomSize == 0 { return false }
+            offset += atomSize
+        }
+        return false
+    }
+
+    /// True when an `mdat` atom's declared size runs past EOF — Nikon proxies (and partial
+    /// caches) can ship a complete `moov` for more media than the file actually contains.
+    static func mediaDataExtendsPastEndOfFile(at url: URL) -> Bool {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return false }
+        defer { try? handle.close() }
+        let fileSize = (try? handle.seekToEnd()) ?? 0
+        var offset: UInt64 = 0
+        while offset + 8 <= fileSize {
+            try? handle.seek(toOffset: offset)
+            guard let sizeBytes = try? handle.read(upToCount: 4), sizeBytes.count == 4,
+                let typeBytes = try? handle.read(upToCount: 4), typeBytes.count == 4
+            else { return false }
+            var atomSize = sizeBytes.reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
+            let type = String(bytes: typeBytes, encoding: .ascii) ?? ""
+            if atomSize == 1 {
+                guard let ext = try? handle.read(upToCount: 8), ext.count == 8 else { return false }
+                atomSize = ext.reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
+            }
+            if type == "mdat", atomSize >= 8, offset + atomSize > fileSize {
+                return true
+            }
+            if atomSize < 8 { return false }
+            offset += atomSize
+        }
+        return false
+    }
+
+    /// Header duration scaled by how much of `mdat` is actually on disk.
+    ///
+    /// Nikon proxies can advertise a full clip duration while the file was cut off halfway
+    /// through media data. Progress uses this so the bar isn't stuck at ~50% of a lying header.
+    static func scaledProgressDuration(for url: URL, headerDuration: CMTime) -> CMTime {
+        guard headerDuration.isNumeric, headerDuration.seconds > 0,
+            let fraction = mdatAvailableFraction(at: url), fraction > 0, fraction < 0.98
+        else { return headerDuration }
+        return CMTimeMultiplyByFloat64(headerDuration, multiplier: fraction)
+    }
+
+    /// Available `mdat` payload / declared payload when the atom runs past EOF; otherwise `nil`.
+    static func mdatAvailableFraction(at url: URL) -> Double? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        let fileSize = (try? handle.seekToEnd()) ?? 0
+        var offset: UInt64 = 0
+        while offset + 8 <= fileSize {
+            try? handle.seek(toOffset: offset)
+            guard let sizeBytes = try? handle.read(upToCount: 4), sizeBytes.count == 4,
+                let typeBytes = try? handle.read(upToCount: 4), typeBytes.count == 4
+            else { return nil }
+            var atomSize = sizeBytes.reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
+            let type = String(bytes: typeBytes, encoding: .ascii) ?? ""
+            var header: UInt64 = 8
+            if atomSize == 1 {
+                guard let ext = try? handle.read(upToCount: 8), ext.count == 8 else { return nil }
+                atomSize = ext.reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
+                header = 16
+            }
+            if type == "mdat", atomSize >= header, offset + atomSize > fileSize {
+                let declaredPayload = atomSize - header
+                let available = fileSize - (offset + header)
+                guard declaredPayload > 0 else { return nil }
+                return Double(available) / Double(declaredPayload)
+            }
+            if atomSize < 8 { return nil }
+            offset += atomSize
+        }
+        return nil
     }
 
     /// Waits briefly for AVFoundation / copy writes to become readable on disk.

--- a/ios/Runner/MediaTimecode.swift
+++ b/ios/Runner/MediaTimecode.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import CoreMedia
 import Foundation
 import os
 
@@ -27,9 +28,26 @@ enum MediaTimecode {
             )
             .appendingPathExtension(outputURL.pathExtension)
         do {
+            if MediaLUT.mediaDataExtendsPastEndOfFile(at: sourceURL) {
+                logger.info("timecode embed skipped: source mdat is truncated")
+                return
+            }
             guard let sourceTrack = try await source.loadTracks(withMediaType: .timecode).first
-            else { return }
-            let timeRange = try await sourceTrack.load(.timeRange)
+            else {
+                logger.info("timecode embed skipped: source has no tmcd track")
+                return
+            }
+            let sourceRange = try await sourceTrack.load(.timeRange)
+            let destDuration = try await AVURLAsset(
+                url: outputURL,
+                options: [AVURLAssetPreferPreciseDurationAndTimingKey: true]
+            ).load(.duration)
+            let timeRange: CMTimeRange
+            if destDuration.isNumeric, destDuration < sourceRange.duration {
+                timeRange = CMTimeRange(start: sourceRange.start, duration: destDuration)
+            } else {
+                timeRange = sourceRange
+            }
 
             try? FileManager.default.removeItem(at: stagedURL)
             try FileManager.default.copyItem(at: outputURL, to: stagedURL)
@@ -51,15 +69,18 @@ enum MediaTimecode {
             }
             try movie.writeHeader(
                 to: stagedURL, fileType: fileType, options: .addMovieHeaderToDestination)
-            guard await hasReadableVideoTrack(at: stagedURL) else {
-                logger.error("timecode embed produced an unreadable movie; keeping the export")
+            guard MediaLUT.movieHasFinishedHeader(at: stagedURL) else {
+                logger.error("timecode embed produced a file without moov; keeping the export")
                 return
             }
             try FileManager.default.removeItem(at: outputURL)
             try FileManager.default.copyItem(at: stagedURL, to: outputURL)
+            logger.info("timecode embed succeeded")
         } catch {
+            let ns = error as NSError
             logger.error(
-                "timecode embed failed: \(error.localizedDescription, privacy: .public)")
+                "timecode embed failed: \(ns.domain, privacy: .public) code=\(ns.code) \(ns.localizedDescription, privacy: .public)"
+            )
         }
     }
 

--- a/ios/RunnerTests/MediaDeliveryOverlayStateTests.swift
+++ b/ios/RunnerTests/MediaDeliveryOverlayStateTests.swift
@@ -1,0 +1,50 @@
+import Testing
+
+@testable import Runner
+
+@Suite("Media delivery overlay status")
+struct MediaDeliveryOverlayStateTests {
+    @Test("Save to Photos asks for access instead of freezing a percent")
+    func awaitingPhotosAccessHasAWaitingStatus() {
+        let state = MediaDeliveryOverlayState(
+            destination: .nativeShare,
+            totalClips: 1,
+            clipIndex: 1,
+            clipFraction: 0.75,
+            postExportAction: .saveToPhotos,
+            phase: .awaitingPhotosAccess
+        )
+        #expect(state.statusLine == "Waiting for Photos access…")
+        #expect(state.showsBusySpinner)
+        #expect(state.percentText.isEmpty)
+    }
+
+    @Test("Photos ingest keeps a spinner after export")
+    func savingToPhotosKeepsBusyChrome() {
+        let state = MediaDeliveryOverlayState(
+            destination: .nativeShare,
+            totalClips: 1,
+            clipIndex: 1,
+            clipFraction: 0.9,
+            postExportAction: .saveToPhotos,
+            phase: .savingToPhotos
+        )
+        #expect(state.statusLine == "Saving to Photos…")
+        #expect(state.showsBusySpinner)
+        #expect(state.percentText.isEmpty)
+    }
+
+    @Test("Save-to-Photos export uses the Android-matching verb")
+    func saveToPhotosExportVerb() {
+        let state = MediaDeliveryOverlayState(
+            destination: .nativeShare,
+            totalClips: 1,
+            clipIndex: 1,
+            clipFraction: 0.4,
+            postExportAction: .saveToPhotos
+        )
+        #expect(state.statusLine.hasPrefix("Saving to Photos"))
+        #expect(state.statusLine.contains("40%"))
+        #expect(!state.showsBusySpinner)
+    }
+}

--- a/ios/RunnerTests/MediaTimecodeTests.swift
+++ b/ios/RunnerTests/MediaTimecodeTests.swift
@@ -123,6 +123,57 @@ final class MediaTimecodeTests: XCTestCase {
         XCTAssertEqual(start?.frame, Self.startFrame)
     }
 
+    func testCompleteMovieIsNotFlaggedTruncated() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let sourceURL = dir.appendingPathComponent("source.mov")
+        try await Self.writeMovieWithTimecode(to: sourceURL)
+        XCTAssertFalse(MediaLUT.mediaDataExtendsPastEndOfFile(at: sourceURL))
+        XCTAssertTrue(MediaLUT.movieHasFinishedHeader(at: sourceURL))
+        XCTAssertNil(MediaLUT.mdatAvailableFraction(at: sourceURL))
+    }
+
+    func testTruncatedFastStartProxyExportWritesPlayableFile() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let sourceURL = dir.appendingPathComponent("source.mov")
+        try await Self.writeMovieWithTimecode(
+            to: sourceURL, frameCount: 60, optimizeForNetworkUse: true)
+        let truncatedURL = dir.appendingPathComponent("truncated.mov")
+        try Self.truncateMdatPayload(from: sourceURL, to: truncatedURL, keepFraction: 0.35)
+        try XCTSkipUnless(
+            MediaLUT.mediaDataExtendsPastEndOfFile(at: truncatedURL),
+            "fast-start rewrite did not leave moov before a declared-oversize mdat")
+        let fraction = try XCTUnwrap(MediaLUT.mdatAvailableFraction(at: truncatedURL))
+        XCTAssertGreaterThan(fraction, 0.1)
+        XCTAssertLessThan(fraction, 0.9)
+        let header = CMTime(seconds: 10, preferredTimescale: 25_000)
+        let scaled = MediaLUT.scaledProgressDuration(for: truncatedURL, headerDuration: header)
+        XCTAssertLessThan(scaled.seconds, header.seconds)
+
+        let result = try await MediaLUT.export(
+            sourceURL: truncatedURL,
+            outputFilename: "truncated-export-\(UUID().uuidString).mov",
+            format: .mov,
+            cube: Self.identityCube(),
+            metadata: nil
+        ) { _ in }
+        defer { try? FileManager.default.removeItem(at: result.videoURL) }
+
+        let size =
+            (try FileManager.default.attributesOfItem(atPath: result.videoURL.path)[.size]
+                as? UInt64) ?? 0
+        XCTAssertGreaterThan(size, 0)
+        XCTAssertTrue(MediaLUT.movieHasFinishedHeader(at: result.videoURL))
+        XCTAssertFalse(MediaLUT.mediaDataExtendsPastEndOfFile(at: result.videoURL))
+    }
+
     func testExportReferenceProxyIfPresent() async throws {
         let sample = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -146,8 +197,11 @@ final class MediaTimecodeTests: XCTestCase {
     // MARK: - Synthesis
 
     /// Writes a tiny H.264 movie with a `tmcd` track starting at `startFrame`.
-    private static func writeMovieWithTimecode(to url: URL) async throws {
+    private static func writeMovieWithTimecode(
+        to url: URL, frameCount: Int = 5, optimizeForNetworkUse: Bool = false
+    ) async throws {
         let writer = try AVAssetWriter(outputURL: url, fileType: .mov)
+        writer.shouldOptimizeForNetworkUse = optimizeForNetworkUse
 
         let videoInput = AVAssetWriterInput(
             mediaType: .video,
@@ -189,7 +243,6 @@ final class MediaTimecodeTests: XCTestCase {
         }
         writer.startSession(atSourceTime: .zero)
 
-        let frameCount = 5
         for frame in 0..<frameCount {
             while !videoInput.isReadyForMoreMediaData {
                 try await Task.sleep(for: .milliseconds(10))
@@ -333,5 +386,40 @@ final class MediaTimecodeTests: XCTestCase {
         guard let pointer, length >= 4 else { return nil }
         let raw = pointer.withMemoryRebound(to: UInt32.self, capacity: 1) { $0.pointee }
         return StartTimecode(frame: UInt32(bigEndian: raw), frameQuanta: quanta)
+    }
+
+    /// Copies `from` up through the `mdat` header plus `keepFraction` of its payload, leaving
+    /// the declared atom size intact so the file looks like a Nikon proxy whose media was cut off.
+    private static func truncateMdatPayload(from: URL, to: URL, keepFraction: Double) throws {
+        let data = try Data(contentsOf: from)
+        var offset = 0
+        var output = Data()
+        while offset + 8 <= data.count {
+            var atomSize = data.subdata(in: offset..<(offset + 4)).reduce(0) {
+                ($0 << 8) | Int($1)
+            }
+            let type =
+                String(data: data.subdata(in: (offset + 4)..<(offset + 8)), encoding: .ascii) ?? ""
+            var header = 8
+            if atomSize == 1, offset + 16 <= data.count {
+                atomSize = data.subdata(in: (offset + 8)..<(offset + 16)).reduce(0) {
+                    ($0 << 8) | Int($1)
+                }
+                header = 16
+            }
+            guard atomSize >= header else { break }
+            if type == "mdat" {
+                let payload = max(0, atomSize - header)
+                let keepPayload = min(payload, max(1, Int(Double(payload) * keepFraction)))
+                let end = min(data.count, offset + header + keepPayload)
+                output.append(data.subdata(in: offset..<end))
+                try output.write(to: to)
+                return
+            }
+            let end = min(data.count, offset + atomSize)
+            output.append(data.subdata(in: offset..<end))
+            offset += atomSize
+        }
+        throw NSError(domain: "MediaTimecodeTests", code: -6)
     }
 }

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -11,7 +11,7 @@ Fixes
 
 - Original Z 6, Z 5, and Z 7 no longer get pairing steps they do not support. iPad USB-C copy says this device, not iPhone.
 - Format a card and Media used to keep the old clip names. REFRESH now follows the card, and Settings > Clear Cache reloads Media from the card.
-- Share and Save to Photos work on clips from the camera. They used to fail with "Invalid sample cursor".
+- Share and Save to Photos work on clips from the camera, including proxies whose media is shorter than the header. They used to fail with "Invalid sample cursor".
 - Share on the player is available while the camera is connected. You no longer have to disconnect and go through Operator Setup to reach it.
 - On iPad in photo mode, the battery gauges sit beside the lock instead of covering PLAY.
 - Photo FOCUS follows stills AF, not leftover video AF-F. After a focus-dial pull, a tap focuses without a half-press.

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -22,6 +22,6 @@ What to test
 
 - If you have an original Z 6, Z 5, or Z 7, connect over USB-C and the camera's own Wi-Fi. It should reach the monitor without a wireless error on the camera.
 - Format a spare card or delete a shot, then tap REFRESH on Media: gone files leave and new ones show. Clear Cache in Settings and reopen Media to rebuild from the card.
-- Connect to the camera, play a clip, tap Share, then Share and Save to Photos. Both should finish. You should not have to disconnect first.
+- Connect to the camera, play a clip, tap Share, then Share and Save to Photos. Both should finish. Save to Photos should ask for access up front, then keep a spinner while Photos writes — not a frozen percent. You should not have to disconnect first.
 - Put the body in Aperture-priority photo, change the light, and check shutter and ISO on the phone match the camera.
 - Set stills AF-S and video full-time AF. Photo FOCUS should match the Focus panel, not leftover AF-F. Pull the focus dial, then tap: it should focus without a half-press.


### PR DESCRIPTION
## Summary

Follow-up to #343. LUT-baked Share / Save to Photos / Frame.io still failed on some Nikon ZR proxies with `Invalid sample cursor` (−11880). #343 blamed the `tmcd` track; hardware on `es_iphone16` showed the real cause: the camera file's `moov` advertises a full duration while `mdat` is shorter (this clip: 97.8s header, readable media ends ~50s). `AVAssetReader` throws at the first missing sample; the previous exporter aborted **before** `finishWriting`, leaving a headerless `mdat` and that toast. The progress bar sat at ~50% because it used header duration.

Export now:
- reads video and audio on separate readers (one dying does not kill the other)
- treats `−11880` / a truncated `mdat` as end-of-readable-media
- always `finishWriting` so the file has a `moov`
- scales the progress bar to how much `mdat` is actually on disk
- skips timecode embed when the source `mdat` is truncated

Verified on device: Share/Save to Photos of `A004_C012_082289` succeeds with a playable file of the readable half.

## Single-platform exception

**iOS only.** This is AVFoundation (`AVAssetReader` / `AVAssetWriter` / `AVErrorInvalidSampleCursor`). Android does not share this engine. Connected-camera Share enablement already landed dual-platform in #343.

## Test plan

- [x] `MediaTimecodeTests` including truncated fast-start proxy export
- [x] `just ios-build`, `just watch-build`, `just ios-test`
- [x] Hardware: Share / Save to Photos on a Nikon proxy that previously failed with Invalid sample cursor (`es_iphone16`)
- [ ] CI Native Swift/iOS job green
