### PR TITLE
fix: stop treating a Z 6III USB product name as an original Z 6

### DIFF
--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/MainActivity.kt
@@ -407,7 +407,11 @@ class MainActivity : ComponentActivity() {
                 val pairingEnvironment =
                     remember(pairingScript) {
                         pairingScript?.environment
-                            ?: realPairingEnvironment(applicationContext) { phase, _ ->
+                            ?: realPairingEnvironment(applicationContext) { phase, detail ->
+                                if (phase == "connect.gate") {
+                                    diagnostics.recordConnectTrace(detail)
+                                    return@realPairingEnvironment
+                                }
                                 // Closed phase tokens only; free-form detail is discarded here.
                                 AndroidDiagnosticEvent.fromPhase(phase)?.let {
                                     diagnostics.record(it)
@@ -904,8 +908,10 @@ class MainActivity : ComponentActivity() {
                                         }
                                     },
                                     onDiagnosticPhase = { phase ->
-                                        AndroidDiagnosticEvent.fromPhase(phase)?.let {
-                                            diagnostics.record(it)
+                                        if (phase != "connect.gate") {
+                                            AndroidDiagnosticEvent.fromPhase(phase)?.let {
+                                                diagnostics.record(it)
+                                            }
                                         }
                                     },
                                 )

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/diagnostics/AndroidAppDiagnostics.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/diagnostics/AndroidAppDiagnostics.kt
@@ -102,6 +102,18 @@ internal class AndroidAppDiagnostics private constructor(
         runCatching { store.record(event) }
     }
 
+    fun recordConnectTrace(line: String) {
+        runCatching { store.recordConnectTrace(line) }
+        when {
+            line.contains("fallback=gen1-name") ->
+                record(AndroidDiagnosticEvent.CONNECTION_GATE_GEN1_FALLBACK)
+            line.contains("ops=unknown") ->
+                record(AndroidDiagnosticEvent.CONNECTION_GATE_UNKNOWN_OPS)
+            line.contains("join=prefix") ->
+                record(AndroidDiagnosticEvent.CONNECTION_JOIN_PREFIX)
+        }
+    }
+
     /**
      * The opt-in anonymous-report activity log, reduced to closed event and incident codes.
      *
@@ -134,6 +146,7 @@ internal class AndroidAppDiagnostics private constructor(
                         ),
                     events = store.recentEvents(),
                     historicalExits = exitReader.recentExits(),
+                    connectTrace = store.recentConnectTrace(),
                 )
             File(readyDirectory, "OpenZCine-Android-Diagnostics-$generatedAt.txt").also { file ->
                 file.writeText(report, Charsets.UTF_8)

--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/diagnostics/DiagnosticEventStore.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/diagnostics/DiagnosticEventStore.kt
@@ -92,6 +92,10 @@ internal enum class AndroidDiagnosticEvent(val wireValue: String) {
     // log, not the vocabulary.
     PROPERTY_WRITE_SLOW("camera.write.slow"),
 
+    CONNECTION_GATE_GEN1_FALLBACK("connection.gate.gen1-fallback"),
+    CONNECTION_GATE_UNKNOWN_OPS("connection.gate.unknown-ops"),
+    CONNECTION_JOIN_PREFIX("connection.join.prefix"),
+
     // Camera-AP credential scanner: on-device OCR could not run. The two codes
     // separate a recoverable state from a device/build that will never manage
     // it, so a report distinguishes "retry helped" from "OCR is impossible here".
@@ -158,6 +162,11 @@ internal enum class AndroidDiagnosticEvent(val wireValue: String) {
                 "liveViewFailed" -> LIVE_VIEW_FAILED
                 "liveViewStalled" -> LIVE_VIEW_STALLED
                 "propertyWriteSlow" -> PROPERTY_WRITE_SLOW
+                "gate.gen1Fallback",
+                "connect.gate.gen1",
+                -> CONNECTION_GATE_GEN1_FALLBACK
+                "gate.unknownOps" -> CONNECTION_GATE_UNKNOWN_OPS
+                "join.prefix" -> CONNECTION_JOIN_PREFIX
                 else -> null
             }
 
@@ -249,6 +258,34 @@ internal class DiagnosticEventStore(
         writeEvents(bounded(next))
     }
 
+    /**
+     * Appends one already-sanitized connect-attempt line. Stays on the phone until
+     * the operator shares a diagnostics report; never enters the anonymous log.
+     */
+    @Synchronized
+    fun recordConnectTrace(line: String) {
+        val sanitized = line.trim()
+        if (sanitized.isEmpty() || sanitized.length > 240) return
+        if (sanitized.any { it == '\n' || it == '\r' }) return
+        val file = connectTraceFile()
+        file.parentFile?.mkdirs()
+        file.appendText("${nowMillis()} $sanitized\n", Charsets.UTF_8)
+        trimConnectTrace(file)
+    }
+
+    @Synchronized
+    fun recentConnectTrace(): List<String> {
+        val file = connectTraceFile()
+        if (!file.isFile) return emptyList()
+        return file.useLines { lines ->
+            lines
+                .map { it.trim() }
+                .filter { it.isNotEmpty() }
+                .toList()
+                .takeLast(CONNECT_TRACE_MAXIMUM_LINES)
+        }
+    }
+
     @Synchronized
     fun recentEvents(): List<DiagnosticBreadcrumb> {
         if (!eventFile.isFile) return emptyList()
@@ -300,6 +337,17 @@ internal class DiagnosticEventStore(
     private fun encodeLine(event: DiagnosticBreadcrumb): String =
         "${event.timestampMillis}|${event.event.wireValue}"
 
+    private fun connectTraceFile(): File = File(eventFile.parentFile, "connect-trace.log")
+
+    private fun trimConnectTrace(file: File) {
+        val lines = file.readLines().filter { it.isNotBlank() }
+        if (lines.size <= CONNECT_TRACE_MAXIMUM_LINES) return
+        file.writeText(
+            lines.takeLast(CONNECT_TRACE_MAXIMUM_LINES).joinToString(separator = "\n", postfix = "\n"),
+            Charsets.UTF_8,
+        )
+    }
+
     private fun decodeLine(line: String): DiagnosticBreadcrumb? {
         val delimiter = line.indexOf('|')
         if (delimiter <= 0 || delimiter == line.lastIndex) return null
@@ -311,6 +359,7 @@ internal class DiagnosticEventStore(
     internal companion object {
         const val DEFAULT_MAXIMUM_EVENT_COUNT: Int = 500
         const val DEFAULT_MAXIMUM_EVENT_BYTES: Int = 256 * 1_024
+        const val CONNECT_TRACE_MAXIMUM_LINES: Int = 200
         private const val MINIMUM_EVENT_BYTES: Int = 128
     }
 }
@@ -321,6 +370,7 @@ internal object DiagnosticReportRenderer {
         metadata: DiagnosticReportMetadata,
         events: List<DiagnosticBreadcrumb>,
         historicalExits: List<DiagnosticHistoricalExit>,
+        connectTrace: List<String> = emptyList(),
     ): String {
         val version = normalizedVersion(metadata.appVersion)
         val lines =
@@ -332,6 +382,9 @@ internal object DiagnosticReportRenderer {
                 "This local report intentionally excludes camera identities and serials, Wi-Fi",
                 "names and network addresses, media names and paths, account identities and tokens,",
                 "credentials, camera frames, arbitrary exception text, and user-entered text.",
+                "The connect-attempt trace is closed tokens only (body family, DeviceInfo",
+                "known/unknown, pairing decision) and never leaves this phone unless you share",
+                "this file.",
                 "No diagnostics are uploaded automatically by OpenZCine.",
                 "Anonymous reports can include only separately selected closed app-event and incident codes.",
                 "",
@@ -347,6 +400,16 @@ internal object DiagnosticReportRenderer {
         } else {
             events.takeLast(DiagnosticEventStore.DEFAULT_MAXIMUM_EVENT_COUNT).forEach { event ->
                 lines += "${isoTimestamp(event.timestampMillis)}  ${event.event.wireValue}"
+            }
+        }
+        lines += ""
+        lines += "Connect attempt trace"
+        lines += "---------------------"
+        if (connectTrace.isEmpty()) {
+            lines += "No retained connect-attempt trace."
+        } else {
+            connectTrace.takeLast(DiagnosticEventStore.CONNECT_TRACE_MAXIMUM_LINES).forEach { line ->
+                lines += line
             }
         }
         lines += ""

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/diagnostics/DiagnosticEventStoreTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/diagnostics/DiagnosticEventStoreTest.kt
@@ -188,7 +188,37 @@ class DiagnosticEventStoreTest {
         assertTrue(report.contains("ANR  foreground"))
         assertTrue(report.contains("No diagnostics are uploaded"))
         assertTrue(report.contains("arbitrary exception text"))
+        assertTrue(report.contains("Connect attempt trace"))
         assertFalse(report.contains("beta!"))
+    }
+
+    @Test
+    fun `connect trace stays out of the anonymous activity log`() {
+        val file = temporaryEventFile()
+        val store = DiagnosticEventStore(file, nowMillis = { 1_000 })
+        store.record(AndroidDiagnosticEvent.CONNECTION_CONNECTED)
+        store.recordConnectTrace("event=connect.gate body=z6iii inferred=three ops=unknown")
+
+        val activity = store.privacyFilteredActivityLog()
+        assertEquals(listOf("connection.connected"), activity)
+        assertFalse(activity.joinToString().contains("z6iii"))
+
+        val report =
+            DiagnosticReportRenderer.render(
+                metadata =
+                    DiagnosticReportMetadata(
+                        generatedAtMillis = 1_000,
+                        appVersion = "0.2.5",
+                        buildNumber = 1,
+                        androidApi = 34,
+                        deviceClass = DiagnosticDeviceClass.PHONE,
+                    ),
+                events = store.recentEvents(),
+                historicalExits = emptyList(),
+                connectTrace = store.recentConnectTrace(),
+            )
+        assertTrue(report.contains("body=z6iii"))
+        assertTrue(report.contains("ops=unknown"))
     }
 
     @Test

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,4 +1,4 @@
-- Fixed: original Z 6, Z 5, and Z 7 connect without pairing steps they do not support.
+- Fixed: original Z 6 / Z 5 / Z 7 skip pairing they lack; Z 6III is not treated as Z 6. Share Diagnostics keeps a connect trace until you send it.
 - Fixed: USB-C connect after permission, and a retry after the picture drops should stay up.
 - Fixed: Aperture-priority shutter and ISO on the phone follow the camera as it meters.
 - Fixed: photo FOCUS and taps follow stills AF, not leftover video AF-F.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,14 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- **Z 6III USB product names are no longer treated as an original Z 6.** Nikon's USB
+  iProduct `NIKON DSC Z6_3` (and `Z 6_2` / `Z5_2`) was compacted to `Z63` and matched
+  generation 1, so a missed DeviceInfo probe skipped pairing and wrote the gen-1
+  ApplicationMode property — the camera-side connection error in Discussion #12.
+  Camera AP setups that cannot derive an SSID from a Z 6III name now prefix-join a
+  Nikon camera network instead of skipping the join. Share Diagnostics includes a
+  local-only connect-attempt trace (body family, DeviceInfo known/unknown, pairing
+  decision) that never leaves the phone unless the operator shares the file.
 - **Original Z 6 / Z 5 / Z 7 connect no longer sends pairing or ChangeApplicationMode when
   DeviceInfo is missing.** Those bodies have no pairing handshake; polling it is what put a
   wireless error on the camera and left the app connecting. The PTP-IP name or USB product name

--- a/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
+++ b/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
@@ -727,6 +727,10 @@ public final class PTPIPClientSession: @unchecked Sendable {
     /// callers, so reads never race the write.
     public private(set) var identity: PTPIPClientIdentity
 
+    /// Privacy-safe connect-gate line sink. Set by the JNI connect wrappers so
+    /// a Share Diagnostics report can show body family and DeviceInfo outcome.
+    var connectTraceSink: ((String) -> Void)?
+
     /// True only for the production target whose stable descriptor omissions have explicit policy.
     private var usesNikonZRFallbacks: Bool {
         let manufacturer = identity.manufacturer.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -770,7 +774,8 @@ public final class PTPIPClientSession: @unchecked Sendable {
         friendlyName: String = AndroidPTPIPInitiator.friendlyName,
         timeoutMilliseconds: Int32 = 10_000,
         strategy: ConnectionStrategy = .restoreProfileThenPairing,
-        onPhase: (CameraConnectionPhase, String) -> Void = { _, _ in }
+        onPhase: (CameraConnectionPhase, String) -> Void = { _, _ in },
+        onConnectTrace: @escaping (String) -> Void = { _ in }
     ) throws -> PTPIPClientSession {
         onPhase(.handshaking, "")
         switch strategy {
@@ -781,7 +786,8 @@ public final class PTPIPClientSession: @unchecked Sendable {
                 guid: guid,
                 friendlyName: friendlyName,
                 timeoutMilliseconds: timeoutMilliseconds,
-                onPhase: onPhase
+                onPhase: onPhase,
+                onConnectTrace: onConnectTrace
             )
         case .firstTimePairing:
             return try connectFirstTimePairing(
@@ -790,7 +796,8 @@ public final class PTPIPClientSession: @unchecked Sendable {
                 guid: guid,
                 friendlyName: friendlyName,
                 timeoutMilliseconds: timeoutMilliseconds,
-                onPhase: onPhase
+                onPhase: onPhase,
+                onConnectTrace: onConnectTrace
             )
         case .restoreProfileThenPairing:
             do {
@@ -800,7 +807,8 @@ public final class PTPIPClientSession: @unchecked Sendable {
                     guid: guid,
                     friendlyName: friendlyName,
                     timeoutMilliseconds: timeoutMilliseconds,
-                    onPhase: onPhase
+                    onPhase: onPhase,
+                    onConnectTrace: onConnectTrace
                 )
             } catch {
                 guard let sessionError = error as? PTPIPClientSessionError,
@@ -814,7 +822,8 @@ public final class PTPIPClientSession: @unchecked Sendable {
                     guid: guid,
                     friendlyName: friendlyName,
                     timeoutMilliseconds: timeoutMilliseconds,
-                    onPhase: onPhase
+                    onPhase: onPhase,
+                    onConnectTrace: onConnectTrace
                 )
             }
         }
@@ -833,7 +842,8 @@ public final class PTPIPClientSession: @unchecked Sendable {
         guid: Data,
         friendlyName: String,
         timeoutMilliseconds: Int32,
-        onPhase: (CameraConnectionPhase, String) -> Void
+        onPhase: (CameraConnectionPhase, String) -> Void,
+        onConnectTrace: @escaping (String) -> Void
     ) throws -> PTPIPClientSession {
         do {
             return try connectSavedProfile(
@@ -842,7 +852,8 @@ public final class PTPIPClientSession: @unchecked Sendable {
                 guid: guid,
                 friendlyName: friendlyName,
                 timeoutMilliseconds: timeoutMilliseconds,
-                onPhase: onPhase
+                onPhase: onPhase,
+                onConnectTrace: onConnectTrace
             )
         } catch PTPIPClientSessionError.initFailed(.busy) {
             Thread.sleep(forTimeInterval: 5)
@@ -852,7 +863,8 @@ public final class PTPIPClientSession: @unchecked Sendable {
                 guid: guid,
                 friendlyName: friendlyName,
                 timeoutMilliseconds: timeoutMilliseconds,
-                onPhase: onPhase
+                onPhase: onPhase,
+                onConnectTrace: onConnectTrace
             )
         }
     }
@@ -863,7 +875,8 @@ public final class PTPIPClientSession: @unchecked Sendable {
         guid: Data,
         friendlyName: String,
         timeoutMilliseconds: Int32,
-        onPhase: (CameraConnectionPhase, String) -> Void
+        onPhase: (CameraConnectionPhase, String) -> Void,
+        onConnectTrace: @escaping (String) -> Void
     ) throws -> PTPIPClientSession {
         let session = try establishLink(
             host: host,
@@ -872,6 +885,7 @@ public final class PTPIPClientSession: @unchecked Sendable {
             friendlyName: friendlyName,
             timeoutMilliseconds: timeoutMilliseconds
         )
+        session.connectTraceSink = onConnectTrace
         do {
             try establishSavedProfile(on: session, onPhase: onPhase)
             return session
@@ -886,7 +900,7 @@ public final class PTPIPClientSession: @unchecked Sendable {
         onPhase: (CameraConnectionPhase, String) -> Void
     ) throws {
         try session.openSession()
-        let policy = session.probeOperationPolicy()
+        let policy = session.probeOperationPolicy(requestPairing: false)
         guard try session.enableAppControl(policy: policy) else {
             throw PTPIPClientSessionError.savedProfileRequired
         }
@@ -954,7 +968,8 @@ public final class PTPIPClientSession: @unchecked Sendable {
         guid: Data,
         friendlyName: String,
         timeoutMilliseconds: Int32,
-        onPhase: (CameraConnectionPhase, String) -> Void
+        onPhase: (CameraConnectionPhase, String) -> Void,
+        onConnectTrace: @escaping (String) -> Void
     ) throws -> PTPIPClientSession {
         let session = try establishLink(
             host: host,
@@ -963,6 +978,7 @@ public final class PTPIPClientSession: @unchecked Sendable {
             friendlyName: friendlyName,
             timeoutMilliseconds: timeoutMilliseconds
         )
+        session.connectTraceSink = onConnectTrace
         do {
             try establishFirstTimePairing(on: session, onPhase: onPhase)
             return session
@@ -977,7 +993,7 @@ public final class PTPIPClientSession: @unchecked Sendable {
         onPhase: (CameraConnectionPhase, String) -> Void
     ) throws {
         try session.openSession()
-        let policy = session.probeOperationPolicy()
+        let policy = session.probeOperationPolicy(requestPairing: true)
         guard policy.supportsPairing else {
             // No pairing surface on this body (gen 1): joining its access point IS the trust
             // boundary, so first-time connect is just the saved-profile shape. Polling
@@ -1021,7 +1037,8 @@ public final class PTPIPClientSession: @unchecked Sendable {
             host: String,
             cameraNameHint: String,
             strategy: ConnectionStrategy = .restoreProfileThenPairing,
-            onPhase: (CameraConnectionPhase, String) -> Void = { _, _ in }
+            onPhase: (CameraConnectionPhase, String) -> Void = { _, _ in },
+            onConnectTrace: @escaping (String) -> Void = { _ in }
         ) throws -> PTPIPClientSession {
             onPhase(.handshaking, "")
             let session = PTPIPClientSession(
@@ -1034,6 +1051,7 @@ public final class PTPIPClientSession: @unchecked Sendable {
                     serialNumber: ""
                 )
             )
+            session.connectTraceSink = onConnectTrace
             // The privacy-safe USB key is a Kotlin-local saved-record lookup;
             // PTP has no network host, so it is neither addressed nor sent here.
             _ = host
@@ -1069,7 +1087,14 @@ public final class PTPIPClientSession: @unchecked Sendable {
                 {
                     policy = ZCameraOperationPolicy(deviceInfo: info)
                 }
+                let probedKnown = policy.isKnown
                 policy = policy.resolvingUnknown(cameraName: cameraNameHint)
+                session.emitConnectGate(
+                    probedKnown: probedKnown,
+                    policy: policy,
+                    isUSB: true,
+                    requestPairing: false
+                )
                 try establishUSBSession(on: session, policy: policy, onPhase: onPhase)
                 return session
             } catch {
@@ -1147,7 +1172,7 @@ public final class PTPIPClientSession: @unchecked Sendable {
     /// rejection — a Z 5 polled with a pairing op it never implemented put a wireless error on its
     /// own screen (#292). Best-effort: a failed fetch yields an unknown policy, which keeps the
     /// modern-surface behaviour on every path. [verify-on-HW: Z 5 over camera AP]
-    private func probeOperationPolicy() -> ZCameraOperationPolicy {
+    private func probeOperationPolicy(requestPairing: Bool) -> ZCameraOperationPolicy {
         let probed: ZCameraOperationPolicy
         if let probe = try? executeTransaction(.getDeviceInfo, dataPhase: .dataIn),
             probe.operationResponse.responseCode == .ok,
@@ -1157,7 +1182,36 @@ public final class PTPIPClientSession: @unchecked Sendable {
         } else {
             probed = ZCameraOperationPolicy(operations: [])
         }
-        return probed.resolvingUnknown(cameraName: identity.cameraName)
+        let resolved = probed.resolvingUnknown(cameraName: identity.cameraName)
+        emitConnectGate(
+            probedKnown: probed.isKnown,
+            policy: resolved,
+            isUSB: false,
+            requestPairing: requestPairing
+        )
+        return resolved
+    }
+
+    fileprivate func emitConnectGate(
+        probedKnown: Bool,
+        policy: ZCameraOperationPolicy,
+        isUSB: Bool,
+        requestPairing: Bool
+    ) {
+        guard
+            let line = ConnectAttemptDiagnostic.line(
+                event: "connect.gate",
+                cameraName: identity.cameraName,
+                facts: [
+                    "ops": probedKnown ? "known" : "unknown",
+                    "fallback": (!probedKnown && policy.isKnown) ? "gen1-name" : "none",
+                    "pairing": ConnectAttemptDiagnostic.pairingDecision(
+                        policy: policy, isUSB: isUSB, requestPairing: requestPairing),
+                    "transport": isUSB ? "usb" : "ptpIP",
+                ]
+            )
+        else { return }
+        connectTraceSink?(line)
     }
 
     /// Nikon app-control gate. `true` when the camera accepted app control —

--- a/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
+++ b/Sources/OpenZCineAndroidFacade/SwiftCoreJNI.swift
@@ -1167,6 +1167,9 @@
                 strategy: strategy,
                 onPhase: { phase, detail in
                     callStrings(handle.onPhase, [String(describing: phase), detail])
+                },
+                onConnectTrace: { line in
+                    callStrings(handle.onPhase, ["connect.gate", line])
                 }
             )
             let completion = ActiveSessionSlot.shared.completeConnection(
@@ -1237,6 +1240,9 @@
                 strategy: strategy,
                 onPhase: { phase, detail in
                     callStrings(handle.onPhase, [String(describing: phase), detail])
+                },
+                onConnectTrace: { line in
+                    callStrings(handle.onPhase, ["connect.gate", line])
                 }
             )
             let completion = ActiveSessionSlot.shared.completeConnection(

--- a/Sources/OpenZCineCore/CameraWiFiSSID.swift
+++ b/Sources/OpenZCineCore/CameraWiFiSSID.swift
@@ -178,7 +178,12 @@ public enum CameraWiFiJoinPolicy {
                 savedCamera: savedCamera,
                 discoveredCamera: discoveredCamera
             )
-        else { return nil }
+        else {
+            // ZR derives NIKON_ZR_… from its PTP name. A Z 6III cannot, so a Camera AP
+            // setup without a stored SSID used to skip the join entirely. Prefix-join
+            // still prompts for a Nikon camera AP without inventing a model-specific SSID.
+            return JoinTarget(ssidPrefix: CameraWiFiSSID.nikonAccessPointBrandPrefix)
+        }
         return JoinTarget(ssid: ssid)
     }
 

--- a/Sources/OpenZCineCore/ConnectAttemptDiagnostic.swift
+++ b/Sources/OpenZCineCore/ConnectAttemptDiagnostic.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// Privacy-safe connect-attempt facts for the on-device trace included in a Share
+/// Diagnostics export. Nothing here is sent automatically; anonymous bug reports
+/// never include this log.
+///
+/// Lines contain only closed keys and values (model token, generation, ops known
+/// or not, pairing decision, join skip reason, PTP hex codes). Hosts, SSIDs,
+/// serials, PINs, passwords, and free-form errors are dropped.
+public enum ConnectAttemptDiagnostic {
+    public static let maximumLineCount = 200
+
+    /// One sanitized connect-trace line, or nil when nothing allowlisted remains.
+    public static func line(
+        event: String,
+        cameraName: String? = nil,
+        facts: [String: String] = [:]
+    ) -> String? {
+        var fields: [(String, String)] = []
+        if let event = sanitizedToken(event) {
+            fields.append(("event", event))
+        }
+        if let cameraName,
+            let token = ZCameraBodyGeneration.matchedToken(fromCameraName: cameraName)
+        {
+            fields.append(("body", token.token.lowercased()))
+            fields.append(("inferred", label(for: token.generation)))
+        }
+        for key in facts.keys.sorted() {
+            guard let safeKey = sanitizedToken(key),
+                let safeValue = sanitizedToken(facts[key] ?? "")
+            else { continue }
+            fields.append((safeKey, safeValue))
+        }
+        guard !fields.isEmpty else { return nil }
+        return fields.map { "\($0.0)=\($0.1)" }.joined(separator: " ")
+    }
+
+    /// Handshake establishment summary reduced to `key=value` tokens whose values
+    /// are hex codes or closed words. Localized error text is dropped.
+    public static func sanitizedSummary(_ raw: String) -> String? {
+        let kept = raw.split(whereSeparator: \.isWhitespace).compactMap { token -> String? in
+            let parts = token.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else { return nil }
+            guard let key = sanitizedToken(String(parts[0])),
+                let value = sanitizedToken(String(parts[1]))
+            else { return nil }
+            return "\(key)=\(value)"
+        }
+        guard !kept.isEmpty else { return nil }
+        return kept.joined(separator: " ")
+    }
+
+    /// Closed pairing decision from the live operation policy.
+    public static func pairingDecision(
+        policy: ZCameraOperationPolicy,
+        isUSB: Bool,
+        requestPairing: Bool
+    ) -> String {
+        if isUSB { return "usb" }
+        if !policy.supportsPairing { return "unadvertised" }
+        return requestPairing ? "attempt" : "skipped"
+    }
+
+    public static func generationLabel(_ generation: ZCameraBodyGeneration?) -> String {
+        guard let generation else { return "unknown" }
+        return label(for: generation)
+    }
+
+    private static func label(for generation: ZCameraBodyGeneration) -> String {
+        switch generation {
+        case .one: return "one"
+        case .two: return "two"
+        case .three: return "three"
+        }
+    }
+
+    /// Closed words, model tokens (`z6iii`), and PTP hex codes. Rejects SSIDs,
+    /// hosts, serials, and sentences even when they are alphanumeric.
+    private static func sanitizedToken(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed.count <= 48 else { return nil }
+        if trimmed.hasPrefix("0x") {
+            let hex = trimmed.dropFirst(2)
+            guard !hex.isEmpty, hex.allSatisfy(\.isHexDigit) else { return nil }
+            return trimmed.lowercased()
+        }
+        if allowedValues.contains(trimmed) { return trimmed }
+        if allowedValues.contains(trimmed.lowercased()) { return trimmed.lowercased() }
+        return nil
+    }
+
+    private static let allowedValues: Set<String> = [
+        "connect.gate", "connect.join", "connect.handshake", "connect.result",
+        "event", "body", "inferred", "ops", "fallback", "pairing", "join", "ssid",
+        "path", "transport", "result", "stage", "ptp",
+        "gateOps", "gateFallback", "openSession", "appMode", "pairConfirm", "remoteMode",
+        "recProhib",
+        "gateops", "gatefallback", "opensession", "appmode", "pairconfirm", "remotemode",
+        "recprohib",
+        "known", "unknown", "none", "gen1-name",
+        "attempt", "skipped", "unadvertised", "usb",
+        "exact", "prefix", "skipped-on-ap", "skipped-path", "skipped-unresolvable",
+        "skipped-declined", "skipped-wizard", "skipped-recovery",
+        "resolved", "unresolvable", "unreadable", "on-ap", "non-nikon",
+        "cameraAccessPoint", "infrastructure", "phoneHotspot", "usbC", "hdmiCapture",
+        "ptpIP", "ok", "fail", "icc",
+        "one", "two", "three",
+        "open-session", "device-info", "app-mode", "identify", "capability",
+        "z6", "z6ii", "z6iii", "z7", "z7ii", "z7iii", "z5", "z5ii", "z50", "z50ii",
+        "zr", "z8", "z9", "zf", "zfc", "z30",
+    ]
+}

--- a/Sources/OpenZCineCore/ZCameraCapabilityProfile.swift
+++ b/Sources/OpenZCineCore/ZCameraCapabilityProfile.swift
@@ -118,24 +118,75 @@ public enum ZCameraBodyGeneration: Equatable, Sendable {
     case three
 
     /// Longest-token match so "Z 6III" is not classified as the original Z 6.
+    ///
+    /// USB product strings mark generation with an underscore digit (`Z6_3`, `Z 6_2`)
+    /// rather than roman numerals. Those marks are rewritten before punctuation is
+    /// stripped, otherwise `Z6_3` collapses to `Z63` and matches the original Z 6.
     public static func inferred(fromCameraName raw: String) -> ZCameraBodyGeneration? {
-        let compact = raw.uppercased().replacingOccurrences(of: "NIKON", with: "").filter {
-            $0.isLetter || $0.isNumber
-        }
+        matchedToken(fromCameraName: raw)?.generation
+    }
+
+    /// The model token that won the longest-match, such as `Z6III` or `Z6`. Nil when
+    /// the name does not look like a Z body. Safe for a diagnostics export: it never
+    /// includes a serial.
+    public static func matchedToken(fromCameraName raw: String) -> (
+        token: String, generation: ZCameraBodyGeneration
+    )? {
+        let compact = compactName(raw)
         guard !compact.isEmpty else { return nil }
-        let tokens: [(token: String, generation: ZCameraBodyGeneration)] = [
-            ("Z6III", .three), ("Z7III", .three),
-            ("Z50II", .three), ("Z5II", .three),
-            ("Z6II", .two), ("Z7II", .two),
-            ("ZFC", .two), ("Z30", .two),
-            ("Z50", .one),
-            ("ZR", .three), ("Z8", .three), ("Z9", .three), ("ZF", .three),
-            ("Z5", .one), ("Z6", .one), ("Z7", .one),
-        ]
-        for entry in tokens where compact.contains(entry.token) {
-            return entry.generation
+        for entry in modelTokens where compact.contains(entry.token) {
+            return entry
         }
         return nil
+    }
+
+    /// USB product / PTP-IP names reduced to alphanumerics after generation marks
+    /// such as `Z6_3` / `Z5_2` / `Z50_2` have been rewritten to roman-numeral tokens.
+    public static func compactName(_ raw: String) -> String {
+        var compact = raw.uppercased()
+        compact = compact.replacingOccurrences(of: "NIKON", with: "")
+        compact = compact.replacingOccurrences(of: "DSC", with: "")
+        compact = applyingUsbGenerationMarks(compact)
+        return compact.filter { $0.isLetter || $0.isNumber }
+    }
+
+    private static let modelTokens: [(token: String, generation: ZCameraBodyGeneration)] = [
+        ("Z6III", .three), ("Z7III", .three),
+        ("Z50II", .three), ("Z5II", .three),
+        ("Z6II", .two), ("Z7II", .two),
+        ("ZFC", .two), ("Z30", .two),
+        ("Z50", .one),
+        ("ZR", .three), ("Z8", .three), ("Z9", .three), ("ZF", .three),
+        ("Z5", .one), ("Z6", .one), ("Z7", .one),
+    ]
+
+    /// Nikon USB iProduct generation marks. Longest needles first so `Z50_2` is
+    /// not eaten as `Z5_2`. A following digit means this underscore starts a
+    /// serial (`Z 6_1234567`), not a generation suffix.
+    private static let usbGenerationMarks: [(needle: String, token: String)] = [
+        ("Z50_2", "Z50II"), ("Z 50_2", "Z50II"),
+        ("Z7_3", "Z7III"), ("Z 7_3", "Z7III"),
+        ("Z6_3", "Z6III"), ("Z 6_3", "Z6III"),
+        ("Z5_2", "Z5II"), ("Z 5_2", "Z5II"),
+        ("Z7_2", "Z7II"), ("Z 7_2", "Z7II"),
+        ("Z6_2", "Z6II"), ("Z 6_2", "Z6II"),
+    ]
+
+    private static func applyingUsbGenerationMarks(_ raw: String) -> String {
+        var result = raw
+        for (needle, token) in usbGenerationMarks {
+            var searchStart = result.startIndex
+            while let range = result.range(of: needle, range: searchStart..<result.endIndex) {
+                let after = range.upperBound
+                if after < result.endIndex, result[after].isNumber {
+                    searchStart = after
+                    continue
+                }
+                result.replaceSubrange(range, with: token)
+                searchStart = result.index(range.lowerBound, offsetBy: token.count)
+            }
+        }
+        return result
     }
 }
 

--- a/Tests/OpenZCineAndroidFacadeTests/PTPIPClientSessionTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/PTPIPClientSessionTests.swift
@@ -212,6 +212,28 @@ struct PTPIPClientSessionTests {
         #expect(write?.data == Data([1]))
     }
 
+    /// USB iProduct `NIKON DSC Z6_3` is a Z 6III. Empty DeviceInfo must not take the
+    /// original-Z 6 path (skip pairing, write ApplicationMode).
+    @Test func z6iiiUsbProductNameStillPairsWhenDeviceInfoOpsAreUnknown() throws {
+        var options = FakeZRServer.Options()
+        options.cameraName = "NIKON DSC Z6_3"
+        options.model = "Z6III"
+        options.advertisedOperations = []
+        let server = try FakeZRServer(options: options)
+        defer { server.stop() }
+
+        var phases: [CameraConnectionPhase] = []
+        let session = try connect(to: server, strategy: .firstTimePairing) { phase, _ in
+            phases.append(phase)
+        }
+        defer { session.disconnect() }
+
+        let operations = server.receivedOperations()
+        #expect(operations.contains(.getPairingInfo))
+        #expect(!operations.contains(.setDevicePropValue))
+        #expect(phases.contains(.pairing) || phases.contains(.connected))
+    }
+
     @Test func savedProfileRejectsWithoutStartingFirstTimePairing() throws {
         var options = FakeZRServer.Options()
         options.acceptsAppControlImmediately = false

--- a/Tests/OpenZCineCoreTests/CameraWiFiSSIDTests.swift
+++ b/Tests/OpenZCineCoreTests/CameraWiFiSSIDTests.swift
@@ -11,6 +11,31 @@ import Testing
 @Test func cameraWiFiSSIDRejectsNonZRNames() {
     #expect(CameraWiFiSSID.deriveSSID(fromCameraName: "Nikon ZR") == nil)
     #expect(CameraWiFiSSID.deriveSSID(fromCameraName: "PTP-IP Camera") == nil)
+    #expect(CameraWiFiSSID.deriveSSID(fromCameraName: "Z 6III_1234567") == nil)
+}
+
+/// Camera AP setups of a Z 6III cannot derive an SSID from the PTP name. Skipping
+/// the join left the phone on house Wi-Fi; prefix-join still asks iOS to join a
+/// Nikon camera AP without synthesizing a body-specific SSID.
+@Test func cameraApSetupWithoutStoredSSIDStillProducesPrefixJoin() {
+    let saved = PTPIPSavedCameraRecord(
+        host: "192.168.1.1",
+        displayName: "Z 6III_1234567",
+        transport: "Wi-Fi",
+        lastSeenAt: nil,
+        path: .cameraAccessPoint(ssid: nil)
+    )
+    let target = CameraWiFiJoinPolicy.joinTargetIfNeeded(
+        transportKind: .ptpIP,
+        localAddresses: ["10.0.0.12"],
+        savedCamera: saved,
+        discoveredCamera: nil,
+        connectedSSID: "HOME-WIFI"
+    )
+    #expect(
+        target
+            == CameraWiFiJoinPolicy.JoinTarget(
+                ssidPrefix: CameraWiFiSSID.nikonAccessPointBrandPrefix))
 }
 
 @Test func cameraWiFiSSIDRecognizesModelSpecificNikonZAccessPointShapes() {

--- a/Tests/OpenZCineCoreTests/ZCameraCapabilityProfileTests.swift
+++ b/Tests/OpenZCineCoreTests/ZCameraCapabilityProfileTests.swift
@@ -57,7 +57,10 @@ struct ZCameraCapabilityProfileTests {
     /// product name is the only generation signal. Original Z 6 / Z 5 / Z 7 / Z 50
     /// names must not keep the modern pairing + ChangeApplicationMode surface.
     @Test func unknownOpsWithGeneration1NameUsePropertyAppModeAndSkipPairing() {
-        for name in ["Z 6_1234567", "Z6_1234567", "Nikon Z 6", "NIKON_Z6_01234", "Z 5_7654321"] {
+        for name in [
+            "Z 6_1234567", "Z6_1234567", "Nikon Z 6", "NIKON_Z6_01234", "Z 5_7654321",
+            "NIKON DSC Z 5", "NIKON DSC Z 6", "NIKON DSC Z 7", "NIKON DSC Z 50",
+        ] {
             let policy = ZCameraOperationPolicy(operations: []).resolvingUnknown(cameraName: name)
             #expect(policy.isKnown, "name: \(name)")
             #expect(!policy.appModeViaOperation, "name: \(name)")
@@ -69,12 +72,49 @@ struct ZCameraCapabilityProfileTests {
     @Test func unknownOpsWithLaterGenerationNameKeepModernPairingSurface() {
         for name in [
             "ZR_6001234", "Z 6III_1234567", "Z 6II_1234567", "Z 5II_123", "NIKON_ZR_01234",
+            "NIKON DSC Z6_3", "NIKON DSC Z 6_2", "NIKON DSC Z5_2", "NIKON DSC Z50_2",
+            "NIKON DSC Z 7_2", "NIKON DSC Z 30", "NIKON DSC Z fc", "NIKON DSC Z f",
+            "NIKON DSC Z 8", "NIKON DSC Z 9", "NIKON DSC ZR",
         ] {
             let policy = ZCameraOperationPolicy(operations: []).resolvingUnknown(cameraName: name)
             #expect(!policy.isKnown, "name: \(name)")
             #expect(policy.supportsPairing, "name: \(name)")
             #expect(policy.appModeViaOperation, "name: \(name)")
         }
+    }
+
+    /// USB iProduct strings use an underscore generation mark (`Z6_3` = Z 6III).
+    /// Dropping punctuation before rewriting that mark made `Z6_3` match original Z 6.
+    ///
+    /// The strings below are the USB product names the bodies advertise (observable on
+    /// the bus). Later bodies drop the space (`Z6_3`, `Z5_2`, `Z50_2`); II-generation
+    /// stills keep it (`Z 6_2`, `Z 7_2`).
+    @Test func usbProductGenerationMarksAreNotOriginalBodies() {
+        let cases: [(name: String, token: String, generation: ZCameraBodyGeneration)] = [
+            ("NIKON DSC Z 5", "Z5", .one),
+            ("NIKON DSC Z 6", "Z6", .one),
+            ("NIKON DSC Z 7", "Z7", .one),
+            ("NIKON DSC Z 50", "Z50", .one),
+            ("NIKON DSC Z 6_2", "Z6II", .two),
+            ("NIKON DSC Z 7_2", "Z7II", .two),
+            ("NIKON DSC Z 30", "Z30", .two),
+            ("NIKON DSC Z fc", "ZFC", .two),
+            ("NIKON DSC Z6_3", "Z6III", .three),
+            ("NIKON DSC Z5_2", "Z5II", .three),
+            ("NIKON DSC Z50_2", "Z50II", .three),
+            ("NIKON DSC Z 8", "Z8", .three),
+            ("NIKON DSC Z 9", "Z9", .three),
+            ("NIKON DSC Z f", "ZF", .three),
+            ("NIKON DSC ZR", "ZR", .three),
+        ]
+        for entry in cases {
+            let matched = ZCameraBodyGeneration.matchedToken(fromCameraName: entry.name)
+            #expect(matched?.token == entry.token, "name: \(entry.name)")
+            #expect(matched?.generation == entry.generation, "name: \(entry.name)")
+        }
+        // A serial after the original Z 6 must still be generation 1.
+        #expect(ZCameraBodyGeneration.inferred(fromCameraName: "Z 6_1234567") == .one)
+        #expect(ZCameraBodyGeneration.inferred(fromCameraName: "Z6_1234567") == .one)
     }
 
     @Test func advertisedOpsAreNotOverriddenByAGeneration1Name() {
@@ -107,6 +147,33 @@ struct ZCameraCapabilityProfileTests {
         let narrowCodes = PTPVendorPropertyCodeList.decode(narrow, fourByteCodes: false)
         #expect(narrowCodes.contains(0xD0A2))
         #expect(narrowCodes.count == 8)
+    }
+
+    @Test func connectAttemptDiagnosticKeepsClosedTokensAndDropsFreeForm() throws {
+        let line = ConnectAttemptDiagnostic.line(
+            event: "connect.gate",
+            cameraName: "NIKON DSC Z6_3",
+            facts: [
+                "ops": "unknown",
+                "fallback": "none",
+                "pairing": "attempt",
+                "ssid": "NIKON_Z6III_00042",
+            ]
+        )
+        let rendered = try #require(line)
+        #expect(rendered.contains("event=connect.gate"))
+        #expect(rendered.contains("body=z6iii"))
+        #expect(rendered.contains("inferred=three"))
+        #expect(rendered.contains("ops=unknown"))
+        #expect(rendered.contains("pairing=attempt"))
+        #expect(!rendered.contains("NIKON_Z6III"))
+        #expect(!rendered.contains("00042"))
+
+        #expect(
+            ConnectAttemptDiagnostic.sanitizedSummary(
+                "gateOps=known gateFallback=gen1-name pairing=usb appMode=0x2001 pairInfoLastError=The operation couldn't complete"
+            ) == "gateOps=known gateFallback=gen1-name pairing=usb appMode=0x2001")
+        #expect(ConnectAttemptDiagnostic.sanitizedSummary("host=192.168.1.1 ssid=SECRET") == nil)
     }
 
     @Test func vendorPropertyListRejectsGarbledPayloads() {

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		C0DE000000000000000000F5 /* ZCameraCapabilityProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE000000000000000000F6 /* ZCameraCapabilityProfile.swift */; };
+		C0DE00000000000000000111 /* ConnectAttemptDiagnostic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000112 /* ConnectAttemptDiagnostic.swift */; };
 		C0DE000000000000000000F3 /* StillCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE000000000000000000F4 /* StillCapture.swift */; };
 		C0DE000000000000000000F1 /* PhotographyChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE000000000000000000F2 /* PhotographyChrome.swift */; };
 		079C56E717DE773E92A622FF /* MediaBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55F9DD1E7FF51371E4DC6E1 /* MediaBrowser.swift */; };
@@ -290,6 +291,7 @@
 		C0DE00000000000000000021 /* PTPLiveViewObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PTPLiveViewObject.swift; path = ../Sources/OpenZCineCore/PTPLiveViewObject.swift; sourceTree = SOURCE_ROOT; };
 		C0DE00000000000000000023 /* PTPCameraProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PTPCameraProperties.swift; path = ../Sources/OpenZCineCore/PTPCameraProperties.swift; sourceTree = SOURCE_ROOT; };
 		C0DE000000000000000000F6 /* ZCameraCapabilityProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ZCameraCapabilityProfile.swift; path = ../Sources/OpenZCineCore/ZCameraCapabilityProfile.swift; sourceTree = SOURCE_ROOT; };
+		C0DE00000000000000000112 /* ConnectAttemptDiagnostic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = ConnectAttemptDiagnostic.swift; path = ../Sources/OpenZCineCore/ConnectAttemptDiagnostic.swift; sourceTree = SOURCE_ROOT; };
 		C0DE000000000000000000F4 /* StillCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StillCapture.swift; path = ../Sources/OpenZCineCore/StillCapture.swift; sourceTree = SOURCE_ROOT; };
 		C0DE00000000000000000025 /* LinkExperience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkExperience.swift; sourceTree = "<group>"; };
 		C0DE00000000000000000027 /* StartupDesign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupDesign.swift; sourceTree = "<group>"; };
@@ -550,6 +552,7 @@
 				C0DE00000000000000000021 /* PTPLiveViewObject.swift */,
 				C0DE00000000000000000023 /* PTPCameraProperties.swift */,
 				C0DE000000000000000000F6 /* ZCameraCapabilityProfile.swift */,
+				C0DE00000000000000000112 /* ConnectAttemptDiagnostic.swift */,
 				C0DE000000000000000000F4 /* StillCapture.swift */,
 				C0DE0000000000000000000A /* CameraDisplayState.swift */,
 				C0DE00000000000000000011 /* MonitorLayoutPolicy.swift */,
@@ -840,6 +843,7 @@
 				C0DE00000000000000000020 /* PTPLiveViewObject.swift in Sources */,
 				C0DE00000000000000000022 /* PTPCameraProperties.swift in Sources */,
 				C0DE000000000000000000F5 /* ZCameraCapabilityProfile.swift in Sources */,
+				C0DE00000000000000000111 /* ConnectAttemptDiagnostic.swift in Sources */,
 				C0DE000000000000000000F3 /* StillCapture.swift in Sources */,
 				C0DE00000000000000000012 /* OperatorPreferences.swift in Sources */,
 				C0DE00000000000000000032 /* MonitorTextFormat.swift in Sources */,

--- a/ios/Runner/AppDiagnostics.swift
+++ b/ios/Runner/AppDiagnostics.swift
@@ -77,6 +77,13 @@ enum AppDiagnosticEvent: String, Codable, Sendable {
     // A camera property write held the transaction gate unusually long (>1.5s) — the feed and
     // queued writes stall behind it. The property rides the connection log, not the vocabulary.
     case propertyWriteSlow = "camera.write.slow"
+
+    /// DeviceInfo was empty, so generation was taken from the USB / PTP-IP name.
+    case connectionGateGen1Fallback = "connection.gate.gen1-fallback"
+    /// DeviceInfo did not arrive; modern pairing / app-mode is still assumed.
+    case connectionGateUnknownOps = "connection.gate.unknown-ops"
+    /// Camera AP path had no stored or derived SSID, so join used the Nikon prefix.
+    case connectionJoinPrefix = "connection.join.prefix"
 }
 
 struct DiagnosticBreadcrumb: Codable, Equatable, Sendable {
@@ -126,6 +133,7 @@ actor DiagnosticEventStore {
     private let fileManager: FileManager
     private let rootDirectory: URL
     private let eventsURL: URL
+    private let connectTraceURL: URL
     private let payloadDirectory: URL
     private let maximumEventBytes: Int
     private let maximumPayloadCount: Int
@@ -144,10 +152,44 @@ actor DiagnosticEventStore {
                 "OpenZCine/Diagnostics", isDirectory: true)
         self.rootDirectory = rootDirectory ?? defaultRoot
         self.eventsURL = (rootDirectory ?? defaultRoot).appendingPathComponent("events.jsonl")
+        self.connectTraceURL = (rootDirectory ?? defaultRoot).appendingPathComponent(
+            "connect-trace.jsonl")
         self.payloadDirectory = (rootDirectory ?? defaultRoot).appendingPathComponent(
             "metrickit", isDirectory: true)
         self.maximumEventBytes = max(1_024, maximumEventBytes)
         self.maximumPayloadCount = max(1, maximumPayloadCount)
+    }
+
+    /// Appends one sanitized connect-attempt line. Stays on device until the operator
+    /// exports a diagnostics report; never enters the anonymous activity log.
+    func recordConnectTrace(_ line: String, at timestamp: Date = Date()) {
+        guard let sanitized = ConnectAttemptDiagnostic.sanitizedSummary(line) else { return }
+        do {
+            try prepareDirectories()
+            let stamp = ISO8601DateFormatter().string(from: timestamp)
+            let data = Data("\(stamp)  \(sanitized)\n".utf8)
+            if !fileManager.fileExists(atPath: connectTraceURL.path) {
+                guard fileManager.createFile(atPath: connectTraceURL.path, contents: nil) else {
+                    return
+                }
+            }
+            let handle = try FileHandle(forWritingTo: connectTraceURL)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: data)
+            try handle.synchronize()
+            try compactConnectTraceIfNeeded()
+        } catch {
+            // Diagnostics must never interfere with camera control.
+        }
+    }
+
+    func recentConnectTrace() -> [String] {
+        guard let data = try? Data(contentsOf: connectTraceURL) else { return [] }
+        return String(decoding: data, as: UTF8.self)
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .suffix(ConnectAttemptDiagnostic.maximumLineCount)
+            .map(String.init)
     }
 
     func record(_ event: AppDiagnosticEvent, at timestamp: Date = Date()) {
@@ -237,6 +279,7 @@ actor DiagnosticEventStore {
         let report = Self.renderReport(
             metadata: metadata,
             events: recentEvents(),
+            connectTrace: recentConnectTrace(),
             payloads: metricPayloads()
         )
         guard let data = report.data(using: .utf8) else {
@@ -256,6 +299,7 @@ actor DiagnosticEventStore {
     static func renderReport(
         metadata: DiagnosticReportMetadata,
         events: [DiagnosticBreadcrumb],
+        connectTrace: [String] = [],
         payloads: [(name: String, data: Data)]
     ) -> String {
         let formatter = ISO8601DateFormatter()
@@ -266,6 +310,9 @@ actor DiagnosticEventStore {
             "Review this file before sharing it publicly.",
             "It intentionally excludes camera frames, media names, camera identities, network",
             "addresses, Wi-Fi details, pairing data, credentials, and account identifiers.",
+            "The connect-attempt trace below is closed tokens only (body family, DeviceInfo",
+            "known/unknown, pairing decision). It never leaves this phone unless you share",
+            "this file.",
             "",
             "Generated: \(formatter.string(from: metadata.generatedAt))",
             "App: OpenZCine \(metadata.appVersion) (build \(metadata.buildNumber))",
@@ -282,6 +329,13 @@ actor DiagnosticEventStore {
                 contentsOf: events.suffix(500).map {
                     "\(formatter.string(from: $0.timestamp))  \($0.event)"
                 })
+        }
+
+        lines.append(contentsOf: ["", "Connect attempt trace", "---------------------"])
+        if connectTrace.isEmpty {
+            lines.append("No retained connect-attempt trace.")
+        } else {
+            lines.append(contentsOf: connectTrace.suffix(ConnectAttemptDiagnostic.maximumLineCount))
         }
 
         lines.append(contentsOf: ["", "MetricKit diagnostics", "---------------------"])
@@ -324,6 +378,13 @@ actor DiagnosticEventStore {
     private func prepareDirectories() throws {
         try fileManager.createDirectory(at: rootDirectory, withIntermediateDirectories: true)
         try fileManager.createDirectory(at: payloadDirectory, withIntermediateDirectories: true)
+    }
+
+    private func compactConnectTraceIfNeeded() throws {
+        let data = try Data(contentsOf: connectTraceURL)
+        guard data.count > maximumEventBytes else { return }
+        let compacted = Self.compactedEventData(data, limit: maximumEventBytes)
+        try compacted.write(to: connectTraceURL, options: .atomic)
     }
 
     private func compactEventsIfNeeded() throws {
@@ -374,6 +435,10 @@ final class AppDiagnostics: NSObject, MXMetricManagerSubscriber, @unchecked Send
 
     func record(_ event: AppDiagnosticEvent) {
         Task { await store.record(event) }
+    }
+
+    func recordConnectTrace(_ line: String) {
+        Task { await store.recordConnectTrace(line) }
     }
 
     @MainActor

--- a/ios/Runner/NativeAppRoot.swift
+++ b/ios/Runner/NativeAppRoot.swift
@@ -5719,6 +5719,16 @@ final class NativeAppModel {
         if let savedCamera, savedCamera.path?.kind != .cameraAccessPoint {
             logConnection(
                 "join skipped: setup path is \(savedCamera.path?.kind.rawValue ?? "none")")
+            if let line = ConnectAttemptDiagnostic.line(
+                event: "connect.join",
+                cameraName: savedCamera.displayName,
+                facts: [
+                    "join": "skipped-path",
+                    "path": savedCamera.path?.kind.rawValue ?? "none",
+                ]
+            ) {
+                AppDiagnostics.shared.recordConnectTrace(line)
+            }
             return
         }
         // The operator picked a path that never puts this device on the camera's own access point,
@@ -5758,6 +5768,17 @@ final class NativeAppModel {
                     + "discovered=\(discoveredCamera == nil ? "nil" : "yes") "
                     + "ssid=\(CameraWiFiJoinPolicy.resolvedSSID(savedCamera: savedCamera, discoveredCamera: discoveredCamera) ?? "unresolvable") "
                     + "connectedSSID=\(connectedWiFiSSID ?? "unreadable")")
+            if let line = ConnectAttemptDiagnostic.line(
+                event: "connect.join",
+                cameraName: savedCamera?.displayName ?? discoveredCamera?.name,
+                facts: [
+                    "join": "skipped-unresolvable",
+                    "ssid": "unresolvable",
+                    "path": savedCamera?.path?.kind.rawValue ?? "none",
+                ]
+            ) {
+                AppDiagnostics.shared.recordConnectTrace(line)
+            }
             return
         }
 
@@ -5777,6 +5798,14 @@ final class NativeAppModel {
             proactiveTarget = .specificSSID(ssid)
         } else if let prefix = joinTarget.ssidPrefix {
             proactiveTarget = .ssidPrefix(prefix)
+            AppDiagnostics.shared.record(.connectionJoinPrefix)
+            if let line = ConnectAttemptDiagnostic.line(
+                event: "connect.join",
+                cameraName: savedCamera?.displayName ?? discoveredCamera?.name,
+                facts: ["join": "prefix", "ssid": "unresolvable"]
+            ) {
+                AppDiagnostics.shared.recordConnectTrace(line)
+            }
         } else {
             logConnection("join skipped: target names neither an SSID nor a prefix")
             return
@@ -5889,6 +5918,16 @@ final class NativeAppModel {
         let recordEstablishmentDiagnostic: @Sendable (String) -> Void = { [weak self] summary in
             // "stage:" strings are live progress (shown so a stuck connect names its step —
             // that's how the USB hang was pinned down); everything else is the failure trace.
+            if summary.hasPrefix("connect.gate ") {
+                let line = String(summary.dropFirst("connect.gate ".count))
+                AppDiagnostics.shared.recordConnectTrace(line)
+                if line.contains("fallback=gen1-name") {
+                    AppDiagnostics.shared.record(.connectionGateGen1Fallback)
+                } else if line.contains("ops=unknown") {
+                    AppDiagnostics.shared.record(.connectionGateUnknownOps)
+                }
+                return
+            }
             if summary.hasPrefix("stage:") {
                 let stage = String(summary.dropFirst("stage:".count))
                 diagnosticBox.withLock { $0 = summary }

--- a/ios/Runner/NativeCameraSession.swift
+++ b/ios/Runner/NativeCameraSession.swift
@@ -488,7 +488,8 @@ final class NativeCameraSession: @unchecked Sendable {
             return try await session.openAndIdentify(
                 requestPairing: requestPairing,
                 onPairingChallenge: onPairingChallenge,
-                onStage: { onEstablishmentDiagnostic?("stage:\($0)") }
+                onStage: { onEstablishmentDiagnostic?("stage:\($0)") },
+                onConnectTrace: { onEstablishmentDiagnostic?("connect.gate \($0)") }
             )
         } catch {
             if !session.establishmentSummary.isEmpty {
@@ -1285,7 +1286,8 @@ final class NativeCameraSession: @unchecked Sendable {
     private func openAndIdentify(
         requestPairing: Bool,
         onPairingChallenge: NativePairingChallengeHandler?,
-        onStage: (@Sendable (String) -> Void)? = nil
+        onStage: (@Sendable (String) -> Void)? = nil,
+        onConnectTrace: (@Sendable (String) -> Void)? = nil
     ) async throws -> NativeCameraSession {
         // Over USB the first transaction can sit behind ImageCaptureCore's own card enumeration,
         // which scales with card fullness (thousands of stills = minutes, not seconds) — the 15 s
@@ -1359,6 +1361,19 @@ final class NativeCameraSession: @unchecked Sendable {
         establishmentSummary += "gateOps=\(gatePolicy.isKnown ? "known" : "unknown") "
         if !probedKnown, gatePolicy.isKnown {
             establishmentSummary += "gateFallback=gen1-name "
+        }
+        if let line = ConnectAttemptDiagnostic.line(
+            event: "connect.gate",
+            cameraName: cameraName,
+            facts: [
+                "ops": probedKnown ? "known" : "unknown",
+                "fallback": (!probedKnown && gatePolicy.isKnown) ? "gen1-name" : "none",
+                "pairing": ConnectAttemptDiagnostic.pairingDecision(
+                    policy: gatePolicy, isUSB: isUSB, requestPairing: requestPairing),
+                "transport": isUSB ? "usb" : "ptpIP",
+            ]
+        ) {
+            onConnectTrace?(line)
         }
 
         // USB has no pairing surface: GetPairingInfo/ConfirmPairing are absent from the camera's

--- a/ios/RunnerTests/ExternalBetaReadinessTests.swift
+++ b/ios/RunnerTests/ExternalBetaReadinessTests.swift
@@ -140,6 +140,7 @@ struct ExternalBetaDiagnosticsTests {
         #expect(report.contains("live-view.started"))
         #expect(report.contains("Review this file before sharing it publicly."))
         #expect(report.contains("Wi-Fi details"))
+        #expect(report.contains("Connect attempt trace"))
         #expect(report.contains("No MetricKit payloads"))
     }
 
@@ -160,10 +161,18 @@ struct ExternalBetaDiagnosticsTests {
         defer { try? FileManager.default.removeItem(at: root) }
         let store = DiagnosticEventStore(rootDirectory: root)
         await store.record(.connectionConnected, at: metadata.generatedAt)
+        await store.recordConnectTrace(
+            "event=connect.gate body=z6iii inferred=three ops=unknown fallback=none pairing=attempt"
+        )
         let url = try await store.makeReport(metadata: metadata)
         let report = try String(contentsOf: url, encoding: .utf8)
         #expect(report.contains("connection.connected"))
         #expect(report.contains("OpenZCine 0.2.0 (build 200)"))
+        #expect(report.contains("body=z6iii"))
+        #expect(report.contains("Connect attempt trace"))
+        let anonymous = await store.anonymousActivityLog()
+        #expect(anonymous == ["connection.connected"])
+        #expect(!anonymous.joined(separator: " ").contains("z6iii"))
     }
 }
 

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -10,7 +10,7 @@ New and changed
 Fixes
 
 - USB-C reconnects after the cable is knocked loose, or after a few seconds in the background, without force-quitting the app.
-- Original Z 6, Z 5, and Z 7 no longer get pairing steps they do not support. iPad USB-C copy says this device, not iPhone.
+- Original Z 6, Z 5, and Z 7 no longer get pairing steps they do not support. A Z 6III is no longer treated as an original Z 6. iPad USB-C copy says this device, not iPhone. Settings → Share Diagnostics now keeps a connect-attempt trace on the phone until you send it.
 - Format a card and Media used to keep the old clip names. REFRESH now follows the card, and Settings > Clear Cache reloads Media from the card.
 - Share and Save to Photos work on clips from the camera, including proxies whose media is shorter than the header. They used to fail with "Invalid sample cursor".
 - Share on the player is available while the camera is connected. You no longer have to disconnect and go through Operator Setup to reach it.
@@ -21,7 +21,7 @@ Fixes
 What to test
 
 - Plug in over USB-C, connect, then knock the cable loose and plug it back in. It should come back without force-quitting. Background the app for a few seconds with the cable in, then return.
-- If you have an original Z 6, Z 5, or Z 7, connect over USB-C and the camera's own Wi-Fi. It should reach the monitor without a wireless error on the camera.
+- If you have an original Z 6, Z 5, Z 7, or Z 6III, connect over USB-C and the camera's own Wi-Fi. It should reach the monitor without a wireless error on the camera. If a Z 6III still fails, share diagnostics from Settings.
 - Connect to the camera, play a clip, tap Share, then Share and Save to Photos. Both should finish. Save to Photos should ask for access up front, then keep a spinner while Photos writes — not a frozen percent. You should not have to disconnect first.
 - Put the body in Aperture-priority photo, change the light, and check shutter and ISO on the phone match the camera.
 - Set stills AF-S and video full-time AF. Photo FOCUS should match the Focus panel, not leftover AF-F. Pull the focus dial, then tap: it should focus without a half-press.


### PR DESCRIPTION
## What & why

[#362](https://github.com/erik-sutton95/OpenZCine/issues/362) / [Discussion #12](https://github.com/erik-sutton95/OpenZCine/discussions/12) — one operator cannot connect a Z 6III over USB or the camera's own Wi-Fi (camera shows a connection error). Other Z 6III users succeed.

USB iProduct `NIKON DSC Z6_3` identifies a Z 6III. After the original-Z 6 DeviceInfo fallback (#350), that name compacted to `Z63` and matched the original Z 6, so a missed DeviceInfo probe skipped pairing and wrote the gen-1 `ApplicationMode` property instead of `ChangeApplicationMode`.

This PR (iOS + Android):

- Rewrites USB generation marks (`Z6_3`, `Z 6_2`, `Z5_2`, `Z50_2`) **before** stripping punctuation, so later bodies stay gen 2/3 when DeviceInfo is missing.
- Pins the USB product names the bodies advertise on the bus so a sibling of the `Z6_3` collapse cannot land again.
- Prefix-joins a Nikon camera AP when a Camera AP setup has no stored/derived SSID (Z 6III cannot derive `NIKON_ZR_…` from its PTP name).
- Adds a local-only connect-attempt trace (body token, DeviceInfo known/unknown, pairing decision, join skip reason) included only in Share Diagnostics. Anonymous bug reports stay closed-vocabulary; hosts/SSIDs/serials never leave the phone unless the operator sends the file.

Kaneo: OPE-176

## TestFlight notes

Updated `ios/TestFlight/WhatToTest.en-US.txt`.

## Google Play notes

Updated `Apps/Android/distribution/whatsnew/whatsnew-en-US`.

## Test plan

- [x] `just check` (hygiene, notes, Swift lint + 1385 package tests)
- [x] `just ios-build` and `just watch-build`
- [x] `ExternalBetaReadinessTests` on iPhone 16 Pro simulator
- [x] FakeZR: USB iProduct `NIKON DSC Z6_3` with empty DeviceInfo still pairs; original `Z 6_…` still skips pairing and writes `ApplicationMode`
- [x] Android `DiagnosticEventStoreTest` (connect-trace stays local, drops free-form)
- [ ] Full `just ios-test` — not used as the gate; the suite hung on the unrelated truncated-proxy export test
- [ ] Full `just android-check` — not re-run this change; unit test above plus shared Swift core coverage
- [ ] **[VERIFY-ON-HW]** Z 6III over USB-C: connect without a camera-side connection error
- [ ] **[VERIFY-ON-HW]** Z 6III over camera AP: Network → Connect to computer → Direct connection (not SnapBridge)
- [ ] If a Z 6III still fails, Share Diagnostics from Settings and send the report (connect-attempt trace is in the zip)
- [ ] Original Z 6 / Z 5 / Z 7 still skip unsupported pairing

## Checklist

- [x] `just check` passes.
- [ ] Native production changes: `just native-check` — Swift lint/tests, iOS build, watch build, and ExternalBetaReadinessTests pass; full `just ios-test` hung on an unrelated media-export test.
- [ ] Android production changes: `just android-check` not fully re-run; DiagnosticEventStoreTest + shared core tests pass.
- [x] Commits follow Conventional Commits.
- [x] No proprietary assets (`vendor/`, `ref/`) are included.
- [x] Docs/CHANGELOG updated if behavior or setup changed.
- [x] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy.
- [x] Play-triggering changes include reviewed `Apps/Android/distribution/whatsnew/whatsnew-en-US` copy.
