### PR TITLE
fix(ios): recover USB after a stale camera session

### DIFF
--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,5 +1,5 @@
 - Fixed: original Z 6, Z 5, and Z 7 connect without pairing steps they do not support.
-- Fixed: USB-C connect after permission. If the picture came up then dropped, retry should stay up.
+- Fixed: USB-C connect after permission, and a retry after the picture drops should stay up.
 - Fixed: Aperture-priority shutter and ISO on the phone follow the camera as it meters.
 - Fixed: photo FOCUS and taps follow stills AF, not leftover video AF-F.
 - New: Media has REFRESH. After a format it follows the card; Clear Cache reloads from the camera.

--- a/Sources/OpenZCineCore/CameraTransport.swift
+++ b/Sources/OpenZCineCore/CameraTransport.swift
@@ -59,3 +59,78 @@ public protocol CameraTransport: Sendable {
     /// Tears the transport down. Safe to call more than once.
     func close()
 }
+
+/// Next action for opening an ImageCaptureCore session on iOS USB.
+///
+/// ICC owns the PTP session: attach-time pre-warm may already have it open, and a
+/// retry after a failed first command must close that session for real before
+/// requesting a new one. Adopting a session that `requestCloseSession` did not
+/// actually close is how a cable-knock / background return stayed dead until
+/// force-quit (#254).
+public enum USBICCSessionOpenDecision: Equatable, Sendable {
+    /// Attach-time `requestOpenSession` is still in flight — wait, do not duplicate it.
+    case waitForPrewarm
+    /// A previous connect parked a live session; take it over.
+    case adoptExisting
+    /// The retry path: close the adopted session, then open fresh.
+    case recycleThenOpen
+    /// Recycle ran, but ICC still reports the session open — do not adopt the corpse.
+    case failStillOpenAfterRecycle
+    /// No open session; issue `requestOpenSession`.
+    case requestOpen
+}
+
+/// Pure decision table for the iOS USB transport's session-open path.
+public enum USBICCSessionOpenPolicy {
+    public static func decision(
+        hasOpenSession: Bool,
+        prewarmInFlight: Bool,
+        recycleFirst: Bool,
+        recycleCompleted: Bool
+    ) -> USBICCSessionOpenDecision {
+        if prewarmInFlight, !hasOpenSession {
+            return .waitForPrewarm
+        }
+        if recycleFirst, hasOpenSession, !recycleCompleted {
+            return .recycleThenOpen
+        }
+        if recycleFirst, hasOpenSession, recycleCompleted {
+            return .failStillOpenAfterRecycle
+        }
+        if hasOpenSession {
+            return .adoptExisting
+        }
+        return .requestOpen
+    }
+}
+
+/// Closed USB handshake tokens for the privacy-safe diagnostic export.
+///
+/// Raw values match the Android anonymous-log vocabulary so a field report names
+/// the same step on either shell (accessory discovery stays `usb.camera.attached`;
+/// live-view setup stays `live-view.failed`).
+public enum USBHandshakeDiagnostic: String, Sendable {
+    case sessionOpen = "usb.session.open"
+    case deviceInfo = "usb.handshake.device-info"
+    case openSession = "usb.handshake.open-session"
+    case appMode = "usb.handshake.app-mode"
+    case identify = "usb.handshake.identify"
+
+    /// Maps an establish `stage:` string (or the bare stage id) onto a closed token.
+    /// Unknown or free-form text — camera names, raw ICC errors — returns `nil`.
+    public static func from(stage raw: String) -> USBHandshakeDiagnostic? {
+        var stage = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if stage.lowercased().hasPrefix("stage:") {
+            stage = String(stage.dropFirst("stage:".count))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let key = stage.lowercased()
+        guard !key.isEmpty else { return nil }
+        if key.contains("capability probe") { return .deviceInfo }
+        if key.contains("first command") || key.contains("opensession") { return .openSession }
+        if key.contains("app-control") || key.contains("remote-mode") { return .appMode }
+        if key == "device info" || key.contains("vendor") { return .identify }
+        if key.contains("session") && key.contains("open") { return .sessionOpen }
+        return nil
+    }
+}

--- a/Tests/OpenZCineCoreTests/CameraTransportPolicyTests.swift
+++ b/Tests/OpenZCineCoreTests/CameraTransportPolicyTests.swift
@@ -293,3 +293,105 @@ import Testing
             hotspotSubnetBases: hotspotBases)
             == .available(overRouter))
 }
+
+@Suite("USB ICC session-open policy")
+struct USBICCSessionOpenPolicyTests {
+    @Test("A live session is adopted instead of opening a second ICC session")
+    func adoptExistingOpenSession() {
+        #expect(
+            USBICCSessionOpenPolicy.decision(
+                hasOpenSession: true,
+                prewarmInFlight: false,
+                recycleFirst: false,
+                recycleCompleted: false
+            ) == .adoptExisting)
+    }
+
+    @Test("A connect during attach-time pre-warm waits instead of issuing a duplicate open")
+    func waitForInFlightPrewarm() {
+        #expect(
+            USBICCSessionOpenPolicy.decision(
+                hasOpenSession: false,
+                prewarmInFlight: true,
+                recycleFirst: false,
+                recycleCompleted: false
+            ) == .waitForPrewarm)
+    }
+
+    @Test("The stale-session retry closes before it opens")
+    func recycleBeforeOpen() {
+        #expect(
+            USBICCSessionOpenPolicy.decision(
+                hasOpenSession: true,
+                prewarmInFlight: false,
+                recycleFirst: true,
+                recycleCompleted: false
+            ) == .recycleThenOpen)
+    }
+
+    @Test("A recycle that leaves the ICC session open is a failure, not another adopt")
+    func recycleThatDidNotCloseFails() {
+        // #254: the retry used to fall through to adoptExisting, so the "fresh"
+        // attempt reused the corpse the first command just failed on.
+        #expect(
+            USBICCSessionOpenPolicy.decision(
+                hasOpenSession: true,
+                prewarmInFlight: false,
+                recycleFirst: true,
+                recycleCompleted: true
+            ) == .failStillOpenAfterRecycle)
+    }
+
+    @Test("A completed recycle of a now-closed session requests a real open")
+    func recycleThenRequestOpen() {
+        #expect(
+            USBICCSessionOpenPolicy.decision(
+                hasOpenSession: false,
+                prewarmInFlight: false,
+                recycleFirst: true,
+                recycleCompleted: true
+            ) == .requestOpen)
+    }
+
+    @Test("No open session and no pre-warm means a normal open")
+    func requestOpenWhenIdle() {
+        #expect(
+            USBICCSessionOpenPolicy.decision(
+                hasOpenSession: false,
+                prewarmInFlight: false,
+                recycleFirst: false,
+                recycleCompleted: false
+            ) == .requestOpen)
+    }
+}
+
+@Suite("USB handshake diagnostic tokens")
+struct USBHandshakeDiagnosticTests {
+    @Test("Closed tokens match the Android anonymous-log vocabulary")
+    func closedTokens() {
+        #expect(USBHandshakeDiagnostic.sessionOpen.rawValue == "usb.session.open")
+        #expect(USBHandshakeDiagnostic.deviceInfo.rawValue == "usb.handshake.device-info")
+        #expect(USBHandshakeDiagnostic.openSession.rawValue == "usb.handshake.open-session")
+        #expect(USBHandshakeDiagnostic.appMode.rawValue == "usb.handshake.app-mode")
+        #expect(USBHandshakeDiagnostic.identify.rawValue == "usb.handshake.identify")
+    }
+
+    @Test("Establish stage strings map to a specific handshake token")
+    func stageMapping() {
+        #expect(USBHandshakeDiagnostic.from(stage: "capability probe") == .deviceInfo)
+        #expect(
+            USBHandshakeDiagnostic.from(stage: "stage:first command (OpenSession)") == .openSession)
+        #expect(USBHandshakeDiagnostic.from(stage: "app-control switch") == .appMode)
+        #expect(USBHandshakeDiagnostic.from(stage: "remote-mode fallback") == .appMode)
+        #expect(USBHandshakeDiagnostic.from(stage: "device info") == .identify)
+        #expect(USBHandshakeDiagnostic.from(stage: "vendor codes") == .identify)
+    }
+
+    @Test("Free-form camera or error text never becomes a handshake token")
+    func rejectsOpenText() {
+        #expect(USBHandshakeDiagnostic.from(stage: "Nikon ZR") == nil)
+        #expect(
+            USBHandshakeDiagnostic.from(stage: "com.apple.ImageCaptureCore error -21400") == nil)
+        #expect(USBHandshakeDiagnostic.from(stage: "") == nil)
+    }
+}

--- a/ios/Runner/AppDiagnostics.swift
+++ b/ios/Runner/AppDiagnostics.swift
@@ -43,6 +43,13 @@ enum AppDiagnosticEvent: String, Codable, Sendable {
     case connectionFailed = "error.connection.failed"
     case connectionWifiJoinFailed = "error.connection.wifi-join.failed"
     case connectionUsbFailed = "error.connection.usb.failed"
+    // USB handshake stages. The generic `error.connection.usb.failed` breadcrumb cannot
+    // tell ICC session-open from PTP OpenSession from application-mode (issue #254).
+    case usbSessionOpen = "usb.session.open"
+    case usbHandshakeDeviceInfo = "usb.handshake.device-info"
+    case usbHandshakeOpenSession = "usb.handshake.open-session"
+    case usbHandshakeAppMode = "usb.handshake.app-mode"
+    case usbHandshakeIdentify = "usb.handshake.identify"
     case connectionPtpFailed = "error.connection.ptp.failed"
     case connectionPairingFailed = "error.connection.pairing.failed"
     case connectionReconnectFailed = "error.connection.reconnect.failed"

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -3863,6 +3863,13 @@ final class NativeAppModel {
                     )
                     return
                 }
+                if transportKind == .usb,
+                    let token = USBHandshakeDiagnostic.from(
+                        stage: establishmentDiagnostic.withLock { $0 }),
+                    let event = AppDiagnosticEvent(rawValue: token.rawValue)
+                {
+                    AppDiagnostics.shared.record(event)
+                }
                 AppDiagnostics.shared.record(
                     connectionFailureDiagnostic(
                         transportKind: transportKind,
@@ -5878,11 +5885,19 @@ final class NativeAppModel {
     ) async throws -> (session: NativeCameraSession, requestedPairing: Bool) {
         connectionStageDetail = ""
         let diagnosticBox = establishmentDiagnostic
+        let isUSBHost = host.hasPrefix(DiscoveredCamera.usbHostKeyPrefix)
         let recordEstablishmentDiagnostic: @Sendable (String) -> Void = { [weak self] summary in
             // "stage:" strings are live progress (shown so a stuck connect names its step —
             // that's how the USB hang was pinned down); everything else is the failure trace.
             if summary.hasPrefix("stage:") {
                 let stage = String(summary.dropFirst("stage:".count))
+                diagnosticBox.withLock { $0 = summary }
+                if isUSBHost,
+                    let token = USBHandshakeDiagnostic.from(stage: stage),
+                    let event = AppDiagnosticEvent(rawValue: token.rawValue)
+                {
+                    AppDiagnostics.shared.record(event)
+                }
                 // Operator-friendly wording; the technical stage ids stay in the failure trace.
                 let friendly =
                     switch stage {
@@ -6070,6 +6085,7 @@ final class NativeAppModel {
         } catch {
             scanTicker.cancel()
             usbTransport.close()
+            AppDiagnostics.shared.record(.usbSessionOpen)
             throw error
         }
         scanTicker.cancel()
@@ -6096,6 +6112,7 @@ final class NativeAppModel {
                 try await retryTransport.open(recycleFirst: true)
             } catch let openError {
                 retryTransport.close()
+                AppDiagnostics.shared.record(.usbSessionOpen)
                 throw openError
             }
             return try await NativeCameraSession.establish(

--- a/ios/Runner/NativeCameraSession.swift
+++ b/ios/Runner/NativeCameraSession.swift
@@ -1299,33 +1299,42 @@ final class NativeCameraSession: @unchecked Sendable {
         // eat the 180 s USB first-command budget. [verify-on-HW: Z 6 over USB-C on iPad]
         let isUSB = transport.kind == .usb
         var gatePolicy = ZCameraOperationPolicy(operations: [])
+        var usbIccSessionProven = false
         if isUSB {
+            // ICC already opened the PTP session in `USBCameraTransport.open`. GetDeviceInfo
+            // with auto-assigned TIDs is a normal in-session command; TID 0 is reserved for
+            // OpenSession and desyncs a session ICC already holds (#254 ZR handshake).
             onStage?("capability probe")
             if let probe = try? await transact(
                 operationCode: .getDeviceInfo,
-                transactionID: 0,
                 dataPhase: .dataIn,
                 deadline: .seconds(8)
             ),
-                probe.operationResponse.responseCode == .ok,
-                let probedInfo = try? PTPDeviceInfo(data: probe.data)
+                probe.operationResponse.responseCode == .ok
             {
-                gatePolicy = ZCameraOperationPolicy(deviceInfo: probedInfo)
+                usbIccSessionProven = true
+                if let probedInfo = try? PTPDeviceInfo(data: probe.data) {
+                    gatePolicy = ZCameraOperationPolicy(deviceInfo: probedInfo)
+                }
             }
         }
 
-        onStage?("first command (OpenSession)")
-        let open = try await transact(
-            operationCode: .openSession,
-            transactionID: 0,
-            parameters: [1],
-            deadline: isUSB ? .seconds(180) : Self.commandTransactionTimeout
-        )
-        // `Session_Already_Open` is success: over USB, ImageCaptureCore opens the PTP session
-        // itself before handing the device to the app. [VERIFY-ON-HW] on the ZR over USB-C.
-        let openResponse = open.operationResponse.responseCode
-        guard openResponse == .ok || openResponse == .sessionAlreadyOpen else {
-            throw NativeCameraSessionError.operationRejected(.openSession, openResponse)
+        if !usbIccSessionProven {
+            onStage?("first command (OpenSession)")
+            let open = try await transact(
+                operationCode: .openSession,
+                transactionID: 0,
+                parameters: [1],
+                deadline: isUSB ? .seconds(180) : Self.commandTransactionTimeout
+            )
+            // `Session_Already_Open` is success: over USB, ImageCaptureCore opens the PTP
+            // session itself before handing the device to the app. [VERIFY-ON-HW] on the ZR.
+            let openResponse = open.operationResponse.responseCode
+            guard openResponse == .ok || openResponse == .sessionAlreadyOpen else {
+                throw NativeCameraSessionError.operationRejected(.openSession, openResponse)
+            }
+        } else {
+            establishmentSummary += "openSession=icc "
         }
 
         // DeviceInfo before pairing or the app-control switch, because both must be gated

--- a/ios/Runner/USBCameraTransport.swift
+++ b/ios/Runner/USBCameraTransport.swift
@@ -330,43 +330,58 @@ final class USBCameraTransport: NSObject, CameraTransport, ICCameraDeviceDelegat
     func open(timeout: Duration = .seconds(30), recycleFirst: Bool = false) async throws {
         device.delegate = self
         USBCameraDeviceBrowser.shared.adoptSession(self)
-        // If the attach-time pre-warm's open is still in flight, wait it out instead of issuing a
-        // duplicate requestOpenSession — ICC swallows the duplicate, so a connect started in that
-        // window used to hang for the full timeout.
         let waitStart = ContinuousClock.now
-        while !device.hasOpenSession,
-            USBCameraDeviceBrowser.shared.isPrewarmOpenInFlight(for: device),
-            ContinuousClock.now - waitStart < timeout
-        {
-            try await Task.sleep(for: .milliseconds(100))
-        }
-        if recycleFirst, device.hasOpenSession {
-            // Retry path: the adopted session just failed its first command — it went stale while
-            // parked (camera sleep, ICC housekeeping). Close it for real, await the ack (bounded),
-            // and fall through to a fresh open. Costs a new card scan; correctness over speed here.
-            await recycleStaleSession()
-        }
-        // Adopt an already-open session (attach-time pre-warm, or a previous connect that parked
-        // it warm). The passthrough gate, if ICC's catalog pass is still running, is waited out by
-        // the first transaction's long USB deadline — a close→reopen "abort" was tried here and
-        // did NOT skip the gate on the ZR; it only risks restarting a mostly-done pass.
-        if device.hasOpenSession {
-            lock.withLock { didOpenSession = true }
-            return
-        }
-        let timeoutTask = Task { [weak self] in
-            try? await Task.sleep(for: timeout)
-            guard !Task.isCancelled else { return }
-            self?.resumeOpen(
-                throwing: NativeCameraSessionError.timeout("USB camera session open"))
-        }
-        defer { timeoutTask.cancel() }
-        try await withCheckedThrowingContinuation {
-            (continuation: CheckedContinuation<Void, Error>) in
-            lock.lock()
-            openContinuation = continuation
-            lock.unlock()
-            device.requestOpenSession()
+        var recycleCompleted = false
+        while true {
+            try Task.checkCancellation()
+            if ContinuousClock.now - waitStart >= timeout {
+                throw NativeCameraSessionError.timeout("USB camera session open")
+            }
+            let decision = USBICCSessionOpenPolicy.decision(
+                hasOpenSession: device.hasOpenSession,
+                prewarmInFlight: USBCameraDeviceBrowser.shared.isPrewarmOpenInFlight(for: device),
+                recycleFirst: recycleFirst,
+                recycleCompleted: recycleCompleted
+            )
+            switch decision {
+            case .waitForPrewarm:
+                // Duplicate requestOpenSession is swallowed by ICC, so a connect started during
+                // attach-time pre-warm used to hang for the full timeout.
+                try await Task.sleep(for: .milliseconds(100))
+            case .recycleThenOpen:
+                // Retry path: the adopted session just failed its first command — it went stale
+                // while parked (camera sleep, ICC housekeeping). Close it for real, await the ack
+                // (bounded), then open fresh. Costs a new card scan; correctness over speed here.
+                await recycleStaleSession()
+                recycleCompleted = true
+            case .failStillOpenAfterRecycle:
+                // #254: adopting here reused the corpse the first command just failed on, so the
+                // "fresh" attempt died in 1–2 s with the same ICC error and needed a force-quit.
+                throw NativeCameraSessionError.connectionFailed(
+                    "The USB link got stuck. Unplug the cable, plug it back in, and try again.")
+            case .adoptExisting:
+                // Attach-time pre-warm, or a previous connect that parked the catalog warm.
+                lock.withLock { didOpenSession = true }
+                return
+            case .requestOpen:
+                let elapsed = ContinuousClock.now - waitStart
+                let remaining = elapsed < timeout ? timeout - elapsed : .milliseconds(1)
+                let timeoutTask = Task { [weak self] in
+                    try? await Task.sleep(for: remaining)
+                    guard !Task.isCancelled else { return }
+                    self?.resumeOpen(
+                        throwing: NativeCameraSessionError.timeout("USB camera session open"))
+                }
+                defer { timeoutTask.cancel() }
+                try await withCheckedThrowingContinuation {
+                    (continuation: CheckedContinuation<Void, Error>) in
+                    lock.lock()
+                    openContinuation = continuation
+                    lock.unlock()
+                    device.requestOpenSession()
+                }
+                return
+            }
         }
     }
 

--- a/ios/RunnerTests/ExternalBetaReadinessTests.swift
+++ b/ios/RunnerTests/ExternalBetaReadinessTests.swift
@@ -255,6 +255,33 @@ struct AnonymousBugReportTests {
         #expect(snapshot.allSatisfy { AppDiagnosticEvent(rawValue: $0) != nil })
     }
 
+    @Test("USB handshake stages round-trip through the closed diagnostic vocabulary")
+    func usbHandshakeStagesAreClosedEvents() {
+        let stages: [USBHandshakeDiagnostic] = [
+            .sessionOpen, .deviceInfo, .openSession, .appMode, .identify,
+        ]
+        for stage in stages {
+            #expect(AppDiagnosticEvent(rawValue: stage.rawValue) != nil)
+        }
+
+        let snapshot = DiagnosticEventStore.anonymousActivityLog(
+            events: stages.enumerated().map { index, stage in
+                DiagnosticBreadcrumb(
+                    timestamp: Date(timeIntervalSince1970: 1_700_000_100 + TimeInterval(index)),
+                    event: stage.rawValue)
+            }
+        )
+        #expect(
+            snapshot == [
+                "usb.session.open",
+                "usb.handshake.device-info",
+                "usb.handshake.open-session",
+                "usb.handshake.app-mode",
+                "usb.handshake.identify",
+            ])
+        #expect(snapshot.allSatisfy { AppDiagnosticEvent(rawValue: $0) != nil })
+    }
+
     @Test("Screenshot sanitizer re-renders a metadata-bearing image as a clean bounded PNG")
     func screenshotSanitizer() throws {
         let source = try pngWithDescription("Bob’s iPhone")

--- a/ios/RunnerTests/NativeCameraEstablishRetryTests.swift
+++ b/ios/RunnerTests/NativeCameraEstablishRetryTests.swift
@@ -110,3 +110,157 @@ struct NativeCameraEstablishRetryTests {
         )
     }
 }
+
+/// USB establish over a scripted transport — ICC has already opened the PTP session
+/// (`USBCameraTransport.open` returns only after `hasOpenSession`).
+@Suite("USB establish after ICC session open")
+struct USBEstablishSequenceTests {
+    @Test("A successful in-session GetDeviceInfo skips a second PTP OpenSession")
+    func skipRedundantOpenSession() async throws {
+        let transport = ScriptedUSBTransport { operation, transactionID in
+            #expect(operation != .openSession, "ICC already opened the session")
+            if operation == .getDeviceInfo {
+                #expect(transactionID == nil, "in-session GetDeviceInfo must not reuse TID 0")
+                return try usbOK(data: zrDeviceInfoBytes())
+            }
+            return try usbOK()
+        }
+
+        let session = try await NativeCameraSession.establish(
+            transport: transport,
+            host: "usb:zr-handshake-tests",
+            cameraName: "Nikon ZR",
+            requestPairing: false
+        )
+
+        #expect(session.transportKind == .usb)
+        #expect(!transport.operations.contains(.openSession))
+        #expect(transport.operations.contains(.getDeviceInfo))
+        transport.close()
+    }
+
+    @Test("A failed USB probe still sends OpenSession and reports that stage")
+    func failedProbeStillOpensSession() async {
+        let transport = ScriptedUSBTransport { operation, _ in
+            if operation == .openSession {
+                throw NativeCameraSessionError.connectionFailed(
+                    "The operation couldn’t be completed. (com.apple.ImageCaptureCore error -21400.)"
+                )
+            }
+            throw NativeCameraSessionError.connectionFailed("probe failed")
+        }
+        let stages = StageLog()
+
+        await #expect(throws: NativeCameraSessionError.self) {
+            _ = try await NativeCameraSession.establish(
+                transport: transport,
+                host: "usb:zr-handshake-tests",
+                cameraName: "Nikon ZR",
+                requestPairing: false,
+                onEstablishmentDiagnostic: { stages.append($0) }
+            )
+        }
+
+        let recorded = stages.snapshot
+        #expect(recorded.contains(where: { $0.contains("OpenSession") }))
+        #expect(
+            USBHandshakeDiagnostic.from(stage: recorded.last { $0.hasPrefix("stage:") } ?? "")
+                == .openSession)
+        #expect(transport.didClose)
+    }
+}
+
+private final class StageLog: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [String] = []
+
+    func append(_ value: String) {
+        lock.lock()
+        values.append(value)
+        lock.unlock()
+    }
+
+    var snapshot: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
+    }
+}
+
+private final class ScriptedUSBTransport: CameraTransport, @unchecked Sendable {
+    let kind: CameraTransportKind = .usb
+    private(set) var operations: [PTPOperationCode] = []
+    private(set) var didClose = false
+    private let handler:
+        @Sendable (PTPOperationCode, UInt32?) async throws -> PTPIPTransactionResult
+
+    init(
+        handler:
+            @escaping @Sendable (PTPOperationCode, UInt32?) async throws ->
+            PTPIPTransactionResult
+    ) {
+        self.handler = handler
+    }
+
+    func executeTransaction(
+        operationCode: PTPOperationCode,
+        transactionID: UInt32?,
+        parameters: [UInt32],
+        dataPhase: PTPDataPhase,
+        dataOut: Data?,
+        deadline: Duration?
+    ) async throws -> PTPIPTransactionResult {
+        operations.append(operationCode)
+        return try await handler(operationCode, transactionID)
+    }
+
+    func nextEvent() async throws -> PTPEvent {
+        throw NativeCameraSessionError.connectionClosed
+    }
+
+    func close() { didClose = true }
+}
+
+private func usbOK(data: Data = Data(), transactionID: UInt32 = 1) throws -> PTPIPTransactionResult
+{
+    let payload =
+        ByteCoding.uint16LE(PTPResponseCode.ok.rawValue) + ByteCoding.uint32LE(transactionID)
+    return PTPIPTransactionResult(
+        operationResponse: try PTPOperationResponse(payloadBytes: payload),
+        data: data
+    )
+}
+
+private func zrDeviceInfoBytes() -> Data {
+    var bytes: [UInt8] = [
+        100, 0,
+        10, 0, 0, 0,
+        100, 0,
+    ]
+    bytes.append(contentsOf: ptpString(""))
+    bytes.append(contentsOf: [0, 0])
+    bytes.append(contentsOf: emptyUInt16Array())
+    bytes.append(contentsOf: emptyUInt16Array())
+    bytes.append(contentsOf: emptyUInt16Array())
+    bytes.append(contentsOf: emptyUInt16Array())
+    bytes.append(contentsOf: emptyUInt16Array())
+    bytes.append(contentsOf: ptpString("Nikon"))
+    bytes.append(contentsOf: ptpString("ZR"))
+    bytes.append(contentsOf: ptpString("1.0"))
+    bytes.append(contentsOf: ptpString("ABC123"))
+    return Data(bytes)
+}
+
+private func ptpString(_ value: String) -> [UInt8] {
+    guard !value.isEmpty else { return [0] }
+    var bytes = [UInt8(value.utf16.count + 1)]
+    for unit in value.utf16 {
+        bytes += ByteCoding.uint16LE(unit)
+    }
+    bytes += [0, 0]
+    return bytes
+}
+
+private func emptyUInt16Array() -> [UInt8] {
+    [0, 0, 0, 0]
+}

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -9,19 +9,19 @@ New and changed
 
 Fixes
 
+- USB-C reconnects after the cable is knocked loose, or after a few seconds in the background, without force-quitting the app.
 - Original Z 6, Z 5, and Z 7 no longer get pairing steps they do not support. iPad USB-C copy says this device, not iPhone.
 - Format a card and Media used to keep the old clip names. REFRESH now follows the card, and Settings > Clear Cache reloads Media from the card.
 - Share and Save to Photos work on clips from the camera. They used to fail with "Invalid sample cursor".
 - Share on the player is available while the camera is connected. You no longer have to disconnect and go through Operator Setup to reach it.
-- On iPad in photo mode, the battery gauges sit beside the lock instead of covering PLAY.
 - Photo FOCUS follows stills AF, not leftover video AF-F. After a focus-dial pull, a tap focuses without a half-press.
 - Aperture-priority shutter and ISO follow the camera as it meters - they used to sit stale, take twenty seconds, or in video never.
 - A camera whose clock has drifted is set to your phone's time on connect - automatically, never while recording.
 
 What to test
 
+- Plug in over USB-C, connect, then knock the cable loose and plug it back in. It should come back without force-quitting. Background the app for a few seconds with the cable in, then return.
 - If you have an original Z 6, Z 5, or Z 7, connect over USB-C and the camera's own Wi-Fi. It should reach the monitor without a wireless error on the camera.
 - Format a spare card or delete a shot, then tap REFRESH on Media: gone files leave and new ones show. Clear Cache in Settings and reopen Media to rebuild from the card.
-- Connect to the camera, play a clip, tap Share, then Share and Save to Photos. Both should finish. You should not have to disconnect first.
 - Put the body in Aperture-priority photo, change the light, and check shutter and ISO on the phone match the camera.
 - Set stills AF-S and video full-time AF. Photo FOCUS should match the Focus panel, not leftover AF-F. Pull the focus dial, then tap: it should focus without a half-press.


### PR DESCRIPTION
## What & why

[#254](https://github.com/erik-sutton95/OpenZCine/issues/254) — iOS USB did not recover after a cable knock, brief backgrounding, or a handshake that died in one or two seconds with `error.connection.usb.failed`. The August ZR report on current iPhone hardware reproduced after the earlier recovery fix in #281.

ImageCaptureCore already owns the PTP session. Two things in the connect path fought that:

- After the first command failed (ICC `-21400`), recycle called `requestCloseSession` then still **adopted** the session if `hasOpenSession` stayed true. The “fresh” attempt reused the corpse and died immediately.
- USB then sent a second PTP `OpenSession` and `GetDeviceInfo` with transaction ID 0 into a session ICC had already opened.

This PR:

- Fails closed when a recycle leaves the ICC session open, then issues a real `requestOpenSession`.
- Skips a redundant PTP `OpenSession` when in-session `GetDeviceInfo` succeeds, using normal transaction IDs.
- Records closed handshake stages in the diagnostic export (`usb.session.open`, `usb.handshake.device-info`, `usb.handshake.open-session`, `usb.handshake.app-mode`, `usb.handshake.identify`) so the next report names the step instead of collapsing into `error.connection.usb.failed`.

**Single-platform:** ImageCaptureCore session ownership is iOS-only. Android already ships USB handshake stages and reconnect (#349). Shared diagnostic tokens live in `OpenZCineCore` so both shells name the same step.

Kaneo: OPE-115

## TestFlight notes

Updated `ios/TestFlight/WhatToTest.en-US.txt`.

## Google Play notes

Updated `Apps/Android/distribution/whatsnew/whatsnew-en-US` (shared-core path requires Play notes; no Android product change).

## Test plan

- [x] `just check`
- [x] `just native-check`
- [x] Recycle that leaves the ICC session open fails instead of adopting
- [x] USB establish skips redundant OpenSession after in-session GetDeviceInfo
- [x] Handshake stages round-trip through the closed diagnostic vocabulary
- [x] **[VERIFY-ON-HW]** ZR USB-C connect on iPhone 16 Pro Max, iOS 26.6 — connects without force-quit
- [x] **[VERIFY-ON-HW]** Knock the USB-C cable loose and plug it back in
- [x] **[VERIFY-ON-HW]** Background for a few seconds with the cable in, then return

## Checklist

- [x] `just check` passes.
- [x] Native production changes: `just native-check` passes.
- [x] Commits follow Conventional Commits.
- [x] No proprietary assets (`vendor/`, `ref/`) are included.
- [x] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy.
- [x] Play-triggering changes include reviewed `Apps/Android/distribution/whatsnew/whatsnew-en-US` copy.

Closes #254