### PR TITLE
fix(android): retry the USB GetDeviceInfo write after a PTP reset

### DIFF
--- a/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/AndroidUsbPtpHost.kt
+++ b/Apps/Android/app/src/main/kotlin/com/opencapture/openzcine/transport/AndroidUsbPtpHost.kt
@@ -292,9 +292,8 @@ public class AndroidUsbPtpCameraSource(
         // The system MTP handler (com.android.mtp) grabs a PTP camera on attach
         // and often leaves a stuck session: its aborted OpenSession stalls the
         // bulk pipes, so our first write fails with -1 even after a force-claim.
-        // The PTP class recovery is a Device Reset (class request 0x66) followed
-        // by clearing any HALT on the bulk endpoints — the standard sequence
-        // libptp/gPhoto use to take a camera another host left mid-transaction.
+        // Status-gated Device Reset here, plus a one-shot reset-and-retry on the
+        // first dead bulk-out (GET_DEVICE_STATUS can still read OK).
         recoverStalledPtpInterface(connection, usbInterface.id, bulkIn.address, bulkOut.address)
         val eventIn = endpoint(usbInterface, selection.eventInAddress)
         val eventRequest = UsbRequest()
@@ -579,6 +578,45 @@ private fun copyUsbRequestPayload(buffer: ByteBuffer): ByteArray {
 
 private const val PTP_STATUS_OK: Int = 0x2001
 
+/** Outcome of one bulk-out, including a one-shot reset-and-retry after a dead write. */
+internal data class UsbPtpDeadWriteOutcome(
+    val byteCount: Int,
+    val recoveryAttempted: Boolean,
+    val retried: Boolean = false,
+)
+
+/**
+ * GET_DEVICE_STATUS can still read OK while bulk-out is wedged (the system MTP
+ * handler left an aborted session on attach). A negative write is the only
+ * reliable signal. Reset once and retry THIS transfer so the operator does not
+ * have to tap Connect again — returning the original -1 made every reconnect
+ * fail in the UI even when the reset would have unwedged the next tap.
+ *
+ * [verify-on-HW] Z 6III USB-C on OnePlus 15: reconnect after a pending live
+ * view must not show "USB wrote -1 of 12 bytes".
+ */
+internal fun recoverDeadBulkOutWrite(
+    isClosed: () -> Boolean,
+    alreadyRecovered: Boolean,
+    write: () -> Int,
+    reset: () -> Unit,
+): UsbPtpDeadWriteOutcome {
+    if (isClosed()) {
+        return UsbPtpDeadWriteOutcome(byteCount = -1, recoveryAttempted = alreadyRecovered)
+    }
+    val first = write()
+    if (first >= 0 || isClosed() || alreadyRecovered) {
+        return UsbPtpDeadWriteOutcome(byteCount = first, recoveryAttempted = alreadyRecovered)
+    }
+    reset()
+    val retried = if (isClosed()) -1 else write()
+    return UsbPtpDeadWriteOutcome(
+        byteCount = retried,
+        recoveryAttempted = true,
+        retried = true,
+    )
+}
+
 /** PTP class GET_DEVICE_STATUS; returns the status code or 0 on failure. */
 private fun ptpDeviceStatus(
     connection: UsbDeviceConnection,
@@ -859,21 +897,27 @@ private class AndroidUsbPtpTransport(
 
     override fun writeBulk(bytes: ByteArray, timeoutMillis: Int): Int =
         synchronized(commandLock) {
-            if (closed) return@synchronized -1
-            val count = connection.bulkTransfer(bulkOut, bytes, bytes.size, timeoutMillis)
-            if (count < 0 && !closed && !deadWriteRecoveryDone) {
-                // GET_DEVICE_STATUS reads OK even while the body's bulk-out
-                // is wedged (Samsung's com.android.mtp left an aborted session
-                // on attach), so a dead write is the only reliable wedge
-                // signal. Reset once so the NEXT attempt starts on a healthy
-                // interface; this attempt still reports failure.
-                deadWriteRecoveryDone = true
-                android.util.Log.i(USB_DIAG_TAG, "USB bulk-out wedged; PTP reset")
-                ptpResetAndSettle(
-                    connection, usbInterface.id, bulkIn.address, bulkOut.address, USB_DIAG_TAG,
+            val outcome =
+                recoverDeadBulkOutWrite(
+                    isClosed = { closed },
+                    alreadyRecovered = deadWriteRecoveryDone,
+                    write = { connection.bulkTransfer(bulkOut, bytes, bytes.size, timeoutMillis) },
+                    reset = {
+                        android.util.Log.i(USB_DIAG_TAG, "USB bulk-out wedged; PTP reset")
+                        ptpResetAndSettle(
+                            connection,
+                            usbInterface.id,
+                            bulkIn.address,
+                            bulkOut.address,
+                            USB_DIAG_TAG,
+                        )
+                    },
                 )
+            deadWriteRecoveryDone = outcome.recoveryAttempted
+            if (outcome.retried && outcome.byteCount >= 0) {
+                android.util.Log.i(USB_DIAG_TAG, "USB bulk-out recovered after PTP reset")
             }
-            count
+            outcome.byteCount
         }
 
     override fun readBulk(maxBytes: Int, timeoutMillis: Int): ByteArray? =

--- a/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/transport/UsbPtpDeadWriteRecoveryTest.kt
+++ b/Apps/Android/app/src/test/kotlin/com/opencapture/openzcine/transport/UsbPtpDeadWriteRecoveryTest.kt
@@ -1,0 +1,123 @@
+package com.opencapture.openzcine.transport
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The Z 6III OnePlus 15 reconnect (Discussion #12): bulk-out returns -1 for the
+ * 12-byte GetDeviceInfo container even when GET_DEVICE_STATUS reads OK. Reset
+ * without retrying this write made every reconnect fail in the UI.
+ */
+class UsbPtpDeadWriteRecoveryTest {
+    @Test
+    fun `a healthy write is returned and never resets`() {
+        var writes = 0
+        var resets = 0
+        val outcome =
+            recoverDeadBulkOutWrite(
+                isClosed = { false },
+                alreadyRecovered = false,
+                write = {
+                    writes += 1
+                    12
+                },
+                reset = { resets += 1 },
+            )
+
+        assertEquals(12, outcome.byteCount)
+        assertFalse(outcome.recoveryAttempted)
+        assertFalse(outcome.retried)
+        assertEquals(1, writes)
+        assertEquals(0, resets)
+    }
+
+    @Test
+    fun `a dead write resets once and retries the same transfer`() {
+        val writes = mutableListOf<Int>()
+        var resets = 0
+        val outcome =
+            recoverDeadBulkOutWrite(
+                isClosed = { false },
+                alreadyRecovered = false,
+                write = {
+                    val result = if (writes.isEmpty()) -1 else 12
+                    writes += result
+                    result
+                },
+                reset = { resets += 1 },
+            )
+
+        assertEquals(12, outcome.byteCount)
+        assertTrue(outcome.recoveryAttempted)
+        assertTrue(outcome.retried)
+        assertEquals(listOf(-1, 12), writes)
+        assertEquals(1, resets)
+    }
+
+    @Test
+    fun `a second dead write does not reset again`() {
+        var writes = 0
+        var resets = 0
+        val outcome =
+            recoverDeadBulkOutWrite(
+                isClosed = { false },
+                alreadyRecovered = true,
+                write = {
+                    writes += 1
+                    -1
+                },
+                reset = { resets += 1 },
+            )
+
+        assertEquals(-1, outcome.byteCount)
+        assertTrue(outcome.recoveryAttempted)
+        assertFalse(outcome.retried)
+        assertEquals(1, writes)
+        assertEquals(0, resets)
+    }
+
+    @Test
+    fun `a closed connection never writes or resets`() {
+        var writes = 0
+        var resets = 0
+        val outcome =
+            recoverDeadBulkOutWrite(
+                isClosed = { true },
+                alreadyRecovered = false,
+                write = {
+                    writes += 1
+                    12
+                },
+                reset = { resets += 1 },
+            )
+
+        assertEquals(-1, outcome.byteCount)
+        assertFalse(outcome.recoveryAttempted)
+        assertFalse(outcome.retried)
+        assertEquals(0, writes)
+        assertEquals(0, resets)
+    }
+
+    @Test
+    fun `closing during reset still reports failure after the one-shot recovery`() {
+        var closed = false
+        var writes = 0
+        val outcome =
+            recoverDeadBulkOutWrite(
+                isClosed = { closed },
+                alreadyRecovered = false,
+                write = {
+                    writes += 1
+                    -1
+                },
+                reset = { closed = true },
+            )
+
+        assertEquals(-1, outcome.byteCount)
+        assertTrue(outcome.recoveryAttempted)
+        assertTrue(outcome.retried)
+        assertEquals(1, writes)
+    }
+}

--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,5 +1,5 @@
 - Fixed: original Z 6 / Z 5 / Z 7 skip pairing they lack; Z 6III is not treated as Z 6. Share Diagnostics keeps a connect trace until you send it.
-- Fixed: USB-C connect after permission, and a retry after the picture drops should stay up.
+- Fixed: USB-C reconnect after a stuck pipe, permission, or dropped picture should stay up.
 - Fixed: Aperture-priority shutter and ISO on the phone follow the camera as it meters.
 - Fixed: photo FOCUS and taps follow stills AF, not leftover video AF-F.
 - New: Media has REFRESH. After a format it follows the card; Clear Cache reloads from the camera.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,11 @@ All notable changes to this project are documented here. The format is based on
 
 ### Fixed
 
+- **Android USB reconnect no longer fails the attempt that unwedged the pipe.** A
+  dead first bulk-out (`USB wrote -1 of 12 bytes`, the GetDeviceInfo command) already
+  issued a PTP Device Reset, but still returned failure so every reconnect showed
+  the error. That write is now retried once on the same attempt. Android-only; iOS
+  USB goes through ImageCaptureCore.
 - **Z 6III USB product names are no longer treated as an original Z 6.** Nikon's USB
   iProduct `NIKON DSC Z6_3` (and `Z 6_2` / `Z5_2`) was compacted to `Z63` and matched
   generation 1, so a missed DeviceInfo probe skipped pairing and wrote the gen-1


### PR DESCRIPTION
## What & why

[Discussion #12](https://github.com/erik-sutton95/OpenZCine/discussions/12) follow-up after [#363](https://github.com/erik-sutton95/OpenZCine/pull/363) / OPE-176. A Z 6III on a OnePlus 15 (Android 16) reached the monitor after the generation-mark fix, with live view stuck pending; reconnect then showed **USB wrote -1 of 12 bytes** — the GetDeviceInfo command container never left the phone.

Android already force-claims the PTP interface and issues a PTP Device Reset when the first bulk-out returns -1 (`GET_DEVICE_STATUS` can still read OK while the pipe is wedged). That reset was for the *next* tap. This attempt still reported failure, so every reconnect showed the error even when the reset would have unwedged the body.

This PR retries that same write once on the attempt that reset the pipe.

**Single-platform:** Android USB Host `bulkTransfer` only. iOS USB goes through ImageCaptureCore and does not take this path.

Kaneo: OPE-177

## Google Play notes

Updated `Apps/Android/distribution/whatsnew/whatsnew-en-US`.

## Test plan

- [x] JVM: dead bulk-out resets once and retries; healthy writes never reset; closed / already-recovered paths do not loop
- [x] `just android-check`
- [x] `just check`
- [ ] **[VERIFY-ON-HW]** Z 6III USB-C on OnePlus 15: reconnect after a pending live view must not show the -1 dialog
- [ ] If handshake now sticks, confirm live view actually starts (still a separate remaining question from this report)
- [ ] ZR USB-C still connects without an extra Device Reset on a healthy pipe

## Checklist

- [x] `just check` passes.
- [x] Android production changes: `just android-check`.
- [x] Commits follow Conventional Commits.
- [x] No proprietary assets (`vendor/`, `ref/`) are included.
- [x] Docs/CHANGELOG updated if behaviour changed.
- [x] Play-triggering changes include reviewed `Apps/Android/distribution/whatsnew/whatsnew-en-US` copy.
