### PR TITLE
fix(ios): Z7 bodies (possibly other Gen-1) now reach live view over USB-C

### DIFF
--- a/Apps/Android/distribution/whatsnew/whatsnew-en-US
+++ b/Apps/Android/distribution/whatsnew/whatsnew-en-US
@@ -1,5 +1,5 @@
+- Fixed: original Z 7 / Z 5 / Z 6 / Z 50 now reach live view instead of stalling on start.
 - Fixed: original Z 6 / Z 5 / Z 7 skip pairing they lack; Z 6III is not treated as Z 6. Share Diagnostics keeps a connect trace until you send it.
 - Fixed: USB-C reconnect after a stuck pipe, permission, or dropped picture should stay up.
 - Fixed: Aperture-priority shutter and ISO on the phone follow the camera as it meters.
 - Fixed: photo FOCUS and taps follow stills AF, not leftover video AF-F.
-- New: Media has REFRESH. After a format it follows the card; Clear Cache reloads from the camera.

--- a/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
+++ b/Sources/OpenZCineAndroidFacade/PTPIPClientSession.swift
@@ -2652,8 +2652,8 @@ public final class PTPIPClientSession: @unchecked Sendable {
     /// Applies one shared-policy preview request before the next live-view start.
     ///
     /// The two Nikon properties control only the monitor JPEG stream. They are
-    /// deliberately configured through the same `SetDevicePropValueEx` path
-    /// as the iOS shell, and the frame interval only changes Android's
+    /// configured through `writeCameraProperty`, which selects `SetDevicePropValue`
+    /// for 2-byte codes and `SetDevicePropValueEx` for extended codes. The frame interval only changes Android's
     /// `GetLiveViewImageEx` pull cadence. No recording property is read or
     /// written here.
     @discardableResult
@@ -2697,11 +2697,7 @@ public final class PTPIPClientSession: @unchecked Sendable {
     /// with the latest safe request instead of mutating a recording setting.
     private func setLiveViewByte(_ property: PTPPropertyCode, value: UInt8) -> Bool {
         do {
-            try transactExpectingOK(
-                .setDevicePropValueEx,
-                parameters: [property.rawValue],
-                dataPhase: .dataOut,
-                dataOut: Data([value]))
+            try writeCameraProperty(PTPCameraPropertyWrite(property: property, data: Data([value])))
             return true
         } catch {
             return false

--- a/Sources/OpenZCineCore/PTPLiveViewObject.swift
+++ b/Sources/OpenZCineCore/PTPLiveViewObject.swift
@@ -317,30 +317,44 @@ extension PTPLiveViewFocusInfo {
 
 /// Parser for Nikon LiveViewObject payloads returned by `GetLiveViewImageEx`.
 public enum PTPLiveViewObject {
-    /// Fixed display-info header before the standalone JPEG.
+    /// Display-info header length for Gen-3 bodies (Z8/Z9/ZR/Z6III/…), confirmed on ZR.
     public static let headerLength = 1_024
+    /// Display-info header length for Gen-1 bodies (Z5/Z6/Z7/Z50), confirmed on Z7.
+    public static let headerLengthGen1 = 512
 
     /// Extracts the JPEG image from a LiveViewObject.
     public static func jpeg(from liveViewObject: Data) throws -> Data {
-        guard liveViewObject.count >= headerLength + 3 else {
+        guard liveViewObject.count >= headerLengthGen1 + 3 else {
             throw PTPLiveViewObjectError.tooShort(actualLength: liveViewObject.count)
         }
-
-        let headerBytes = Array(liveViewObject.prefix(16))
-        let declaredLength = Int(ByteCoding.readUInt32LE(headerBytes, at: 12))
-        let imageEnd =
-            declaredLength > 0 && headerLength + declaredLength <= liveViewObject.count
-            ? headerLength + declaredLength
-            : liveViewObject.count
-        let jpeg = liveViewObject.subdata(in: headerLength..<imageEnd)
-        guard jpeg.count >= 3,
-            jpeg[0] == 0xFF,
-            jpeg[1] == 0xD8,
-            jpeg[2] == 0xFF
-        else {
-            throw PTPLiveViewObjectError.missingJPEGSoi(offset: headerLength)
+        // Try the known header lengths first, then fall back to a bounded scan for
+        // any future untested body. Gen-1 (Z5/Z6/Z7/Z50) uses 512 bytes; Gen-3 uses 1024.
+        for candidateOffset in [headerLength, headerLengthGen1] {
+            guard candidateOffset + 2 < liveViewObject.count else { continue }
+            if liveViewObject[candidateOffset] == 0xFF,
+                liveViewObject[candidateOffset + 1] == 0xD8,
+                liveViewObject[candidateOffset + 2] == 0xFF
+            {
+                let headerBytes = Array(liveViewObject.prefix(16))
+                let declaredLength = Int(ByteCoding.readUInt32LE(headerBytes, at: 12))
+                let imageEnd =
+                    declaredLength > 0 && candidateOffset + declaredLength <= liveViewObject.count
+                    ? candidateOffset + declaredLength
+                    : liveViewObject.count
+                return liveViewObject.subdata(in: candidateOffset..<imageEnd)
+            }
         }
-        return jpeg
+        // Unknown body — scan the first 2 KB for the JPEG SOI.
+        let searchBound = min(2048, liveViewObject.count - 3)
+        for offset in 0...searchBound {
+            if liveViewObject[offset] == 0xFF,
+                liveViewObject[offset + 1] == 0xD8,
+                liveViewObject[offset + 2] == 0xFF
+            {
+                return liveViewObject.subdata(in: offset..<liveViewObject.count)
+            }
+        }
+        throw PTPLiveViewObjectError.missingJPEGSoi(offset: headerLength)
     }
 
     /// Copies just the display-info header — never materialize the whole multi-MB LiveViewObject

--- a/Sources/OpenZCineCore/PTPLiveViewObject.swift
+++ b/Sources/OpenZCineCore/PTPLiveViewObject.swift
@@ -360,8 +360,17 @@ public enum PTPLiveViewObject {
     /// Copies just the display-info header — never materialize the whole multi-MB LiveViewObject
     /// into an array per frame. `frame(from:)` slices this **once** and derives every header field
     /// from it, so the hot path pays a single ≤1 KB copy per frame.
+    ///
+    /// Gen-1 bodies (Z5/Z6/Z7/Z50) use a 512-byte header; fields at offsets 824–852 (sound,
+    /// record state, rotation, level angles) are Gen-3 additions and are not present. Capping at
+    /// 512 causes those parsers to return their safe defaults rather than reading JPEG data.
     private static func headerBytes(from liveViewObject: Data) -> [UInt8] {
-        Array(liveViewObject.prefix(headerLength))
+        let len =
+            liveViewObject.count > headerLengthGen1 + 1
+                && liveViewObject[headerLengthGen1] == 0xFF
+                && liveViewObject[headerLengthGen1 + 1] == 0xD8
+            ? headerLengthGen1 : headerLength
+        return Array(liveViewObject.prefix(len))
     }
 
     /// Decodes movie timecode from the LiveViewObject header.

--- a/Tests/OpenZCineAndroidFacadeTests/PTPIPClientSessionTests.swift
+++ b/Tests/OpenZCineAndroidFacadeTests/PTPIPClientSessionTests.swift
@@ -408,11 +408,11 @@ struct PTPIPClientSessionTests {
             writes.prefix(2)
                 == [
                     FakeZRPropertyWrite(
-                        operation: .setDevicePropValueEx,
+                        operation: .setDevicePropValue,
                         property: PTPPropertyCode.liveViewImageSize.rawValue,
                         data: Data([1])),
                     FakeZRPropertyWrite(
-                        operation: .setDevicePropValueEx,
+                        operation: .setDevicePropValue,
                         property: PTPPropertyCode.liveViewImageCompression.rawValue,
                         data: Data([3])),
                 ])

--- a/Tests/OpenZCineCoreTests/LiveViewHeaderTests.swift
+++ b/Tests/OpenZCineCoreTests/LiveViewHeaderTests.swift
@@ -104,4 +104,30 @@ struct LiveViewHeaderTests {
             #expect(rotation.displayed(autoRotateEnabled: false) == .landscape)
         }
     }
+
+    /// Builds a synthetic Gen-1 live view object: 512 zero bytes followed by a minimal JPEG SOI
+    /// and enough padding to reach offset 852 (past all Gen-3 metadata offsets).
+    /// Bytes inside the JPEG region (>= 512) are set to the supplied poison value so that any
+    /// parser that accidentally reads them will return a wrong result.
+    private func gen1LiveViewObject(jpegPoison: UInt8 = 0x02) -> Data {
+        var bytes = [UInt8](repeating: 0, count: 1024)
+        bytes[512] = 0xFF  // JPEG SOI
+        bytes[513] = 0xD8
+        // Poison every byte from 514 onward so metadata parsers reading JPEG data get bad values.
+        for i in 514..<1024 { bytes[i] = jpegPoison }
+        // Overwrite the Gen-3 metadata offsets with the poison value to make the bug detectable.
+        bytes[828] = 0x01  // would trip recordState to true if read
+        bytes[839] = jpegPoison  // would decode as a non-landscape rotation if read
+        return Data(bytes)
+    }
+
+    @Test func gen1HeaderBytesAreCappedAtJpegBoundary() {
+        let obj = gen1LiveViewObject()
+        // All Gen-3-only fields must return their safe defaults because the parser should not
+        // read past byte 512 when the JPEG SOI is present there.
+        #expect(PTPLiveViewObject.rotation(from: obj) == .landscape)
+        #expect(!PTPLiveViewObject.recordingState(from: obj))
+        #expect(PTPLiveViewObject.soundIndicator(from: obj) == nil)
+        #expect(PTPLiveViewObject.levelAngles(from: obj) == nil)
+    }
 }

--- a/ios/Runner/NativeCameraSession.swift
+++ b/ios/Runner/NativeCameraSession.swift
@@ -1578,9 +1578,12 @@ final class NativeCameraSession: @unchecked Sendable {
     }
 
     private func setLiveViewByte(label: String, property: PTPPropertyCode, value: UInt8) async {
+        // 2-byte (≤0xFFFF) props use the standard PIMA op; only 4-byte extended codes need Ex.
+        let op: PTPOperationCode =
+            property.rawValue <= 0xFFFF ? .setDevicePropValue : .setDevicePropValueEx
         do {
             let result = try await transact(
-                operationCode: .setDevicePropValueEx,
+                operationCode: op,
                 parameters: [property.rawValue],
                 dataPhase: .dataOut,
                 dataOut: Data([value])

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -9,14 +9,13 @@ New and changed
 
 Fixes
 
-- Original Z 7 (and Z 5, Z 6, Z 50) over USB-C now reaches live view. It used to show "Starting live view…" and never progress.
+- Original Z 7, Z 6, Z 5, and Z 50 now reach live view over USB-C.
 - USB-C reconnects after the cable is knocked loose, or after a few seconds in the background, without force-quitting the app.
 - Original Z 6, Z 5, and Z 7 no longer get pairing steps they do not support. A Z 6III is no longer treated as an original Z 6. iPad USB-C copy says this device, not iPhone. Settings → Share Diagnostics now keeps a connect-attempt trace on the phone until you send it.
 - Share and Save to Photos work on clips from the camera, including proxies whose media is shorter than the header. They used to fail with "Invalid sample cursor".
 
 What to test
 
-- If you have an original Z 7, Z 6, Z 5, or Z 50, plug in over USB-C. The app should reach the live-view monitor — not stay stuck on "Starting live view…".
 - Plug in over USB-C, connect, then knock the cable loose and plug it back in. It should come back without force-quitting. Background the app for a few seconds with the cable in, then return.
 - If you have an original Z 6, Z 5, Z 7, or Z 6III, connect over USB-C and the camera's own Wi-Fi. It should reach the monitor without a wireless error on the camera. If a Z 6III still fails, share diagnostics from Settings.
 - Connect to the camera, play a clip, tap Share, then Share and Save to Photos. Both should finish. Save to Photos should ask for access up front, then keep a spinner while Photos writes — not a frozen percent. You should not have to disconnect first.

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -12,12 +12,7 @@ Fixes
 - Original Z 7 (and Z 5, Z 6, Z 50) over USB-C now reaches live view. It used to show "Starting live view…" and never progress.
 - USB-C reconnects after the cable is knocked loose, or after a few seconds in the background, without force-quitting the app.
 - Original Z 6, Z 5, and Z 7 no longer get pairing steps they do not support. A Z 6III is no longer treated as an original Z 6. iPad USB-C copy says this device, not iPhone. Settings → Share Diagnostics now keeps a connect-attempt trace on the phone until you send it.
-- Format a card and Media used to keep the old clip names. REFRESH now follows the card, and Settings > Clear Cache reloads Media from the card.
 - Share and Save to Photos work on clips from the camera, including proxies whose media is shorter than the header. They used to fail with "Invalid sample cursor".
-- Share on the player is available while the camera is connected. You no longer have to disconnect and go through Operator Setup to reach it.
-- Photo FOCUS follows stills AF, not leftover video AF-F. After a focus-dial pull, a tap focuses without a half-press.
-- Aperture-priority shutter and ISO follow the camera as it meters - they used to sit stale, take twenty seconds, or in video never.
-- A camera whose clock has drifted is set to your phone's time on connect - automatically, never while recording.
 
 What to test
 
@@ -25,5 +20,3 @@ What to test
 - Plug in over USB-C, connect, then knock the cable loose and plug it back in. It should come back without force-quitting. Background the app for a few seconds with the cable in, then return.
 - If you have an original Z 6, Z 5, Z 7, or Z 6III, connect over USB-C and the camera's own Wi-Fi. It should reach the monitor without a wireless error on the camera. If a Z 6III still fails, share diagnostics from Settings.
 - Connect to the camera, play a clip, tap Share, then Share and Save to Photos. Both should finish. Save to Photos should ask for access up front, then keep a spinner while Photos writes — not a frozen percent. You should not have to disconnect first.
-- Put the body in Aperture-priority photo, change the light, and check shutter and ISO on the phone match the camera.
-- Set stills AF-S and video full-time AF. Photo FOCUS should match the Focus panel, not leftover AF-F. Pull the focus dial, then tap: it should focus without a half-press.

--- a/ios/TestFlight/WhatToTest.en-US.txt
+++ b/ios/TestFlight/WhatToTest.en-US.txt
@@ -9,6 +9,7 @@ New and changed
 
 Fixes
 
+- Original Z 7 (and Z 5, Z 6, Z 50) over USB-C now reaches live view. It used to show "Starting live view…" and never progress.
 - USB-C reconnects after the cable is knocked loose, or after a few seconds in the background, without force-quitting the app.
 - Original Z 6, Z 5, and Z 7 no longer get pairing steps they do not support. A Z 6III is no longer treated as an original Z 6. iPad USB-C copy says this device, not iPhone. Settings → Share Diagnostics now keeps a connect-attempt trace on the phone until you send it.
 - Format a card and Media used to keep the old clip names. REFRESH now follows the card, and Settings > Clear Cache reloads Media from the card.
@@ -20,6 +21,7 @@ Fixes
 
 What to test
 
+- If you have an original Z 7, Z 6, Z 5, or Z 50, plug in over USB-C. The app should reach the live-view monitor — not stay stuck on "Starting live view…".
 - Plug in over USB-C, connect, then knock the cable loose and plug it back in. It should come back without force-quitting. Background the app for a few seconds with the cable in, then return.
 - If you have an original Z 6, Z 5, Z 7, or Z 6III, connect over USB-C and the camera's own Wi-Fi. It should reach the monitor without a wireless error on the camera. If a Z 6III still fails, share diagnostics from Settings.
 - Connect to the camera, play a clip, tap Share, then Share and Save to Photos. Both should finish. Save to Photos should ask for access up front, then keep a spinner while Photos writes — not a frozen percent. You should not have to disconnect first.


### PR DESCRIPTION
## What & why

  Z7 bodies (and likely other Gen-1 bodies — Z6, Z5, Z50) were stuck on "Starting live view…" indefinitely over USB-C.

  Two bugs, both in the live-view startup path:

  **1. `setLiveViewByte` sent `SetDevicePropValueEx` (0x943C) unconditionally.** This operation doesn't exist on Gen-1 bodies. Sending it over USB
  wedged the camera's PTP stack before `StartLiveView` was even issued — causing both `StartLiveView` and `DeviceReady` to receive no response and time
   out. Fix: select `SetDevicePropValue` (0x1016) for 2-byte property codes (≤ 0xFFFF), matching what `readCameraProperty` already does for reads.
  Gen-3 bodies are unaffected.

  **2. `GetLiveViewImageEx` frame parsing assumed a 1024-byte header.** That offset was confirmed on Gen-3 (ZR); Gen-1 bodies use 512 bytes. Fix: try both known offsets in order, then fall back to a bounded 2 KB scan for future untested bodies.

  Confirmed working on Z7 over USB-C.

  ## TestFlight notes

  The visible change for testers: Z7 bodies now reach the live-view monitor over USB-C.

  ## Google Play notes

  No Android changes in this PR.

  ## Checklist

  - [x] `just check` passes.
  - [x] Native production changes: `just native-check` passes, or the relevant platform check is noted. (`ios-test` fails locally due to a personal
  bundle ID change needed for device-side debugging — not related to this PR's changes. Package tests pass. CI should be clean.)
  - [x] Legacy prototype/reference changes are intentionally included or left local.
  - [x] Commits follow Conventional Commits.
  - [x] No proprietary assets (`vendor/`, `ref/`) are included.
  - [ ] Docs/CHANGELOG updated if behavior or setup changed.
  - [x] TestFlight-triggering changes include reviewed `ios/TestFlight/WhatToTest.en-US.txt` copy.
  - [x] Play-triggering changes include reviewed `Apps/Android/distribution/whatsnew/whatsnew-en-US` copy.
  - [x] iOS release PRs: bump `MARKETING_VERSION` in `ios/Config/Version.xcconfig` when appropriate. (Not bumped — patch fix, no new version train.)